### PR TITLE
improved frequency accuracy at high zoom levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ The following people and organisations have contributed to gqrx:
 * Jeff Long
 * Jiawei Chen
 * Jiří Pinkava
+* Joachim Schueth, DL2KCD
 * Josh Blum
 * Kate Adams
 * Kenji Rikitake, JJ1BDX

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
      FIXED: Device selection fails for some SoapySDR devices.
      FIXED: Segfault when starting AppImage on some systems.
+  IMPROVED: Frequency accuracy of plots at high zoom levels.
 
 
     2.15.1: Released December 18, 2021


### PR DESCRIPTION
At high zoom levels, like 100 Hz span or less at 145 MHz, there were several artifacts in the spectrum / waterfall plots that are addressed by this pull request:

- The resolution and accuracy of frequency labels is now 1 Hz (spectrum and tooltips).
- The alignment of spectrum plot and frequency grid is more exact.
- When zooming in/out by mouse wheel, the frequency at the mouse pointer now really remains fixed within 1 Hz.
- At extreme zoom levels, frequency panning remains possible.

A small python script was added that allows to create a reference I/Q data file to test the above features with the play I/Q data tool in GQRX.

Some remarks concerning the use of float or double in frequency calculations:

For the frequency labels, float variables have been changed to double, as float does not provide the required precision.
Type double is now also used in some conversions between plot x coordinate and frequency, while the original code preferred to use float. As long as only baseband frequencies are concerned, float may have sufficient accuracy, but double seems more safe. If performance on embedded systems is a concern and the original motive to use float, then calculations in CPlotter::getScreenIntegerFFTData(...) could be changed back from double to float, since they are performed plotWidth many times per spectrum update. Other occurances of double should only be rare events. On most systems, the performance advantage of float versus double is questionable.

Best regards, Joachim