### PR TITLE
Make some SoapySDR devices work when selected from drop-down list

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.15.2: In progress...
+
+     FIXED: Device selection fails for some SoapySDR devices.
+
+
     2.15.1: Released December 18, 2021
 
      FIXED: DSP stops when device is changed.

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -20,6 +20,7 @@
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  */
+#include <iomanip>
 #include <QDebug>
 #include <QFile>
 #include <QPushButton>
@@ -155,7 +156,7 @@ void CIoConfig::getDeviceList(std::map<QString, QVariant> &devList)
             devlabel = "Unknown";
         }
 
-        devstr = QString(dev.to_string().c_str());
+        devstr = QString(escapeDevstr(dev.to_string()).c_str());
         devList.insert(std::pair<QString, QVariant>(devlabel, devstr));
         qDebug() << "  " << devlabel;
     }
@@ -788,4 +789,14 @@ int CIoConfig::decim2idx(int decim) const
         ++idx;
 
     return idx;
+}
+
+/** Escape devstr to make some SoapySDR devices work when selected from drop-down */
+std::string CIoConfig::escapeDevstr(std::string devstr)
+{
+    std::stringstream ss1;
+    if (devstr.find(" ") == std::string::npos)
+        return devstr;
+    ss1 << std::quoted(devstr, '\'', '\\');
+    return ss1.str();
 }

--- a/src/qtgui/ioconfig.h
+++ b/src/qtgui/ioconfig.h
@@ -65,6 +65,7 @@ private:
     void updateOutDev();
     int  idx2decim(int idx) const;
     int  decim2idx(int decim) const;
+    static std::string escapeDevstr(std::string devstr);
 
 private:
     Ui::CIoConfig  *ui;


### PR DESCRIPTION
Correctly escape device strings to make SoapySDR devices work when selected from drop-down list.
HackRF and LimeSDR should work.
RTL-SDR does not work as it gets incorrectly enumerated: invalid rtl=# parameter is added.
