### PR TITLE
Set UHD package path in AppImage

### DIFF
--- a/appimage.sh
+++ b/appimage.sh
@@ -69,6 +69,9 @@ chmod a+x *.AppImage
 mkdir -p ./AppDir/usr/lib
 cp -R /usr/lib/x86_64-linux-gnu/SoapySDR/modules* ./AppDir/usr/soapy-modules
 
+mkdir -p ./AppDir/apprun-hooks
+echo 'export UHD_PKG_PATH="$APPDIR/usr"' >./AppDir/apprun-hooks/uhd-hook.sh
+
 ./linuxdeploy-x86_64.AppImage -e "$APP" -d "$DESKTOP" -i "$ICON" -p qt --output appimage --appdir=./AppDir
 RESULT=$?
 

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
     2.15.2: In progress...
 
      FIXED: Device selection fails for some SoapySDR devices.
+     FIXED: Segfault when starting AppImage on some systems.
 
 
     2.15.1: Released December 18, 2021


### PR DESCRIPTION
Fixes #1032.

By pointing the `UHD_PKG_PATH` environment variable to the AppImage's mount point, UHD modules will be loaded from there instead of from the system (where they may be linked to an incompatible version of libuhd).