### PR TITLE
Use gr-network's UDP Sink in GNU Radio >= 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ include(FindPkgConfig)
 find_package(Gnuradio-osmosdr REQUIRED)
 
 set(GR_REQUIRED_COMPONENTS RUNTIME ANALOG AUDIO BLOCKS DIGITAL FILTER FFT PMT)
-find_package(Gnuradio REQUIRED COMPONENTS analog audio blocks digital filter fft)
+find_package(Gnuradio REQUIRED COMPONENTS analog audio blocks digital filter fft network)
 if(Gnuradio_VERSION VERSION_LESS "3.8")
     find_package(Volk)
 endif()

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
        NEW: Added SoapyRemote to AppImage and DMG releases.
        NEW: Added SoapyPlutoSDR to DMG release.
+       NEW: Preliminary support for GNU Radio 3.10.
      FIXED: Compatibility with case-sensitive filesystems on MacOS.
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,17 @@ target_link_libraries(${PROJECT_NAME}
     ${VOLK_LIBRARIES}
 )
 
-if(NOT Gnuradio_VERSION VERSION_LESS "3.8")
+if(NOT Gnuradio_VERSION VERSION_LESS "3.10")
+    target_link_libraries(${PROJECT_NAME}
+        gnuradio::gnuradio-analog
+        gnuradio::gnuradio-blocks
+        gnuradio::gnuradio-digital
+        gnuradio::gnuradio-filter
+        gnuradio::gnuradio-network
+        gnuradio::gnuradio-audio
+        Volk::volk
+    )
+elseif(NOT Gnuradio_VERSION VERSION_LESS "3.8")
     target_link_libraries(${PROJECT_NAME}
         gnuradio::gnuradio-analog
         gnuradio::gnuradio-blocks

--- a/src/interfaces/udp_sink_f.h
+++ b/src/interfaces/udp_sink_f.h
@@ -23,9 +23,14 @@
 #ifndef UDP_SINK_F_H
 #define UDP_SINK_F_H
 
+#if GNURADIO_VERSION < 0x031000
+#include <gnuradio/blocks/udp_sink.h>
+#else
+#include <gnuradio/network/udp_sink.h>
+#endif
+
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/blocks/float_to_short.h>
-#include <gnuradio/blocks/udp_sink.h>
 #include <gnuradio/blocks/interleave.h>
 #include <gnuradio/blocks/null_sink.h>
 
@@ -50,7 +55,11 @@ public:
     void stop_streaming(void);
 
 private:
+#if GNURADIO_VERSION < 0x031000
     gr::blocks::udp_sink::sptr        d_sink;   /*!< The gnuradio UDP sink. */
+#else
+    gr::network::udp_sink::sptr       d_sink;   /*!< The gnuradio UDP sink. */
+#endif
     gr::blocks::float_to_short::sptr  d_f2s;    /*!< Converts float to short. */
     gr::blocks::interleave::sptr      d_inter;  /*!< Stereo interleaver. */
     gr::blocks::null_sink::sptr       d_null0;  /*!< Null sink for mono. */


### PR DESCRIPTION
Fixes #963.
Replaces #958.

Even though the new UDP Sink block is available in GNU Radio 3.9, I've limited this change to GNU Radio 3.10 to prevent https://github.com/gnuradio/gnuradio/issues/5112 from affecting GNU Radio 3.9 users. Until that bug is fixed, GNU Radio 3.10 users will experience a crash if Gqrx's DSP settings are changed during UDP streaming.

I tested this change against GNU Radio 3.8, 3.9 and 3.10. I used multimon-ng for testing.

/cc @fventuri @phaethon @ulrichloose @willcode 