### PR TITLE
Fix white waterfall and no sound after playing back bad IQ file.

### DIFF
--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -233,6 +233,12 @@ void receiver::set_input_device(const std::string device)
         tb->connect(src, 0, iq_swap, 0);
     }
 
+    //reset DSP IIR filters to safe initial state from possible runaway after
+    // playing bad IQ file
+    auto last_demod = d_demod;
+    set_demod(RX_DEMOD_OFF, true);
+    set_demod(last_demod);
+
     if (d_running)
         tb->start();
 
@@ -1315,6 +1321,7 @@ void receiver::connect_all(rx_chain type)
 
     if (d_dc_cancel)
     {
+        dc_corr = make_dc_corr_cc(d_decim_rate, 1.0);
         tb->connect(b, 0, dc_corr, 0);
         b = dc_corr;
     }
@@ -1342,6 +1349,8 @@ void receiver::connect_all(rx_chain type)
         break;
 
     default:
+        rx.reset();
+        rx = make_nbrx(d_quad_rate, d_audio_rate);
         break;
     }
 


### PR DESCRIPTION
Fix #1018.
Workaround gnuradio blocks state corruption after device change by recreating dc_corr
(fixes white waterfall and no sound) and resetting the demod (fixes corrupted sound).
It looks like sometimes demodulators are not happy with bad samles too.
We should recreate the graph, temporarily switching out current
demodulator to prevent bad behavior.