### PR TITLE
QT doesn't need svg

### DIFF
--- a/gqrx.pro
+++ b/gqrx.pro
@@ -9,7 +9,7 @@
 #    BOOST_SUFFIX=-mt       To link against libboost-xyz-mt (needed for pybombs)
 #--------------------------------------------------------------------------------
 
-QT       += core gui svg network
+QT       += core gui network
 contains(QT_MAJOR_VERSION,5) {
     QT += widgets
 }


### PR DESCRIPTION
It looks like QT doesn't need svg here.  This causes the binary to attempt linking to qtsvg, however, since gqrx doesn't actually link to qtsvg, this seems kinda silly.

the downstream bug is here:
https://bugs.gentoo.org/show_bug.cgi?id=521206

This PR removes the build time dep (since it isn't used at build time).  QTsvg should be a runtime dep only.
