### PR TITLE
Add P25 decoding

### DIFF
--- a/applications/gqrx/mainwindow.cpp
+++ b/applications/gqrx/mainwindow.cpp
@@ -750,6 +750,27 @@ void MainWindow::selectDemod(int index)
         }
         break;
 
+    case DockRxOpt::MODE_P25:
+        rx->set_demod(receiver::RX_DEMOD_P25);
+        ui->plotter->setDemodRanges(-12500, -100, 100, 12500, true);
+        uiDockAudio->setFftRange(0,12000);
+        click_res = 6250;
+        switch (filter_preset) {
+        case 0: //wide
+            flo = -8000;
+            fhi = 8000;
+            break;
+        case 2: // narrow
+            flo = -5000;
+            fhi = 5000;
+            break;
+        default: // normal
+            flo = -6250;
+            fhi = 6250;
+            break;
+        }
+        break;
+
     default:
         qDebug() << "Unsupported mode selection: " << index;
         flo = -5000;

--- a/applications/gqrx/receiver.cpp
+++ b/applications/gqrx/receiver.cpp
@@ -604,6 +604,15 @@ receiver::status receiver::set_demod(rx_demod demod)
         rx->set_demod(nbrx::NBRX_DEMOD_SSB);
         break;
 
+    case RX_DEMOD_P25:
+        if ((d_demod == RX_DEMOD_OFF) || wide_fm)
+        {
+            tb->disconnect_all();
+            connect_all(RX_CHAIN_NBRX);
+        }
+        rx->set_demod(nbrx::NBRX_DEMOD_P25);
+        break;
+
     default:
         ret = STATUS_ERROR;
         break;

--- a/applications/gqrx/receiver.h
+++ b/applications/gqrx/receiver.h
@@ -80,7 +80,8 @@ public:
         RX_DEMOD_NFM   = 3,  /*!< Frequency modulation. */
         RX_DEMOD_WFM_M = 4,  /*!< Frequency modulation (wide, mono). */
         RX_DEMOD_WFM_S = 5,  /*!< Frequency modulation (wide, stereo). */
-        RX_DEMOD_SSB   = 6   /*!< Single Side Band. */
+        RX_DEMOD_SSB   = 6,  /*!< Single Side Band. */
+        RX_DEMOD_P25   = 7   /*!< P25. */
     };
 
     /*! \brief Supported receiver types. */

