### PR TITLE
Restore demodulator settings after recreating it

### DIFF
--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -24,6 +24,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <typeinfo>
 #include <QDebug>
 
 #include <gnuradio/prefs.h>
@@ -1325,7 +1326,9 @@ void receiver::connect_all(rx_chain type)
     // Visualization
     tb->connect(b, 0, iq_fft, 0);
 
+    bool rds_decoder_active = rx && rx->is_rds_decoder_active();
     // RX demod chain
+    receiver_base_cf_sptr old_rx = rx;
     rx.reset();
     switch (type)
     {
@@ -1354,6 +1357,10 @@ void receiver::connect_all(rx_chain type)
         tb->connect(rx, 1, audio_gain1, 0);
         tb->connect(audio_gain0, 0, audio_snk, 0);
         tb->connect(audio_gain1, 0, audio_snk, 1);
+        if(old_rx)
+            rx->restore_settings(old_rx);
+        if(rds_decoder_active)
+            rx->start_rds_decoder();
     }
 
     // Recorders and sniffers

--- a/src/dsp/rx_demod_am.cpp
+++ b/src/dsp/rx_demod_am.cpp
@@ -86,20 +86,16 @@ void rx_demod_am::set_dcr(bool dcr)
     if (d_dcr_enabled)
     {
         // Switching from ON to OFF
-        lock();
         disconnect(d_demod, 0, d_dcr, 0);
         disconnect(d_dcr, 0, self(), 0);
         connect(d_demod, 0, self(), 0);
-        unlock();
     }
     else
     {
         // Switching from OFF to ON
-        lock();
         disconnect(d_demod, 0, self(), 0);
         connect(d_demod, 0, d_dcr, 0);
         connect(d_dcr, 0, self(), 0);
-        unlock();
     }
 
     d_dcr_enabled = dcr;
@@ -164,20 +160,16 @@ void rx_demod_amsync::set_dcr(bool dcr)
     if (d_dcr_enabled)
     {
         // Switching from ON to OFF
-        lock();
         disconnect(d_demod2, 0, d_dcr, 0);
         disconnect(d_dcr, 0, self(), 0);
         connect(d_demod2, 0, self(), 0);
-        unlock();
     }
     else
     {
         // Switching from OFF to ON
-        lock();
         disconnect(d_demod2, 0, self(), 0);
         connect(d_demod2, 0, d_dcr, 0);
         connect(d_dcr, 0, self(), 0);
-        unlock();
     }
 
     d_dcr_enabled = dcr;

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -120,11 +120,13 @@ void nbrx::set_audio_rate(float audio_rate)
 
 void nbrx::set_filter(double low, double high, double tw)
 {
+    receiver_base_cf::set_filter(low, high, tw);
     filter->set_param(low, high, tw);
 }
 
 void nbrx::set_cw_offset(double offset)
 {
+    receiver_base_cf::set_cw_offset(offset);
     filter->set_cw_offset(offset);
 }
 
