### PR TITLE
Quick fix for #1019

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ The following people and organisations have contributed to gqrx:
 * Valentin Ochs
 * Vesa Solonen
 * Vincent Pelletier
+* Vladisslav P
 * Will Scales
 * Wolfgang Fritz, DK7OB
 * Youssef Touil

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.15.1: In progress...
+
+     FIXED: DSP stops when device is changed.
+
+
       2.15: Released December 15, 2021
 
        NEW: Start/stop RDS and fetch Program Identification via remote control.

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1857,7 +1857,9 @@ int MainWindow::on_actionIoConfig_triggered()
 
     if (confres == QDialog::Accepted)
     {
-        if (ui->actionDSP->isChecked())
+        bool dsp_running = ui->actionDSP->isChecked();
+
+        if (dsp_running)
             // suspend DSP while we reload settings
             on_actionDSP_triggered(false);
 
@@ -1866,7 +1868,7 @@ int MainWindow::on_actionIoConfig_triggered()
         storeSession();
         loadConfig(m_settings->fileName(), false, false);
 
-        if (ui->actionDSP->isChecked())
+        if (dsp_running)
             // restsart DSP
             on_actionDSP_triggered(true);
     }


### PR DESCRIPTION
Fixes #1019.

Store previous DSP state in a variable to use it later as on_actionDSP_triggered changes ui->actionDSP state.