--- a/dsp/rx_demod_p25.cpp
+++ b/dsp/rx_demod_p25.cpp
@@ -1,0 +1,143 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012 Joshua Roys KK4AFZ.
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#include <gr_io_signature.h>
+#include <dsp/rx_demod_p25.h>
+#include <algorithm>
+
+#define SYMBOL_RATE 4800.0
+
+/* Create a new instance of rx_demod_p25 and return a boost shared_ptr. */
+rx_demod_p25_sptr make_rx_demod_p25(float quad_rate, float audio_rate, float max_dev)
+{
+    return gnuradio::get_initial_sptr(new rx_demod_p25(quad_rate, audio_rate, max_dev));
+}
+
+
+static const int MIN_IN = 1;  /* Mininum number of input streams. */
+static const int MAX_IN = 1;  /* Maximum number of input streams. */
+static const int MIN_OUT = 1; /* Minimum number of output streams. */
+static const int MAX_OUT = 1; /* Maximum number of output streams. */
+
+
+
+rx_demod_p25::rx_demod_p25(float quad_rate, float audio_rate, float max_dev)
+    : gr_hier_block2 ("rx_demod_p25",
+                      gr_make_io_signature (MIN_IN, MAX_IN, sizeof (gr_complex)),
+                      gr_make_io_signature (MIN_OUT, MAX_OUT, sizeof (float))),
+    d_quad_rate(quad_rate),
+    d_audio_rate(audio_rate),
+    d_max_dev(max_dev)
+{
+    float sps, gain_mu, gain_omega, alpha, beta, fmin, fmax;
+    float sl_arr[4] = {-2.0, 0.0, 2.0, 4.0};
+    std::vector<float> slice_levels(sl_arr, sl_arr + sizeof(sl_arr) / sizeof(float));
+
+    /* AGC/prescale */
+    d_agc = gr_make_feedforward_agc_cc(16, 1.0);
+
+    /* Costas loop for clock/phase recovery */
+    sps = d_quad_rate / SYMBOL_RATE;
+    gain_mu = 0.05;
+    gain_omega = 0.125 * gain_mu * gain_mu;
+    alpha = 0.125;
+    beta = 0.125 * alpha * alpha;
+    fmax = 0.025;
+    fmin = -fmax;
+    d_clock = repeater_make_gardner_costas_cc(sps, gain_mu, gain_omega, alpha, beta, fmax, fmin);
+
+    /* Differential decoding */
+    d_diffdec = gr_make_diff_phasor_cc();
+
+    /* Complex to float */
+    d_to_float = gr_make_complex_to_arg();
+
+    /* Rescale to {-3, -1, 1, 3} */
+    d_rescale = gr_make_multiply_const_ff(1 / (M_PI / 4));
+
+    /* FSK4 slicer */
+    d_slicer = op25_make_fsk4_slicer_fb(slice_levels);
+
+    /* P25 decoder */
+    d_op25 = op25_make_decoder_bf();
+
+    /* Audio resampler */
+    d_audio_resamp = make_resampler_ff(d_audio_rate / 8000.0);
+
+    connect(self(), 0, d_agc, 0);
+    connect(d_agc, 0, d_clock, 0);
+    connect(d_clock, 0, d_diffdec, 0);
+    connect(d_diffdec, 0, d_to_float, 0);
+    connect(d_to_float, 0, d_rescale, 0);
+    connect(d_rescale, 0, d_slicer, 0);
+    connect(d_slicer, 0, d_op25, 0);
+    connect(d_op25, 0, d_audio_resamp, 0);
+    connect(d_audio_resamp, 0, self(), 0);
+
+#if 0
+    float gain;
+    float sl_arr[4] = {-2.0, 0.0, 2.0, 4.0};
+    int samples_per_symbol;
+    std::vector<float> slice_levels(sl_arr, sl_arr + sizeof(sl_arr) / sizeof(float));
+
+    /* demodulator gain */
+    gain = d_quad_rate / (2.0 * M_PI * d_max_dev);
+
+    //std::cout << "G: " << gain << std::endl;
+
+    /* demodulator */
+    d_quad = gr_make_quadrature_demod_cf(gain);
+
+    /* Symbol filter */
+    samples_per_symbol = int(d_quad_rate / SYMBOL_RATE);
+    d_symbol_coeffs.resize(samples_per_symbol);
+    fill(d_symbol_coeffs.begin(), d_symbol_coeffs.end(), (1.0 / samples_per_symbol));
+    d_symbol_filter = gr_make_fir_filter_fff(1, d_symbol_coeffs);
+
+    /* C4FM/FSK4 demodulator */
+    d_queue = gr_make_msg_queue();
+    d_demod_fsk4 = op25_make_fsk4_demod_ff(d_queue, d_quad_rate, SYMBOL_RATE);
+
+    /* FSK4 slicer */
+    d_slicer = op25_make_fsk4_slicer_fb(slice_levels);
+
+    /* P25 decoder */
+    d_op25 = op25_make_decoder_bf();
+
+    /* Audio resampler */
+    d_audio_resamp = make_resampler_ff(d_audio_rate / 8000.0);
+
+    /* connect block */
+    connect(self(), 0, d_quad, 0);
+    connect(d_quad, 0, d_symbol_filter, 0);
+    connect(d_symbol_filter, 0, d_demod_fsk4, 0);
+    connect(d_demod_fsk4, 0, d_slicer, 0);
+    connect(d_slicer, 0, d_op25, 0);
+    connect(d_op25, 0, d_audio_resamp, 0);
+    connect(d_audio_resamp, 0, self(), 0);
+#endif
+
+}
+
+
+rx_demod_p25::~rx_demod_p25 ()
+{
+
+}
+

