### PR TITLE
Dsp freeze fix

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
     2.15.1: In progress...
 
      FIXED: DSP stops when device is changed.
+     FIXED: USB error when device settings are changed.
 
 
       2.15: Released December 15, 2021

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -208,7 +208,18 @@ void receiver::set_input_device(const std::string device)
         tb->disconnect(src, 0, iq_swap, 0);
     }
 
+#if GNURADIO_VERSION < 0x030802
+    //Work around GNU Radio bug #3184
+    //temporarily connect dummy source to ensure that previous device is closed
+    src = osmosdr::source::make("file="+escape_filename(get_zero_file())+",freq=428e6,rate=96000,repeat=true,throttle=true");
+    tb->connect(src, 0, iq_swap, 0);
+    tb->start();
+    tb->stop();
+    tb->wait();
+    tb->disconnect(src, 0, iq_swap, 0);
+#else
     src.reset();
+#endif
 
     try
     {


### PR DESCRIPTION
Fix  #1003.
Switching input devices works even on the fly without DSP freeze/open errors.
Changing device options like direct sampling/bias tee works on the fly too.