### PR TITLE
Iq tool add sampling rate and frequency GUI inputs

### DIFF
--- a/src/qtgui/iq_tool.h
+++ b/src/qtgui/iq_tool.h
@@ -79,12 +79,15 @@ private slots:
     void on_playButton_clicked(bool checked);
     void on_slider_valueChanged(int value);
     void on_listWidget_currentTextChanged(const QString &currentText);
+    void on_centerFreqSpinBox_valueChanged(double value);
+    void on_sampleRateSpinBox_valueChanged(double value);
     void timeoutFunction(void);
 
 private:
     void refreshDir(void);
     void refreshTimeWidgets(void);
     void parseFileName(const QString &filename);
+    void setPlaybackSampleRate(qint64 sr);
 
 private:
     Ui::CIqTool *ui;
@@ -98,7 +101,8 @@ private:
     bool    is_recording;
     bool    is_playing;
     int     bytes_per_sample;  /*!< Bytes per sample (fc = 4) */
-    int     sample_rate;       /*!< Current sample rate. */
+    int     playback_sample_rate;       /*!< Playback sample rate. */
+    int     recording_sample_rate;      /*!< Recording sample rate. */
     qint64  center_freq;       /*!< Center frequency. */
     int     rec_len;           /*!< Length of a recording in seconds */
 };

--- a/src/qtgui/iq_tool.ui
+++ b/src/qtgui/iq_tool.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>482</width>
+    <width>499</width>
     <height>327</height>
    </rect>
   </property>
@@ -208,6 +208,80 @@
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="sampleRateLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Sample Rate, ksps</string>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="sampleRateSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>999999.989999999990687</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="Frequency">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Frequency, kHz</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="centerFreqSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>99999999.989999994635582</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This should help to play arbitrary named iq files at correct sampling rate and align waterfall/panadapter to correct center frequency.