### PR TITLE
Avoid useless lag when comboBox are activated without changing the index

### DIFF
--- a/qtgui/dockrxopt.cpp
+++ b/qtgui/dockrxopt.cpp
@@ -235,12 +235,12 @@ void DockRxOpt::on_filterFreq_newFrequency(qint64 freq)
     emit filterOffsetChanged(freq);
 }
 
-/*! \brief New filter preset selected.
+/*! \brief New filter preset changed.
  *
  * Instead of implementing a new signal, we simply emit demodSelected() since demodulator
  * and filter preset are tightly coupled.
  */
-void DockRxOpt::on_filterCombo_activated(int index)
+void DockRxOpt::on_filterCombo_currentIndexChanged(int index)
 {
     Q_UNUSED(index);
 
@@ -255,7 +255,7 @@ void DockRxOpt::on_filterButton_clicked()
 
 }
 
-/*! \brief Mode selector activated.
+/*! \brief Mode selector changed.
  *  \param New mode selection.
  *
  * This slot is activated when the user selects a new demodulator (mode change).
@@ -265,7 +265,7 @@ void DockRxOpt::on_filterButton_clicked()
  * Note that the modes listed in the selector are different from those defined by
  * receiver::demod (we want to list LSB/USB separately but they have identical demods).
  */
-void DockRxOpt::on_modeSelector_activated(int index)
+void DockRxOpt::on_modeSelector_currentIndexChanged(int index)
 {
     qDebug() << "New mode: " << index;
 

--- a/qtgui/dockrxopt.h
+++ b/qtgui/dockrxopt.h
@@ -144,9 +144,9 @@ signals:
 
 private slots:
     void on_filterFreq_newFrequency(qint64 freq);
-    void on_filterCombo_activated(int index);
+    void on_filterCombo_currentIndexChanged(int index);
     void on_filterButton_clicked();
-    void on_modeSelector_activated(int index);
+    void on_modeSelector_currentIndexChanged(int index);
     void on_modeButton_clicked();
     void on_agcButton_clicked();
     void on_autoSquelchButton_clicked();


### PR DESCRIPTION
When we change the value either on filterCombo or modeSelector, there is a little lag due to the processing of the change.
This lag is also present when we select the filter/mode currently enabled.
The aim of the request is to fix this unwanted lag.
