### PR TITLE
allow app to start on windows - correctly quote file source names - use zero data in default source

### DIFF
--- a/src/applications/gqrx/file_resources.cpp
+++ b/src/applications/gqrx/file_resources.cpp
@@ -29,24 +29,28 @@
 
 std::string receiver::get_random_file(void)
 {
-    static std::string path;
-    if (path.empty())
+#ifdef WIN32
+  return "NUL";
+#else
+  static std::string path;
+  if (path.empty())
+  {
+    path = "/dev/urandom";
+    QFileInfo checkFile(QString::fromStdString(path));
+    if (!checkFile.exists())
     {
-        path = "/dev/urandom";
-        QFileInfo checkFile(QString::fromStdString(path));
-        if (!checkFile.exists())
-        {
-            //static temp file persists until process end
-            static QTemporaryFile temp_file;
-            temp_file.open();
-            path = temp_file.fileName().toStdString();
-            {
-                QDataStream stream(&temp_file);
-                for (size_t i = 0; i < 1024*8; i++) stream << qint8(rand());
-            }
-            temp_file.close();
-            std::cout << "Created random file " << path << std::endl;
-        }
+      //static temp file persists until process end
+      static QTemporaryFile temp_file;
+      temp_file.open();
+      path = temp_file.fileName().toStdString();
+      {
+        QDataStream stream(&temp_file);
+        for (size_t i = 0; i < 1024 * 8; i++) stream << qint8(rand());
+      }
+      temp_file.close();
+      std::cout << "Created random file " << path << std::endl;
     }
-    return path;
+  }
+  return path;
+#endif
 }

--- a/src/applications/gqrx/file_resources.cpp
+++ b/src/applications/gqrx/file_resources.cpp
@@ -21,17 +21,18 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "applications/gqrx/receiver.h"
+#include <iostream>
+#include <sstream>
+
+#include <boost/io/quoted.hpp>
 #include <QFileInfo>
 #include <QTemporaryFile>
 #include <QDataStream>
-#include <iostream>
+
+#include "applications/gqrx/receiver.h"
 
 std::string receiver::get_zero_file(void)
 {
-#ifdef WIN32
-  return "NUL";
-#else
   static std::string path;
   if (path.empty())
   {
@@ -45,12 +46,28 @@ std::string receiver::get_zero_file(void)
       path = temp_file.fileName().toStdString();
       {
         QDataStream stream(&temp_file);
-        for (size_t i = 0; i < 1024 * 8; i++) stream << qint8(rand());
+        for (size_t i = 0; i < 1024 * 8; i++) stream << qint8(0);
       }
       temp_file.close();
-      std::cout << "Created random file " << path << std::endl;
+      std::cout << "Created zero file " << path << std::endl;
     }
   }
   return path;
-#endif
+}
+
+std::string receiver::double_quote_path(std::string path)
+{
+  if (path == "") {
+    return path;
+  }
+
+  std::stringstream q1;
+  q1 << boost::io::quoted(path, '\\', '\'');
+  std::stringstream q2;
+  q2 << boost::io::quoted(q1.str(), '\\', ',');
+  std::string qp = q2.str();
+  if (qp[0] == ',')
+    qp = qp.substr(1, qp.size() - 2);
+
+  return qp;
 }

--- a/src/applications/gqrx/file_resources.cpp
+++ b/src/applications/gqrx/file_resources.cpp
@@ -27,7 +27,7 @@
 #include <QDataStream>
 #include <iostream>
 
-std::string receiver::get_random_file(void)
+std::string receiver::get_zero_file(void)
 {
 #ifdef WIN32
   return "NUL";
@@ -35,7 +35,7 @@ std::string receiver::get_random_file(void)
   static std::string path;
   if (path.empty())
   {
-    path = "/dev/urandom";
+    path = "/dev/zero";
     QFileInfo checkFile(QString::fromStdString(path));
     if (!checkFile.exists())
     {

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1599,8 +1599,9 @@ void MainWindow::startIqPlayback(const QString& filename, float samprate)
     storeSession();
 
     auto sri = (int)samprate;
-    auto devstr = QString("file='%1',rate=%2,throttle=true,repeat=false")
-            .arg(filename).arg(sri);
+    QString quotedFilename = receiver::double_quote_path(filename.toStdString()).c_str();
+    auto devstr = QString("file=%1,rate=%2,throttle=true,repeat=false")
+            .arg(quotedFilename).arg(sri);
 
     qDebug() << __func__ << ":" << devstr;
 

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -76,7 +76,7 @@ receiver::receiver(const std::string input_device,
 
     if (input_device.empty())
     {
-        src = osmosdr::source::make("file="+get_random_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
+        src = osmosdr::source::make("file="+get_zero_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
     }
     else
     {
@@ -215,7 +215,7 @@ void receiver::set_input_device(const std::string device)
     catch (std::exception &x)
     {
         error = x.what();
-        src = osmosdr::source::make("file="+get_random_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
+        src = osmosdr::source::make("file="+get_zero_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
     }
 
     if(src->get_sample_rate() != 0)

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -71,12 +71,11 @@ receiver::receiver(const std::string input_device,
       d_iq_balance(false),
       d_demod(RX_DEMOD_OFF)
 {
-
     tb = gr::make_top_block("gqrx");
 
     if (input_device.empty())
     {
-        src = osmosdr::source::make("file="+get_zero_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
+        src = osmosdr::source::make("file=" + double_quote_path(get_zero_file()) + ",freq=428e6,rate=96000,repeat=true,throttle=true");
     }
     else
     {
@@ -215,7 +214,7 @@ void receiver::set_input_device(const std::string device)
     catch (std::exception &x)
     {
         error = x.what();
-        src = osmosdr::source::make("file="+get_zero_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
+        src = osmosdr::source::make("file=" + double_quote_path(get_zero_file()) + ",freq=428e6,rate=96000,repeat=true,throttle=true");
     }
 
     if(src->get_sample_rate() != 0)

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -291,8 +291,12 @@ private:
     gr::audio::sink::sptr     audio_snk;  /*!< gr audio sink */
 #endif
 
-    //! Get a path to a file containing random bytes
-    static std::string get_zero_file(void);
+public:
+  //! Get a path to a file containing null bytes
+  static std::string get_zero_file(void);
+
+  //! Quote a file path for use in a device string
+  static std::string double_quote_path(std::string path);
 };
 
 #endif // RECEIVER_H

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -292,7 +292,7 @@ private:
 #endif
 
     //! Get a path to a file containing random bytes
-    static std::string get_random_file(void);
+    static std::string get_zero_file(void);
 };
 
 #endif // RECEIVER_H


### PR DESCRIPTION
Something about the 'random' file on Windows doens't work and causes an exception because the device string ends up malformed.

NUL is a valid (virtual) file on Windows which returns \0's and allows the app to start with the default device options before the user has selected a real input device.
