### PR TITLE
Iq tool center freq fix

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,6 +1,7 @@
 
     2.15.2: In progress...
 
+       NEW: Save & restore center frequency when playing I/Q files.
      FIXED: Device selection fails for some SoapySDR devices.
      FIXED: Segfault when starting AppImage on some systems.
      FIXED: Waterfall & sound stop working after playing invalid I/Q file.

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -180,7 +180,7 @@ private slots:
     /* I/Q playback and recording*/
     void startIqRecording(const QString& recdir);
     void stopIqRecording();
-    void startIqPlayback(const QString& filename, float samprate);
+    void startIqPlayback(const QString& filename, float samprate, qint64 center_freq);
     void stopIqPlayback();
     void seekIqFile(qint64 seek_pos);
 

--- a/src/qtgui/iq_tool.h
+++ b/src/qtgui/iq_tool.h
@@ -64,7 +64,7 @@ public:
 signals:
     void startRecording(const QString recdir);
     void stopRecording();
-    void startPlayback(const QString filename, float samprate);
+    void startPlayback(const QString filename, float samprate, qint64 center_freq);
     void stopPlayback();
     void seek(qint64 seek_pos);
 
@@ -84,8 +84,7 @@ private slots:
 private:
     void refreshDir(void);
     void refreshTimeWidgets(void);
-    qint64 sampleRateFromFileName(const QString &filename);
-
+    void parseFileName(const QString &filename);
 
 private:
     Ui::CIqTool *ui;
@@ -100,6 +99,7 @@ private:
     bool    is_playing;
     int     bytes_per_sample;  /*!< Bytes per sample (fc = 4) */
     int     sample_rate;       /*!< Current sample rate. */
+    qint64  center_freq;       /*!< Center frequency. */
     int     rec_len;           /*!< Length of a recording in seconds */
 };
 


### PR DESCRIPTION
1. Parse the center frequency from IQ file name
2. Save center frequency and offset before starting IQ file playback
3. Restore center frequency and offset after finishing IQ file playback
