### PR TITLE
Fix S-meter oscillation

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
        NEW: Start/stop RDS and fetch Program Identification via remote control.
        NEW: Added IQ balancing to MacOS release.
+     FIXED: Erratic behaviour of S-meter.
      FIXED: Compilation error due to missing include.
   IMPROVED: Reordered the receiver mode drop-down list.
   IMPROVED: Receiver mode is now stored as a string in settings files.

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1339,7 +1339,7 @@ void MainWindow::setSqlLevel(double level_db)
  */
 double MainWindow::setSqlLevelAuto()
 {
-    double level = rx->get_signal_pwr(true) + 1.0;
+    double level = rx->get_signal_pwr() + 1.0;
     if (level > -10.0)  // avoid 0 dBFS
         level = uiDockRxOpt->getSqlLevel();
 
@@ -1352,7 +1352,7 @@ void MainWindow::meterTimeout()
 {
     float level;
 
-    level = rx->get_signal_pwr(true);
+    level = rx->get_signal_pwr();
     ui->sMeter->setLevel(level);
     remote->setSignalLevel(level);
 }

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -715,9 +715,9 @@ receiver::status receiver::set_freq_corr(double ppm)
  * This method returns the current signal power detected by the receiver. The detector
  * is located after the band pass filter. The full scale is 1.0
  */
-float receiver::get_signal_pwr(bool dbfs) const
+float receiver::get_signal_pwr() const
 {
-    return rx->get_signal_level(dbfs);
+    return rx->get_signal_level();
 }
 
 /** Set new FFT size. */

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -162,7 +162,7 @@ public:
     double      get_cw_offset(void) const;
     status      set_filter(double low, double high, filter_shape shape);
     status      set_freq_corr(double ppm);
-    float       get_signal_pwr(bool dbfs) const;
+    float       get_signal_pwr() const;
     void        set_iq_fft_size(int newsize);
     void        set_iq_fft_window(int window_type);
     void        get_iq_fft_data(std::complex<float>* fftPoints,

--- a/src/dsp/rx_meter.cpp
+++ b/src/dsp/rx_meter.cpp
@@ -65,7 +65,7 @@ int rx_meter_c::work(int noutput_items,
 }
 
 
-float rx_meter_c::get_level()
+float rx_meter_c::get_level_db()
 {
     std::lock_guard<std::mutex> lock(d_mutex);
 
@@ -82,10 +82,6 @@ float rx_meter_c::get_level()
     for (unsigned int i = 0; i < d_avgsize; i++)
         sum += d_cbuf[i].real()*d_cbuf[i].real() + d_cbuf[i].imag()*d_cbuf[i].imag();
 
-    return sum / (float)(d_avgsize);
-}
-
-float rx_meter_c::get_level_db()
-{
-    return (float) 10. * log10f(get_level() + 1.0e-20);
+    float power = sum / (float)(d_avgsize);
+    return (float) 10. * log10f(power + 1.0e-20);
 }

--- a/src/dsp/rx_meter.h
+++ b/src/dsp/rx_meter.h
@@ -51,7 +51,7 @@ rx_meter_c_sptr make_rx_meter_c(double quad_rate);
  *  \ingroup DSP
  *
  * This block can be used to measure the received signal strength.
- * The get_level() and get_level_db() methods return the average signal power
+ * The get_level_db() method returns the average signal power
  * over a 100ms period.
  */
 class rx_meter_c : public gr::sync_block
@@ -67,9 +67,6 @@ public:
     int work(int noutput_items,
              gr_vector_const_void_star &input_items,
              gr_vector_void_star &output_items);
-
-    /*! \brief Get the current signal level. */
-    float get_level();
 
     /*! \brief Get the current signal level in dBFS. */
     float get_level_db();

--- a/src/dsp/rx_meter.h
+++ b/src/dsp/rx_meter.h
@@ -25,15 +25,6 @@
 
 #include <gnuradio/sync_block.h>
 
-enum detector_type_e {
-    DETECTOR_TYPE_NONE   = 0,
-    DETECTOR_TYPE_SAMPLE = 1,
-    DETECTOR_TYPE_MIN    = 2,
-    DETECTOR_TYPE_MAX    = 3,
-    DETECTOR_TYPE_AVG    = 4,
-    DETECTOR_TYPE_RMS    = 5
-};
-
 
 class rx_meter_c;
 
@@ -45,13 +36,12 @@ typedef std::shared_ptr<rx_meter_c> rx_meter_c_sptr;
 
 
 /*! \brief Return a shared_ptr to a new instance of rx_meter_c.
- *  \param detector Detector type.
  *
  * This is effectively the public constructor. To avoid accidental use
  * of raw pointers, the rx_meter_c constructor is private.
  * make_rxfilter is the public interface for creating new instances.
  */
-rx_meter_c_sptr make_rx_meter_c(int detector=DETECTOR_TYPE_RMS);
+rx_meter_c_sptr make_rx_meter_c();
 
 
 /*! \brief Block for measuring signal strength (complex input).
@@ -64,10 +54,10 @@ rx_meter_c_sptr make_rx_meter_c(int detector=DETECTOR_TYPE_RMS);
  */
 class rx_meter_c : public gr::sync_block
 {
-    friend rx_meter_c_sptr make_rx_meter_c(int detector);
+    friend rx_meter_c_sptr make_rx_meter_c();
 
 protected:
-    rx_meter_c(int detector=DETECTOR_TYPE_RMS);
+    rx_meter_c();
 
 public:
     ~rx_meter_c();
@@ -82,22 +72,10 @@ public:
     /*! \brief Get the current signal level in dBFS. */
     float get_level_db();
 
-    /*! \brief Enable or disable averaging.
-     *  \param detector Detector type.
-     */
-    void set_detector_type(int detector);
-
-    /*! \brief Get averaging status
-     *  \returns TRUE if averaging is enabled, FALSE if it is disabled.
-     */
-    int get_detector_type() {return d_detector;}
-
 private:
-    int    d_detector;  /*! Detector type. */
     float  d_level;     /*! The current level in the range 0.0 to 1.0 */
     float  d_level_db;  /*! The current level in dBFS with FS = 1.0 */
     float  d_sum;       /*! Sum of msamples. */
-    float  d_sumsq;     /*! Sum of samples squared. */
     int    d_num;       /*! Number of samples in d_sum and d_sumsq. */
 
     void reset_stats();

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -128,13 +128,9 @@ void nbrx::set_cw_offset(double offset)
     filter->set_cw_offset(offset);
 }
 
-float nbrx::get_signal_level(bool dbfs)
+float nbrx::get_signal_level()
 {
-    if (dbfs)
-        return meter->get_level_db();
-    else
-        return meter->get_level();
-
+    return meter->get_level_db();
 }
 
 void nbrx::set_nb_on(int nbid, bool on)

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -46,7 +46,7 @@ nbrx::nbrx(float quad_rate, float audio_rate)
     filter = make_rx_filter(PREF_QUAD_RATE, -5000.0, 5000.0, 1000.0);
     agc = make_rx_agc_cc(PREF_QUAD_RATE, true, -100, 0, 0, 500, false);
     sql = gr::analog::simple_squelch_cc::make(-150.0, 0.001);
-    meter = make_rx_meter_c();
+    meter = make_rx_meter_c(PREF_QUAD_RATE);
     demod_raw = gr::blocks::complex_to_float::make(1);
     demod_ssb = gr::blocks::complex_to_real::make(1);
     demod_fm = make_rx_demod_fm(PREF_QUAD_RATE, 5000.0, 75.0e-6);

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -46,7 +46,7 @@ nbrx::nbrx(float quad_rate, float audio_rate)
     filter = make_rx_filter(PREF_QUAD_RATE, -5000.0, 5000.0, 1000.0);
     agc = make_rx_agc_cc(PREF_QUAD_RATE, true, -100, 0, 0, 500, false);
     sql = gr::analog::simple_squelch_cc::make(-150.0, 0.001);
-    meter = make_rx_meter_c(DETECTOR_TYPE_RMS);
+    meter = make_rx_meter_c();
     demod_raw = gr::blocks::complex_to_float::make(1);
     demod_ssb = gr::blocks::complex_to_real::make(1);
     demod_fm = make_rx_demod_fm(PREF_QUAD_RATE, 5000.0, 75.0e-6);

--- a/src/receivers/nbrx.h
+++ b/src/receivers/nbrx.h
@@ -79,7 +79,7 @@ public:
     void set_filter(double low, double high, double tw);
     void set_cw_offset(double offset);
 
-    float get_signal_level(bool dbfs);
+    float get_signal_level();
 
     /* Noise blanker */
     bool has_nb() { return true; }

--- a/src/receivers/receiver_base.h
+++ b/src/receivers/receiver_base.h
@@ -61,7 +61,7 @@ public:
     virtual void set_filter(double low, double high, double tw) = 0;
     virtual void set_cw_offset(double offset) = 0;
 
-    virtual float get_signal_level(bool dbfs) = 0;
+    virtual float get_signal_level() = 0;
 
     virtual void set_demod(int demod) = 0;
 

--- a/src/receivers/wfmrx.cpp
+++ b/src/receivers/wfmrx.cpp
@@ -44,7 +44,7 @@ wfmrx::wfmrx(float quad_rate, float audio_rate)
 
     filter = make_rx_filter(PREF_QUAD_RATE, -80000.0, 80000.0, 20000.0);
     sql = gr::analog::simple_squelch_cc::make(-150.0, 0.001);
-    meter = make_rx_meter_c(DETECTOR_TYPE_RMS);
+    meter = make_rx_meter_c();
     demod_fm = make_rx_demod_fm(PREF_QUAD_RATE, 75000.0, 0.0);
     stereo = make_stereo_demod(PREF_QUAD_RATE, d_audio_rate, true);
     stereo_oirt = make_stereo_demod(PREF_QUAD_RATE, d_audio_rate, true, true);

--- a/src/receivers/wfmrx.cpp
+++ b/src/receivers/wfmrx.cpp
@@ -108,13 +108,9 @@ void wfmrx::set_filter(double low, double high, double tw)
     filter->set_param(low, high, tw);
 }
 
-float wfmrx::get_signal_level(bool dbfs)
+float wfmrx::get_signal_level()
 {
-    if (dbfs)
-        return meter->get_level_db();
-    else
-        return meter->get_level();
-
+    return meter->get_level_db();
 }
 
 /*

--- a/src/receivers/wfmrx.cpp
+++ b/src/receivers/wfmrx.cpp
@@ -44,7 +44,7 @@ wfmrx::wfmrx(float quad_rate, float audio_rate)
 
     filter = make_rx_filter(PREF_QUAD_RATE, -80000.0, 80000.0, 20000.0);
     sql = gr::analog::simple_squelch_cc::make(-150.0, 0.001);
-    meter = make_rx_meter_c();
+    meter = make_rx_meter_c(PREF_QUAD_RATE);
     demod_fm = make_rx_demod_fm(PREF_QUAD_RATE, 75000.0, 0.0);
     stereo = make_stereo_demod(PREF_QUAD_RATE, d_audio_rate, true);
     stereo_oirt = make_stereo_demod(PREF_QUAD_RATE, d_audio_rate, true, true);

--- a/src/receivers/wfmrx.h
+++ b/src/receivers/wfmrx.h
@@ -75,7 +75,7 @@ public:
     void set_filter(double low, double high, double tw);
     void set_cw_offset(double offset) { (void)offset; }
 
-    float get_signal_level(bool dbfs);
+    float get_signal_level();
 
     /* Noise blanker */
     bool has_nb() { return false; }


### PR DESCRIPTION
@LongnoseRob noticed in #994 that the S-meter sometimes begins oscillating. This can easily be reproduced by using a large buffer length with an RTL-SDR by setting the device string to `rtl=0,buflen=1048576`.

To fix this I've changed the rx_meter block to operate the same way the rx_fft block does: incoming samples are stored in a circular buffer (which can accommodate bursts up incoming samples up to one second long), and the same number of samples is always averaged. Clock measurements determine which batch of samples is averaged.