--- a/dsp/rx_demod_p25.h
+++ b/dsp/rx_demod_p25.h
@@ -1,0 +1,98 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012 Joshua Roys KK4AFZ.
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef RX_DEMOD_P25_H
+#define RX_DEMOD_P25_H
+
+#include <gr_complex_to_xxx.h>
+#include <gr_diff_phasor_cc.h>
+#include <gr_feedforward_agc_cc.h>
+#include <gr_multiply_const_cc.h>
+#include <gr_multiply_const_ff.h>
+#include <repeater_gardner_costas_cc.h>
+
+#include <gr_fir_filter_fff.h>
+#include <gr_hier_block2.h>
+#include <gr_msg_queue.h>
+#include <gr_quadrature_demod_cf.h>
+#include <op25_decoder_bf.h>
+#include <op25_fsk4_demod_ff.h>
+#include <op25_fsk4_slicer_fb.h>
+#include <vector>
+#include "dsp/resampler_xx.h"
+
+
+class rx_demod_p25;
+
+
+typedef boost::shared_ptr<rx_demod_p25> rx_demod_p25_sptr;
+
+
+/*! \brief Return a shared_ptr to a new instance of rx_demod_p25.
+ *
+ * This is effectively the public constructor. To avoid accidental use
+ * of raw pointers, rx_demod_p25's constructor is private.
+ * make_rx_dmod_p25 is the public interface for creating new instances.
+ */
+rx_demod_p25_sptr make_rx_demod_p25(float quad_rate, float audio_rate, float max_dev);
+
+
+/*! \brief P25 demodulator.
+ *  \ingroup DSP
+ *
+ * This class implements a P25 demodulator using OP25.
+ *
+ */
+class rx_demod_p25 : public gr_hier_block2
+{
+
+public:
+    rx_demod_p25(float quad_rate=48000.0, float audio_rate=48000.0, float max_dev=600.0); // FIXME: should be private
+    ~rx_demod_p25();
+
+private:
+    /* GR blocks */
+    /* C4FM */
+    gr_quadrature_demod_cf_sptr   d_quad;          /*! The quadrature demodulator block. */
+    gr_fir_filter_fff_sptr        d_symbol_filter; /*! Symbol filter. */
+    op25_fsk4_demod_ff_sptr       d_demod_fsk4;    /*! C4FM/FSK4 demodulator block. */
+    /* CQPSK */
+    gr_feedforward_agc_cc_sptr    d_agc;           /*! AGC/prescaler to for Costas loop. */
+    repeater_gardner_costas_cc_sptr d_clock;       /*! Clock/phase recovery. */
+    gr_diff_phasor_cc_sptr        d_diffdec;       /*! Differential decoder. */
+    gr_complex_to_arg_sptr        d_to_float;      /*! Complex to float. */
+    gr_multiply_const_ff_sptr     d_rescale;       /*! Rescaler to {-3, -1, 1, 3} levels. */
+    /* both */
+    op25_fsk4_slicer_fb_sptr      d_slicer;        /*! FSK4 slicer block. */
+    op25_decoder_bf_sptr          d_op25;          /*! P25 decoder block. */
+    resampler_ff_sptr             d_audio_resamp;  /*! Audio resampler. */
+
+    /* other parameters */
+    float  d_quad_rate;        /*! Quadrature rate. */
+    float  d_audio_rate;       /*! Audio rate. */
+    float  d_max_dev;          /*! Max deviation. */
+    gr_msg_queue_sptr d_queue; /*! Message queue to FSK4 demod. */
+
+    /* FIR filter taps */
+    std::vector<float> d_symbol_coeffs; /*! Symbol coefficients. */
+
+};
+
+
+#endif // RX_DEMOD_P25_H

--- a/gqrx.pro
+++ b/gqrx.pro
@@ -57,6 +57,7 @@ SOURCES += \
     dsp/resampler_xx.cpp \
     dsp/rx_demod_am.cpp \
     dsp/rx_demod_fm.cpp \
+    dsp/rx_demod_p25.cpp \
     dsp/rx_fft.cpp \
     dsp/rx_filter.cpp \
     dsp/rx_meter.cpp \
@@ -94,6 +95,7 @@ HEADERS += \
     dsp/rx_agc_xx.h \
     dsp/rx_demod_am.h \
     dsp/rx_demod_fm.h \
+    dsp/rx_demod_p25.h \
     dsp/rx_fft.h \
     dsp/rx_filter.h \
     dsp/rx_meter.h \
@@ -140,6 +142,8 @@ contains(AUDIO_BACKEND, pulse): {
         pulseaudio/pa_source.cc
     DEFINES += WITH_PULSEAUDIO
 }
+
+LIBS += -lop25 -litpp -lop25repeater
 
 # dependencies via pkg-config
 # FIXME: check for version?

