### PR TITLE
Read and write gain using remote control

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -11,12 +11,18 @@ Supported commands:
     Set demodulator mode and passband [Hz]
     Passing a '?' as the first argument instead of 'mode' will return
     a space separated list of radio backend supported modes.
+ l|L ?
+    Get a space separated list of settings available for reading (l) or writing (L).
  l STRENGTH
     Get signal strength [dBFS]
  l SQL
     Get squelch threshold [dBFS]
  L SQL <sql>
     Set squelch threshold to <sql> [dBFS]
+ l <gain_name>_GAIN
+    Get the value of the gain setting with the name <gain_name>
+ L <gain_name>_GAIN <value>
+    Set the value of the gain setting with the name <gain_name> to <value>
  u RECORD
     Get status of audio recorder
  U RECORD <status>

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -278,7 +278,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(remote, SIGNAL(stopAudioRecorderEvent()), uiDockAudio, SLOT(stopAudioRecorder()));
     connect(ui->plotter, SIGNAL(newFilterFreq(int, int)), remote, SLOT(setPassband(int, int)));
     connect(remote, SIGNAL(newPassband(int)), this, SLOT(setPassband(int)));
-    connect(remote, SIGNAL(gainChanged(QString, double)), this, SLOT(setGain(QString,double)));
+    connect(remote, SIGNAL(gainChanged(QString, double)), uiDockInputCtl, SLOT(setGain(QString,double)));
 
     rds_timer = new QTimer(this);
     connect(rds_timer, SIGNAL(timeout()), this, SLOT(rdsTimeout()));

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -188,6 +188,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(uiDockInputCtl, SIGNAL(lnbLoChanged(double)), this, SLOT(setLnbLo(double)));
     connect(uiDockInputCtl, SIGNAL(lnbLoChanged(double)), remote, SLOT(setLnbLo(double)));
     connect(uiDockInputCtl, SIGNAL(gainChanged(QString, double)), this, SLOT(setGain(QString,double)));
+    connect(uiDockInputCtl, SIGNAL(gainChanged(QString, double)), remote, SLOT(setGain(QString,double)));
     connect(uiDockInputCtl, SIGNAL(autoGainChanged(bool)), this, SLOT(setAutoGain(bool)));
     connect(uiDockInputCtl, SIGNAL(freqCorrChanged(double)), this, SLOT(setFreqCorr(double)));
     connect(uiDockInputCtl, SIGNAL(iqSwapChanged(bool)), this, SLOT(setIqSwap(bool)));
@@ -277,6 +278,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(remote, SIGNAL(stopAudioRecorderEvent()), uiDockAudio, SLOT(stopAudioRecorder()));
     connect(ui->plotter, SIGNAL(newFilterFreq(int, int)), remote, SLOT(setPassband(int, int)));
     connect(remote, SIGNAL(newPassband(int)), this, SLOT(setPassband(int)));
+    connect(remote, SIGNAL(gainChanged(QString, double)), this, SLOT(setGain(QString,double)));
 
     rds_timer = new QTimer(this);
     connect(rds_timer, SIGNAL(timeout()), this, SLOT(rdsTimeout()));
@@ -789,6 +791,7 @@ void MainWindow::updateGainStages(bool read_from_device)
     }
 
     uiDockInputCtl->setGainStages(gain_list);
