### PR TITLE
Add signing & notarization for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,23 @@ jobs:
           cmake ..
           LIBRARY_PATH=/usr/local/opt/icu4c/lib make
           make install
+      - name: Install Apple certificate
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
       - name: Checkout code
         uses: actions/checkout@v2
         with:
@@ -151,8 +168,31 @@ jobs:
       - name: Compile
         working-directory: build
         run: make
-      - name: Build DMG
+      - name: Build app bundle
         run: ./macos_bundle.sh
+      - name: Notarize app bundle
+        uses: devbotsxyz/xcode-notarize@v1
+        with:
+          product-path: Gqrx.app
+          appstore-connect-username: ${{ secrets.NOTARIZE_USERNAME }}
+          appstore-connect-password: ${{ secrets.NOTARIZE_PASSWORD }}
+      - name: Staple app bundle
+        run: xcrun stapler staple --verbose Gqrx.app
+      - name: Create DMG
+        run: hdiutil create Gqrx.dmg -srcfolder Gqrx.app -format UDZO -fs HFS+ -volname Gqrx
+      - name: Notarize DMG
+        uses: devbotsxyz/xcode-notarize@v1
+        with:
+          product-path: Gqrx.dmg
+          primary-bundle-id: dk.gqrx.gqrx
+          appstore-connect-username: ${{ secrets.NOTARIZE_USERNAME }}
+          appstore-connect-password: ${{ secrets.NOTARIZE_PASSWORD }}
+      - name: Staple DMG
+        run: xcrun stapler staple --verbose Gqrx.dmg
+      - name: Rename DMG
+        run: |
+          GQRX_VERSION=$(<version.txt)
+          mv Gqrx.dmg Gqrx-$GQRX_VERSION.dmg
       - name: Save artifact
         uses: actions/upload-artifact@v2
         with:

--- a/macos_bundle.sh
+++ b/macos_bundle.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 GQRX_VERSION=$(<version.txt)
+IDENTITY=Y3GC27WZ4S
 
 mkdir -p Gqrx.app/Contents/MacOS
 mkdir -p Gqrx.app/Contents/Resources
@@ -17,7 +18,7 @@ mkdir -p Gqrx.app/Contents/Resources
   <key>CFBundleExecutable</key>
   <string>gqrx</string>
   <key>CFBundleIdentifier</key>
-  <string>dk.gqrx.www</string>
+  <string>dk.gqrx.gqrx</string>
   <key>CFBundleName</key>
   <string>Gqrx</string>
   <key>CFBundleIconFile</key>
@@ -43,5 +44,9 @@ chmod 644 Gqrx.app/Contents/soapy-modules/*
 
 dylibbundler -s /usr/local/opt/icu4c/lib/ -od -b -x Gqrx.app/Contents/MacOS/gqrx -x Gqrx.app/Contents/soapy-modules/libPlutoSDRSupport.so -x Gqrx.app/Contents/soapy-modules/libremoteSupport.so -d Gqrx.app/Contents/libs/
 ln -sf /usr/local/opt/python@3.9/Frameworks/Python.framework /usr/local/opt/python@3.9/lib/Python.framework
-/usr/local/opt/qt@5/bin/macdeployqt Gqrx.app -dmg -no-strip -always-overwrite
-mv Gqrx.dmg Gqrx-$GQRX_VERSION.dmg
+/usr/local/opt/qt@5/bin/macdeployqt Gqrx.app -no-strip -always-overwrite -sign-for-notarization=$IDENTITY
+
+for f in Gqrx.app/Contents/libs/*.dylib Gqrx.app/Contents/soapy-modules/*.so Gqrx.app/Contents/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python Gqrx.app/Contents/Frameworks/*.framework Gqrx.app/Contents/MacOS/gqrx
+do
+    codesign --force --verify --verbose --timestamp --options runtime --sign $IDENTITY $f
+done


### PR DESCRIPTION
Fixes #989.

With this change, it is now possible to open Gqrx on macOS without bypassing Gatekeeper.