### PR TITLE
Remove unused set_audio_rate methods

### DIFF
--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -112,12 +112,6 @@ void nbrx::set_quad_rate(float quad_rate)
     }
 }
 
-void nbrx::set_audio_rate(float audio_rate)
-{
-    (void) audio_rate;
-    std::cout << "**** FIXME: nbrx::set_audio_rate() not implemented" << std::endl;
-}
-
 void nbrx::set_filter(double low, double high, double tw)
 {
     filter->set_param(low, high, tw);

--- a/src/receivers/nbrx.h
+++ b/src/receivers/nbrx.h
@@ -74,7 +74,6 @@ public:
     bool stop();
 
     void set_quad_rate(float quad_rate);
-    void set_audio_rate(float audio_rate);
 
     void set_filter(double low, double high, double tw);
     void set_cw_offset(double offset);

--- a/src/receivers/receiver_base.h
+++ b/src/receivers/receiver_base.h
@@ -56,7 +56,6 @@ public:
     virtual bool stop() = 0;
 
     virtual void set_quad_rate(float quad_rate) = 0;
-    virtual void set_audio_rate(float audio_rate) = 0;
 
     virtual void set_filter(double low, double high, double tw) = 0;
     virtual void set_cw_offset(double offset) = 0;

--- a/src/receivers/wfmrx.cpp
+++ b/src/receivers/wfmrx.cpp
@@ -98,11 +98,6 @@ void wfmrx::set_quad_rate(float quad_rate)
     }
 }
 
-void wfmrx::set_audio_rate(float audio_rate)
-{
-    (void) audio_rate;
-}
-
 void wfmrx::set_filter(double low, double high, double tw)
 {
     filter->set_param(low, high, tw);

--- a/src/receivers/wfmrx.h
+++ b/src/receivers/wfmrx.h
@@ -70,7 +70,6 @@ public:
     bool stop();
 
     void set_quad_rate(float quad_rate);
-    void set_audio_rate(float audio_rate);
 
     void set_filter(double low, double high, double tw);
     void set_cw_offset(double offset) { (void)offset; }


### PR DESCRIPTION
While reviewing #1034, I noticed that `receiver_base_cf` and its subclasses have a `set_audio_rate` method which has never been implemented or used. We may as well remove them.