+    remote->setGainStages(gain_list);
 }
 
 /**

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -367,6 +367,27 @@ void RemoteControl::setReceiverStatus(bool enabled)
     receiver_running = enabled;
 }
 
+/*! \brief Set available gain settings (from mainwindow). */
+void RemoteControl::setGainStages(gain_list_t &gain_list)
+{
+    gains = gain_list;
+}
+
+/*! \brief Set value for a specific gain setting (from DockInputCtl). */
+bool RemoteControl::setGain(QString name, double gain)
+{
+    qDebug() << name << " = " << gain;
+    for(auto &g : gains)
+    {
+        if(name == QString::fromStdString(g.name))
+        {
+            g.value = gain;
+            return true;
+        }
+    }
+    return false;
+}
+
 
 /*! \brief Convert mode string to enum (DockRxOpt::rxopt_mode_idx)
  *  \param mode The Hamlib rigctld compatible mode string
@@ -571,13 +592,37 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
     QString lvl = cmdlist.value(1, "");
 
     if (lvl == "?")
-       answer = QString("SQL STRENGTH\n");
+    {
+        QStringList names;
+        for(auto &g : gains)
+            names.push_back(QString("%1_GAIN").arg(QString::fromStdString(g.name)));
+        answer = QString("SQL STRENGTH %1\n").arg(names.join(" "));
+    }
     else if (lvl.compare("STRENGTH", Qt::CaseInsensitive) == 0 || lvl.isEmpty())
-       answer = QString("%1\n").arg(signal_level, 0, 'f', 1);
+    {
+        answer = QString("%1\n").arg(signal_level, 0, 'f', 1);
+    }
     else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
-       answer = QString("%1\n").arg(squelch_level, 0, 'f', 1);
+    {
+        answer = QString("%1\n").arg(squelch_level, 0, 'f', 1);
+    }
+    else if (lvl.contains(QRegExp("_GAIN$")))
+    {
+        QString name = lvl.remove(QRegExp("_GAIN$"));
+        answer = QString("RPRT 1\n");
+        for(auto &g : gains)
+        {
+            if(name == QString::fromStdString(g.name))
+            {
+                answer = QString("%1\n").arg(g.value);
+                break;
+            }
+        }
+    }
     else
-       answer = QString("RPRT 1\n");
+    {
+        answer = QString("RPRT 1\n");
+    }
 
     return answer;
 }

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -105,6 +105,7 @@ signals:
     void newSquelchLevel(double level);
     void startAudioRecorderEvent();
     void stopAudioRecorderEvent();
+    void gainChanged(QString name, double value);
 
 private slots:
     void acceptConnection();

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -31,6 +31,9 @@
 #include <QTcpSocket>
 #include <QtNetwork>
 
+/* For gain_t and gain_list_t */
+#include "qtgui/dockinputctl.h"
+
 /*! \brief Simple TCP server for remote control.
  *
  * The TCP interface is compatible with the hamlib rigtctld so that applications
@@ -78,6 +81,7 @@ public:
         return rc_allowed_hosts;
     }
     void setReceiverStatus(bool enabled);
+    void setGainStages(gain_list_t &gain_list);
 
 public slots:
     void setNewFrequency(qint64 freq);
@@ -90,6 +94,7 @@ public slots:
     void setSquelchLevel(double level);
     void startAudioRecorder(QString unused);
     void stopAudioRecorder();
+    bool setGain(QString name, double gain);
 
 signals:
     void newFrequency(qint64 freq);
@@ -125,6 +130,7 @@ private:
     bool        audio_recorder_status; /*!< Recording enabled */
     bool        receiver_running;  /*!< Wether the receiver is running or not */
     bool        hamlib_compatible;
+    gain_list_t gains;             /*!< Possible and current gain settings */
 
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);

--- a/src/qtgui/dockinputctl.cpp
+++ b/src/qtgui/dockinputctl.cpp
@@ -200,7 +200,7 @@ double DockInputCtl::lnbLo()
  * @param name The name of the gain to change.
  * @param value The new value.
  */
-void DockInputCtl::setGain(QString &name, double value)
+void DockInputCtl::setGain(QString name, double value)
 {
     int gain = -1;
 

--- a/src/qtgui/dockinputctl.h
+++ b/src/qtgui/dockinputctl.h
@@ -73,7 +73,6 @@ public:
     double  lnbLo();
     void    readLnbLoFromSettings(QSettings * settings);
 
-    void    setGain(QString &name, double value);
     double  gain(QString &name);
 
     void    setAgc(bool enabled);
@@ -101,6 +100,9 @@ public:
     void    restoreManualGains(void);
 
     void    setFreqCtrlReset(bool enabled);
+
+public slots:
+    void    setGain(QString name, double value);
 
 signals:
     void gainChanged(QString name, double value);


### PR DESCRIPTION
Read and write the gain settings via remote control, as discussed in #524.
The settings are exposed as <NAME>_GAIN and are accessed with the "l" (read) and "L" (write) commands.