### PR TITLE
Add .desktop file for better linux user expirence

### DIFF
--- a/gqrx.desktop
+++ b/gqrx.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=gqrx
+Name=Gqrx
 GenericName=Software Defined Radio
 Comment=Software defined radio receiver implemented using GNU Radio and the Qt GUI toolkit
 # FIXME add comments in other languages


### PR DESCRIPTION
I've tested this file under ubuntu 13.10 but since it made according to the FreeDesktop spec, it should work everywhere.
