### PR TITLE
Do not reopen a device when it's string did not change as it speeds u…

### DIFF
--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -189,6 +189,9 @@ void receiver::set_input_device(const std::string device)
     if (device.empty())
         return;
 
+    if (input_devstr.compare(device) == 0)
+        return;
+
     input_devstr = device;
 
     // tb->lock() can hang occasionally


### PR DESCRIPTION
…p switching filter bandwidths/sample rate.
That was done before 8b4c2efd394734f120245739e72b6f61e8370e32 and removed in, I think, attempt to work around GNU Radio bug gnuradio/gnuradio#3184. We can revert it back at least for input device as we already have a workaround for that bug merged.