### PR TITLE
Prevent SoapySDR from loading incompatible modules

### DIFF
--- a/src/applications/gqrx/main.cpp
+++ b/src/applications/gqrx/main.cpp
@@ -62,7 +62,10 @@ int main(int argc, char *argv[])
     QString plugin_path = QDir::cleanPath(QCoreApplication::applicationDirPath() + "/../soapy-modules");
     QFileInfo plugin_path_info(plugin_path);
     if (plugin_path_info.isDir())
+    {
         qputenv("SOAPY_SDR_PLUGIN_PATH", plugin_path.toUtf8());
+        qputenv("SOAPY_SDR_ROOT", "/invalid");
+    }
 
     // setup controlport via environment variables
     // see http://lists.gnu.org/archive/html/discuss-gnuradio/2013-05/msg00270.html


### PR DESCRIPTION
Fixes #1014.

Setting the `SOAPY_SDR_ROOT` to an invalid path prevents the system's SoapySDR modules from being loaded. I've verified that this change allows Gqrx to run on Debian 10 even when the soapysdr0.6-module-uhd package is installed.

A pre-release build is available here: https://github.com/gqrx-sdr/gqrx/suites/4789753922/artifacts/133971350

/cc @anomalyLuna @akoun @vladisslav2011




