### PR TITLE
Save and restore audio gain setting.

### DIFF
--- a/applications/gqrx/mainwindow.cpp
+++ b/applications/gqrx/mainwindow.cpp
@@ -321,6 +321,7 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash)
     uiDockInputCtl->readSettings(m_settings);
     uiDockRxOpt->readSettings(m_settings);
     uiDockFft->readSettings(m_settings);
+    uiDockAudio->readSettings(m_settings);
 
     return conf_ok;
 }
@@ -378,6 +379,7 @@ void MainWindow::storeSession()
         uiDockInputCtl->saveSettings(m_settings);
         uiDockRxOpt->saveSettings(m_settings);
         uiDockFft->saveSettings(m_settings);
+        uiDockAudio->saveSettings(m_settings);
     }
 }
 

--- a/qtgui/dockaudio.cpp
+++ b/qtgui/dockaudio.cpp
@@ -192,3 +192,24 @@ void DockAudio::setAudioPlayButtonState(bool checked)
     ui->audioRecButton->setEnabled(!isChecked);
     //ui->audioRecConfButton->setEnabled(!isChecked);
 }
+
+void DockAudio::saveSettings(QSettings *settings)
+{
+    if (!settings)
+        return;
+
+    settings->setValue("audio/gain", audioGain());
+}
+
+void DockAudio::readSettings(QSettings *settings)
+{
+    if (!settings)
+        return;
+
+    bool conv_ok = false;
+
+    int gain = settings->value("audio/gain", QVariant( -200 ) ).toInt(&conv_ok);
+    if (conv_ok) {
+        setAudioGain(gain);
+    }
+}

--- a/qtgui/dockaudio.h
+++ b/qtgui/dockaudio.h
@@ -21,6 +21,7 @@
 #define DOCKAUDIO_H
 
 #include <QDockWidget>
+#include <QSettings>
 
 namespace Ui {
     class DockAudio;
@@ -54,6 +55,8 @@ public:
     void setAudioRecButtonState(bool checked);
     void setAudioPlayButtonState(bool checked);
 
+    void saveSettings(QSettings *settings);
+    void readSettings(QSettings *settings);
 
 signals:
     /*! \brief Signal emitted when audio gain has changed. Gain is in dB. */


### PR DESCRIPTION
Fixes issue #56. The reporter actually meant audio gain but referenced RF gain in the config file.
