### PR TITLE
Fix for division by zero error

### DIFF
--- a/qtgui/dockinputctl.cpp
+++ b/qtgui/dockinputctl.cpp
@@ -464,7 +464,9 @@ void DockInputCtl::sliderValueChanged(int value)
     int idx = slider->property("idx").toInt();
 
     // convert to discrete value according to step
-    value = slider->singleStep() * (value / slider->singleStep());
+    if (slider->singleStep()) {
+        value = slider->singleStep() * (value / slider->singleStep());
+    }
 
     // convert to double and send signal
     double gain = (double)value / 10.0;


### PR DESCRIPTION
Changing the gain on a TVRX connected to USRP1 was causing a floating point exception.
This fix prevents a division by zero error.
