### PR TITLE
Escape filename in device specification string

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -5,6 +5,8 @@
        NEW: Added IQ balancing to MacOS release.
      FIXED: Erratic behaviour of S-meter.
      FIXED: Compilation error due to missing include.
+     FIXED: Startup crash on Windows.
+     FIXED: I/Q playback when filename contains special characters.
   IMPROVED: Reordered the receiver mode drop-down list.
   IMPROVED: Receiver mode is now stored as a string in settings files.
   IMPROVED: Increased automatic squelch margin to 3 dB.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ endif(WIN32)
 #######################################################################################################################
 # Build the program
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCE} ${UIS_HDRS} ${RESOURCES_LIST})
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
 # The pulse libraries are only needed on Linux. On other platforms they will not be found, so having them here is fine.
 target_link_libraries(${PROJECT_NAME}
     Qt5::Core

--- a/src/applications/gqrx/file_resources.cpp
+++ b/src/applications/gqrx/file_resources.cpp
@@ -27,12 +27,12 @@
 #include <QDataStream>
 #include <iostream>
 
-std::string receiver::get_random_file(void)
+std::string receiver::get_zero_file(void)
 {
     static std::string path;
     if (path.empty())
     {
-        path = "/dev/urandom";
+        path = "/dev/zero";
         QFileInfo checkFile(QString::fromStdString(path));
         if (!checkFile.exists())
         {
@@ -42,7 +42,7 @@ std::string receiver::get_random_file(void)
             path = temp_file.fileName().toStdString();
             {
                 QDataStream stream(&temp_file);
-                for (size_t i = 0; i < 1024*8; i++) stream << qint8(rand());
+                for (size_t i = 0; i < 1024*8; i++) stream << qint8(0);
             }
             temp_file.close();
             std::cout << "Created random file " << path << std::endl;

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1599,8 +1599,9 @@ void MainWindow::startIqPlayback(const QString& filename, float samprate)
     storeSession();
 
     auto sri = (int)samprate;
-    auto devstr = QString("file='%1',rate=%2,throttle=true,repeat=false")
-            .arg(filename).arg(sri);
+    QString escapedFilename = receiver::escape_filename(filename.toStdString()).c_str();
+    auto devstr = QString("file=%1,rate=%2,throttle=true,repeat=false")
+            .arg(escapedFilename).arg(sri);
 
     qDebug() << __func__ << ":" << devstr;
 

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -76,7 +76,7 @@ receiver::receiver(const std::string input_device,
 
     if (input_device.empty())
     {
-        src = osmosdr::source::make("file="+get_random_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
+        src = osmosdr::source::make("file="+get_zero_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
     }
     else
     {
@@ -215,7 +215,7 @@ void receiver::set_input_device(const std::string device)
     catch (std::exception &x)
     {
         error = x.what();
-        src = osmosdr::source::make("file="+get_random_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
+        src = osmosdr::source::make("file="+get_zero_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
     }
 
     if(src->get_sample_rate() != 0)

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -21,7 +21,9 @@
  * Boston, MA 02110-1301, USA.
  */
 #include <cmath>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <QDebug>
 
 #include <gnuradio/prefs.h>
@@ -76,7 +78,7 @@ receiver::receiver(const std::string input_device,
 
     if (input_device.empty())
     {
-        src = osmosdr::source::make("file="+get_zero_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
+        src = osmosdr::source::make("file="+escape_filename(get_zero_file())+",freq=428e6,rate=96000,repeat=true,throttle=true");
     }
     else
     {
@@ -215,7 +217,7 @@ void receiver::set_input_device(const std::string device)
     catch (std::exception &x)
     {
         error = x.what();
-        src = osmosdr::source::make("file="+get_zero_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
+        src = osmosdr::source::make("file="+escape_filename(get_zero_file())+",freq=428e6,rate=96000,repeat=true,throttle=true");
     }
 
     if(src->get_sample_rate() != 0)
@@ -1412,4 +1414,14 @@ bool receiver::is_rds_decoder_active(void) const
 void receiver::reset_rds_parser(void)
 {
     rx->reset_rds_parser();
+}
+
+std::string receiver::escape_filename(std::string filename)
+{
+    std::stringstream ss1;
+    std::stringstream ss2;
+
+    ss1 << std::quoted(filename, '\'', '\\');
+    ss2 << std::quoted(ss1.str(), '\'', '\\');
+    return ss2.str();
 }

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -292,7 +292,7 @@ private:
 #endif
 
     //! Get a path to a file containing random bytes
-    static std::string get_random_file(void);
+    static std::string get_zero_file(void);
 };
 
 #endif // RECEIVER_H

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -229,6 +229,9 @@ public:
     bool        is_rds_decoder_active(void) const;
     void        reset_rds_parser(void);
 
+    /* utility functions */
+    static std::string escape_filename(std::string filename);
+
 private:
     void        connect_all(rx_chain type);
 


### PR DESCRIPTION
Replaces #1001.

Based on the work of @LouDou an @vladisslav2011 I've put together a cleaner version of a fix for both startup crashes on Windows and failure to play back I/Q files where the filename contains special characters.

Would you mind taking this branch for a spin @LouDou @vladisslav2011?