@@ -135,6 +137,7 @@ float nbrx::get_signal_level()
 
 void nbrx::set_nb_on(int nbid, bool on)
 {
+    receiver_base_cf::set_nb_on(nbid, on);
     if (nbid == 1)
         nb->set_nb1_on(on);
     else if (nbid == 2)
@@ -143,6 +146,7 @@ void nbrx::set_nb_on(int nbid, bool on)
 
 void nbrx::set_nb_threshold(int nbid, float threshold)
 {
+    receiver_base_cf::set_nb_threshold(nbid, threshold);
     if (nbid == 1)
         nb->set_threshold1(threshold);
     else if (nbid == 2)
@@ -151,41 +155,49 @@ void nbrx::set_nb_threshold(int nbid, float threshold)
 
 void nbrx::set_sql_level(double level_db)
 {
+    receiver_base_cf::set_sql_level(level_db);
     sql->set_threshold(level_db);
 }
 
 void nbrx::set_sql_alpha(double alpha)
 {
+    receiver_base_cf::set_sql_alpha(alpha);
     sql->set_alpha(alpha);
 }
 
 void nbrx::set_agc_on(bool agc_on)
 {
+    receiver_base_cf::set_agc_on(agc_on);
     agc->set_agc_on(agc_on);
 }
 
 void nbrx::set_agc_hang(bool use_hang)
 {
+    receiver_base_cf::set_agc_hang(use_hang);
     agc->set_use_hang(use_hang);
 }
 
 void nbrx::set_agc_threshold(int threshold)
 {
+    receiver_base_cf::set_agc_threshold(threshold);
     agc->set_threshold(threshold);
 }
 
 void nbrx::set_agc_slope(int slope)
 {
+    receiver_base_cf::set_agc_slope(slope);
     agc->set_slope(slope);
 }
 
 void nbrx::set_agc_decay(int decay_ms)
 {
+    receiver_base_cf::set_agc_decay(decay_ms);
     agc->set_decay(decay_ms);
 }
 
 void nbrx::set_agc_manual_gain(int gain)
 {
+    receiver_base_cf::set_agc_manual_gain(gain);
     agc->set_manual_gain(gain);
 }
 
@@ -300,25 +312,34 @@ void nbrx::set_demod(int rx_demod)
 
 void nbrx::set_fm_maxdev(float maxdev_hz)
 {
+    receiver_base_cf::set_fm_maxdev(maxdev_hz);
     demod_fm->set_max_dev(maxdev_hz);
 }
 
 void nbrx::set_fm_deemph(double tau)
 {
+    receiver_base_cf::set_fm_deemph(tau);
     demod_fm->set_tau(tau);
 }
 
 void nbrx::set_am_dcr(bool enabled)
 {
+    receiver_base_cf::set_am_dcr(enabled);
+    lock();
     demod_am->set_dcr(enabled);
+    unlock();
 }
 
 void nbrx::set_amsync_dcr(bool enabled)
 {
+    receiver_base_cf::set_amsync_dcr(enabled);
+    lock();
     demod_amsync->set_dcr(enabled);
+    unlock();
 }
 
 void nbrx::set_amsync_pll_bw(float pll_bw)
 {
+    receiver_base_cf::set_amsync_pll_bw(pll_bw);
     demod_amsync->set_pll_bw(pll_bw);
 }

--- a/src/receivers/receiver_base.h
+++ b/src/receivers/receiver_base.h
@@ -25,7 +25,7 @@
 
 #include <gnuradio/hier_block2.h>
 
-
+#define RECEIVER_NB_COUNT 2
 class receiver_base_cf;
 
 #if GNURADIO_VERSION < 0x030900
@@ -58,8 +58,8 @@ public:
     virtual void set_quad_rate(float quad_rate) = 0;
     virtual void set_audio_rate(float audio_rate) = 0;
 
-    virtual void set_filter(double low, double high, double tw) = 0;
-    virtual void set_cw_offset(double offset) = 0;
+    virtual void set_filter(double low, double high, double tw);
+    virtual void set_cw_offset(double offset);
 
     virtual float get_signal_level() = 0;
 
@@ -106,6 +106,27 @@ public:
     virtual void reset_rds_parser();
     virtual bool is_rds_decoder_active();
 
+    virtual void restore_settings(receiver_base_cf_sptr from);
+protected:
+    double d_filter_low;
+    double d_filter_high;
+    double d_filter_tw;
+    double d_cw_offset;
+    double d_level_db;
+    double d_alpha;
+    bool d_agc_on;
+    bool d_agc_use_hang;
+    int d_agc_threshold;
+    int d_agc_slope;
+    int d_agc_decay_ms;
+    int d_agc_gain;
+    float d_fm_maxdev;
+    double d_fm_deemph;
+    bool d_am_dcr;
+    bool d_amsync_dcr;
+    float d_amsync_pll_bw;
+    bool d_nb_on[RECEIVER_NB_COUNT];
+    float d_nb_threshold[RECEIVER_NB_COUNT];
 };
 
 #endif // RECEIVER_BASE_H

--- a/src/receivers/wfmrx.cpp
+++ b/src/receivers/wfmrx.cpp
@@ -105,6 +105,7 @@ void wfmrx::set_audio_rate(float audio_rate)
 
 void wfmrx::set_filter(double low, double high, double tw)
 {
+    receiver_base_cf::set_filter(low, high, tw);
     filter->set_param(low, high, tw);
 }
 
@@ -113,65 +114,17 @@ float wfmrx::get_signal_level()
     return meter->get_level_db();
 }
 