--- a/qtgui/dockrxopt.h
+++ b/qtgui/dockrxopt.h
@@ -57,7 +57,8 @@ public:
         MODE_LSB        = 6, /*!< Lower side band. */
         MODE_USB        = 7, /*!< Upper side band. */
         MODE_CWL        = 8, /*!< CW using LSB filter. */
-        MODE_CWU        = 9  /*!< CW using USB filter. */
+        MODE_CWU        = 9, /*!< CW using USB filter. */
+        MODE_P25        = 10 /*!< P25. */
     };
 
     explicit DockRxOpt(qint64 filterOffsetRange = 90000, QWidget *parent = 0);

--- a/qtgui/dockrxopt.ui
+++ b/qtgui/dockrxopt.ui
@@ -307,6 +307,11 @@ as  rf_freq + filter_offset</string>
           <string>CW-U</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>P25</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item row="1" column="2">

--- a/receivers/nbrx.cpp
+++ b/receivers/nbrx.cpp
@@ -45,6 +45,7 @@ nbrx::nbrx(float quad_rate, float audio_rate)
     demod_ssb = gr_make_complex_to_real(1);
     demod_fm = make_rx_demod_fm(PREF_QUAD_RATE, PREF_AUDIO_RATE, 5000.0, 75.0e-6);
     demod_am = make_rx_demod_am(PREF_QUAD_RATE, PREF_AUDIO_RATE, true);
+    demod_p25 = make_rx_demod_p25(PREF_QUAD_RATE, PREF_AUDIO_RATE, 600.0);
     audio_rr = make_resampler_ff(d_audio_rate/PREF_AUDIO_RATE);
 
     connect(self(), 0, iq_resamp, 0);
@@ -204,6 +205,11 @@ void nbrx::set_demod(int rx_demod)
         disconnect(agc, 0, demod_fm, 0);
         disconnect(demod_fm, 0, audio_rr, 0);
         break;
+
+    case NBRX_DEMOD_P25:
+        disconnect(agc, 0, demod_p25, 0);
+        disconnect(demod_p25, 0, audio_rr, 0);
+        break;
     }
 
     switch (rx_demod) {
@@ -225,6 +231,12 @@ void nbrx::set_demod(int rx_demod)
         d_demod = NBRX_DEMOD_FM;
         connect(agc, 0, demod_fm, 0);
         connect(demod_fm, 0, audio_rr, 0);
+        break;
+
+    case NBRX_DEMOD_P25:
+        d_demod = NBRX_DEMOD_P25;
+        connect(agc, 0, demod_p25, 0);
+        connect(demod_p25, 0, audio_rr, 0);
         break;
 
     default:

--- a/receivers/nbrx.h
+++ b/receivers/nbrx.h
@@ -29,6 +29,7 @@
 #include "dsp/rx_agc_xx.h"
 #include "dsp/rx_demod_fm.h"
 #include "dsp/rx_demod_am.h"
+#include "dsp/rx_demod_p25.h"
 //#include "dsp/resampler_ff.h"
 #include "dsp/resampler_xx.h"
 
@@ -53,7 +54,8 @@ public:
         NBRX_DEMOD_AM   = 1,  /*!< Amplitude modulation. */
         NBRX_DEMOD_FM   = 2,  /*!< Frequency modulation. */
         NBRX_DEMOD_SSB  = 3,  /*!< Single Side Band. */
-        NBRX_DEMOD_NUM  = 4   /*!< Included for convenience. */
+        NBRX_DEMOD_P25  = 4,  /*!< P25. */
+        NBRX_DEMOD_NUM  = 5   /*!< Included for convenience. */
     };
 
 public:
@@ -113,6 +115,7 @@ private:
     gr_complex_to_real_sptr   demod_ssb;  /*!< SSB demodulator. */
     rx_demod_fm_sptr          demod_fm;   /*!< FM demodulator. */
     rx_demod_am_sptr          demod_am;   /*!< AM demodulator. */
+    rx_demod_p25_sptr         demod_p25;  /*!< P25 demodulator. */
     resampler_ff_sptr         audio_rr;   /*!< Audio resampler. */
 
 };


### PR DESCRIPTION
A patched version of the OP25 project is needed to install some needed
functions.  Testing was conducted with a RTLSDR device with an E4000
tuner.  Even with your ppm entered, at higher frequencies your device
may still be off by a small amount.  Set the filter to "Wide" if
"Normal" doesn't work.
