### PR TITLE
Iq tool gui fixes

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1552,6 +1552,8 @@ void MainWindow::startIqRecording(const QString& recdir)
             toString("%1/gqrx_yyyyMMdd_hhmmss_%2_%3_fc.'raw'")
             .arg(recdir).arg(freq).arg(sr/dec);
 
+    ui->actionIoConfig->setDisabled(true);
+    ui->actionLoadSettings->setDisabled(true);
     // start recorder; fails if recording already in progress
     if (rx->start_iq_recording(lastRec.toStdString()))
     {
@@ -1582,6 +1584,8 @@ void MainWindow::stopIqRecording()
         ui->statusBar->showMessage(tr("Error stopping I/Q recoder"));
     else
         ui->statusBar->showMessage(tr("I/Q data recoding stopped"), 5000);
+    ui->actionIoConfig->setDisabled(false);
+    ui->actionLoadSettings->setDisabled(false);
 }
 
 void MainWindow::startIqPlayback(const QString& filename, float samprate, qint64 center_freq)
@@ -1624,6 +1628,9 @@ void MainWindow::startIqPlayback(const QString& filename, float samprate, qint64
 
     // FIXME: would be nice with good/bad status
     ui->statusBar->showMessage(tr("Playing %1").arg(filename));
+    ui->actionIoConfig->setDisabled(true);
+    ui->actionLoadSettings->setDisabled(true);
+    ui->actionSaveSettings->setDisabled(true);
 
     on_actionDSP_triggered(true);
 }
@@ -1637,6 +1644,9 @@ void MainWindow::stopIqPlayback()
     }
 
     ui->statusBar->showMessage(tr("I/Q playback stopped"), 5000);
+    ui->actionIoConfig->setDisabled(false);
+    ui->actionLoadSettings->setDisabled(false);
+    ui->actionSaveSettings->setDisabled(false);
 
     // restore original input device
     auto indev = m_settings->value("input/device", "").toString();

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -101,6 +101,20 @@ void CIqTool::on_listWidget_currentTextChanged(const QString &currentText)
 
 }
 
+/*! \brief Show/hide/enable/disable GUI controls */
+
+void CIqTool::switchControlsState(bool recording, bool playback)
+{
+    ui->recButton->setEnabled(!playback);
+
+    ui->playButton->setEnabled(!recording);
+    ui->slider->setEnabled(!recording);
+
+    ui->listWidget->setEnabled(!(recording || playback));
+    ui->recDirEdit->setEnabled(!(recording || playback));
+    ui->recDirButton->setEnabled(!(recording || playback));
+}
+
 /*! \brief Start/stop playback */
 void CIqTool::on_playButton_clicked(bool checked)
 {
@@ -126,9 +140,8 @@ void CIqTool::on_playButton_clicked(bool checked)
         }
         else
         {
-            ui->listWidget->setEnabled(false);
-            ui->recButton->setEnabled(false);
             on_listWidget_currentTextChanged(current_file);
+            switchControlsState(false, true);
             emit startPlayback(recdir->absoluteFilePath(current_file),
                                (float)sample_rate, center_freq);
         }
@@ -136,8 +149,7 @@ void CIqTool::on_playButton_clicked(bool checked)
     else
     {
         emit stopPlayback();
-        ui->listWidget->setEnabled(true);
-        ui->recButton->setEnabled(true);
+        switchControlsState(false, false);
         ui->slider->setValue(0);
     }
 }
@@ -150,9 +162,7 @@ void CIqTool::on_playButton_clicked(bool checked)
  */
 void CIqTool::cancelPlayback()
 {
-    ui->playButton->setChecked(false);
-    ui->listWidget->setEnabled(true);
-    ui->recButton->setEnabled(true);
+    switchControlsState(false, false);
     is_playing = false;
 }
 
@@ -174,7 +184,7 @@ void CIqTool::on_recButton_clicked(bool checked)
 
     if (checked)
     {
-        ui->playButton->setEnabled(false);
+        switchControlsState(true, false);
         emit startRecording(recdir->path());
 
         refreshDir();
@@ -182,7 +192,7 @@ void CIqTool::on_recButton_clicked(bool checked)
     }
     else
     {
-        ui->playButton->setEnabled(true);
+        switchControlsState(false, false);
         emit stopRecording();
     }
 }

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -29,6 +29,7 @@
 #include <QString>
 #include <QStringList>
 #include <QTime>
+#include <QScrollBar>
 
 #include <math.h>
 
@@ -302,6 +303,8 @@ void CIqTool::timeoutFunction(void)
 void CIqTool::refreshDir()
 {
     int selection = ui->listWidget->currentRow();
+    QScrollBar * sc = ui->listWidget->verticalScrollBar();
+    int lastScroll = sc->sliderPosition();
 
     recdir->refresh();
     QStringList files = recdir->entryList();
@@ -310,6 +313,7 @@ void CIqTool::refreshDir()
     ui->listWidget->clear();
     ui->listWidget->insertItems(0, files);
     ui->listWidget->setCurrentRow(selection);
+    sc->setSliderPosition(lastScroll);
     ui->listWidget->blockSignals(false);
 
     if (is_recording)

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -128,6 +128,7 @@ void CIqTool::on_playButton_clicked(bool checked)
         {
             ui->listWidget->setEnabled(false);
             ui->recButton->setEnabled(false);
+            on_listWidget_currentTextChanged(current_file);
             emit startPlayback(recdir->absoluteFilePath(current_file),
                                (float)sample_rate, center_freq);
         }

--- a/src/qtgui/iq_tool.h
+++ b/src/qtgui/iq_tool.h
@@ -85,6 +85,8 @@ private:
     void refreshDir(void);
     void refreshTimeWidgets(void);
     void parseFileName(const QString &filename);
+    void switchControlsState(bool recording, bool playback);
+
 
 private:
     Ui::CIqTool *ui;


### PR DESCRIPTION
Fix IQ Tool file list jumpy scrollbar.
Always choose correct sample rate when starting IQ playback.
Disable GUI controls, that have no use or may break things during playback/recording of an IQ file.


Previous in series https://github.com/gqrx-sdr/gqrx/pull/1010
Next in series https://github.com/gqrx-sdr/gqrx/pull/1013
Closes https://github.com/gqrx-sdr/gqrx/issues/1037