### PR TITLE
Fix close on pure Qt4 system (with no qt3support)

### DIFF
--- a/applications/gqrx/mainwindow.ui
+++ b/applications/gqrx/mainwindow.ui
@@ -400,7 +400,7 @@
  <connections>
   <connection>
    <sender>actionQuit</sender>
-   <signal>activated()</signal>
+   <signal>triggered()</signal>
    <receiver>MainWindow</receiver>
    <slot>close()</slot>
    <hints>


### PR DESCRIPTION
Just replace deprecated call, which is not present on pure Qt4 systems.
