### PR TITLE
Changes for OSX build

### DIFF
--- a/applications/gqrx/receiver.cpp
+++ b/applications/gqrx/receiver.cpp
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2011-2013 Alexandru Csete OZ9AEC.
+ * Copyright (C) 2013 by Elias Oenal <EliasOenal@gmail.com>
  *
  * Gqrx is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -180,7 +181,11 @@ void receiver::set_output_device(const std::string device)
                   << "  old: " << output_devstr << std::endl
                   << "  new: " << device << std::endl;
 #endif
+
+//At least on OSX there's only noise output without the sink reset
+#ifdef WITH_PULSEAUDIO
         return;
+#endif
     }
 
     output_devstr = device;

--- a/qtgui/freqctrl.cpp
+++ b/qtgui/freqctrl.cpp
@@ -61,7 +61,7 @@ CFreqCtrl::CFreqCtrl(QWidget *parent) :
     setAutoFillBackground(false);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setFocusPolicy(Qt::StrongFocus);
-    setMouseTracking(false);
+    setMouseTracking(true);
     m_BkColor = QColor(0x20,0x20,0x20,0xFF);
     m_DigitColor = QColor(0xFF, 0xE6, 0xC8, 0xFF);
     m_HighlightColor = QColor(0x5A, 0x5A, 0x5A, 0xFF);


### PR DESCRIPTION
Without the "setMouseTracking(true);" I couldn't control the frequency widget anymore. Does it still work on Linux?
