### PR TITLE
FCDPro+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Gqrx
 ====
 
 Gqrx is an experimental software defined radio receiver implemented using GNU Radio and the Qt GUI toolkit. Currently it works on Linux and Mac and supports the following devices:
-- Funcube Dongle Pro (not Pro+)
+- Funcube Dongle Pro (and Pro+ with latest gr-osmosdr)
 - RTL2832U-based DVB-T dongles (rtlsdr)
 - OsmoSDR
 - USRP

--- a/qtgui/ioconfig.cpp
+++ b/qtgui/ioconfig.cpp
@@ -214,7 +214,14 @@ void CIoConfig::updateInputSampleRates(int rate)
 
     if (ui->inDevEdit->text().contains("fcd"))
     {
-        ui->inSrCombo->addItem("96000");
+        if (ui->inDevCombo->currentText().contains("V2.0"))
+        {
+            ui->inSrCombo->addItem("192000");
+        }
+        else
+        {
+            ui->inSrCombo->addItem("96000");
+        }
     }
     else if (ui->inDevEdit->text().contains("rtl"))
     {


### PR DESCRIPTION
FCDPro+ support was added to gr-osmosdr
http://cgit.osmocom.org/gr-osmosdr/commit/?id=3ce7c3398102e49f5fe7411a8e0fb5700236a3c7
gqrx needs to set correct sample rate for FCDPro+
