### PR TITLE
Increase automatic squelch margin to 3 dB

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -7,6 +7,7 @@
      FIXED: Compilation error due to missing include.
   IMPROVED: Reordered the receiver mode drop-down list.
   IMPROVED: Receiver mode is now stored as a string in settings files.
+  IMPROVED: Increased automatic squelch margin to 3 dB.
 
 
     2.14.6: Released October 6, 2021

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1339,7 +1339,7 @@ void MainWindow::setSqlLevel(double level_db)
  */
 double MainWindow::setSqlLevelAuto()
 {
-    double level = rx->get_signal_pwr() + 1.0;
+    double level = rx->get_signal_pwr() + 3.0;
     if (level > -10.0)  // avoid 0 dBFS
         level = uiDockRxOpt->getSqlLevel();
 


### PR DESCRIPTION
Pressing the "A" (automatic squelch) button in the "Receiver Options" panel sets the squelch threshold to just 1 dB higher than the current signal level. This results in the squelch occasionally opening when there is only noise present. To solve this problem I've increased the margin from 1 dB to 3 dB.

To avoid a merge conflict, I've based this branch off of #1006.