### PR TITLE
Make it possible to switch the audio output device

### DIFF
--- a/applications/gqrx/mainwindow.cpp
+++ b/applications/gqrx/mainwindow.cpp
@@ -302,10 +302,7 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash)
     }
 
     QString outdev = m_settings->value("output/device", "").toString();
-    if (!outdev.isEmpty())
-    {
-        rx->set_output_device(outdev.toStdString());
-    }
+    rx->set_output_device(outdev.toStdString());
 
     int sr = m_settings->value("input/sample_rate", 0).toInt(&conv_ok);
     if (conv_ok && (sr > 0))

--- a/applications/gqrx/receiver.cpp
+++ b/applications/gqrx/receiver.cpp
@@ -182,6 +182,8 @@ void receiver::set_output_device(const std::string device)
         return;
     }
 
+    output_devstr = device;
+
     tb->lock();
 
     tb->disconnect(audio_gain0, 0, audio_snk, 0);
@@ -189,7 +191,7 @@ void receiver::set_output_device(const std::string device)
     audio_snk.reset();
 
 #ifdef WITH_PULSEAUDIO
-    audio_snk = make_pa_sink(device, d_audio_rate); // FIXME: does this keep app and stream name?
+    audio_snk = make_pa_sink(device, d_audio_rate);
 #else
     audio_snk = audio_make_sink(d_audio_rate, device, true);
 #endif

--- a/qtgui/ioconfig.cpp
+++ b/qtgui/ioconfig.cpp
@@ -178,7 +178,9 @@ void CIoConfig::saveConfig()
 #endif
     }
     else
-        qDebug() << "Selected output device is 'default' (not saving)";
+    {
+        m_settings->remove("output/device");
+    }
 
     // input settings
     m_settings->setValue("input/device", ui->inDevEdit->text());  // "OK" button disabled if empty


### PR DESCRIPTION
This patch allows user to select an alternate audio device. I have tested it with Logitech USB AudioHub speakers connected to my laptop.