-/*
-void nbrx::set_nb_on(int nbid, bool on)
-{
-    if (nbid == 1)
-        nb->set_nb1_on(on);
-    else if (nbid == 2)
-        nb->set_nb2_on(on);
-}
-
-void nbrx::set_nb_threshold(int nbid, float threshold)
-{
-    if (nbid == 1)
-        nb->set_threshold1(threshold);
-    else if (nbid == 2)
-        nb->set_threshold2(threshold);
-}
-*/
-
 void wfmrx::set_sql_level(double level_db)
 {
+    receiver_base_cf::set_sql_level(level_db);
     sql->set_threshold(level_db);
 }
 
 void wfmrx::set_sql_alpha(double alpha)
 {
+    receiver_base_cf::set_sql_alpha(alpha);
     sql->set_alpha(alpha);
 }
-
-/*
-void nbrx::set_agc_on(bool agc_on)
-{
-    agc->set_agc_on(agc_on);
-}
-
-void nbrx::set_agc_hang(bool use_hang)
-{
-    agc->set_use_hang(use_hang);
-}
-
-void nbrx::set_agc_threshold(int threshold)
-{
-    agc->set_threshold(threshold);
-}
-
-void nbrx::set_agc_slope(int slope)
-{
-    agc->set_slope(slope);
-}
-
-void nbrx::set_agc_decay(int decay_ms)
-{
-    agc->set_decay(decay_ms);
-}
-
-void nbrx::set_agc_manual_gain(int gain)
-{
-    agc->set_manual_gain(gain);
-}
-*/
 
 void wfmrx::set_demod(int demod)
 {
@@ -235,16 +188,6 @@ void wfmrx::set_demod(int demod)
 
     /* continue processing */
     unlock();
-}
-
-void wfmrx::set_fm_maxdev(float maxdev_hz)
-{
-    demod_fm->set_max_dev(maxdev_hz);
-}
-
-void wfmrx::set_fm_deemph(double tau)
-{
-    demod_fm->set_tau(tau);
 }
 
 void wfmrx::get_rds_data(std::string &outbuff, int &num)

--- a/src/receivers/wfmrx.h
+++ b/src/receivers/wfmrx.h
@@ -79,8 +79,6 @@ public:
 
     /* Noise blanker */
     bool has_nb() { return false; }
-    //void set_nb_on(int nbid, bool on);
-    //void set_nb_threshold(int nbid, float threshold);
 
     /* Squelch parameter */
     bool has_sql() { return true; }
@@ -89,19 +87,11 @@ public:
 
     /* AGC */
     bool has_agc() { return false; }
-    /*void set_agc_on(bool agc_on);
-    void set_agc_hang(bool use_hang);
-    void set_agc_threshold(int threshold);
-    void set_agc_slope(int slope);
-    void set_agc_decay(int decay_ms);
-    void set_agc_manual_gain(int gain);*/
 
     void set_demod(int demod);
 
     /* FM parameters */
     bool has_fm() {return true; }
-    void set_fm_maxdev(float maxdev_hz);
-    void set_fm_deemph(double tau);
 
     void get_rds_data(std::string &outbuff, int &num);
     void start_rds_decoder();


### PR DESCRIPTION
Fix regression, introduced in e5e16ccff5e7b50f2f9c50b222819e198a867e5d.
Store filter limits and shape to private class members.
Restore filter bandwidth/offset, squelch level, cw offset after the
demodulator is recreated in connect_all to match actual settings.
Track state of RDS decoder and restore it too to prevent a freeze.