### PR TITLE
Reconnection fixes

### DIFF
--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -252,6 +252,7 @@ private:
     bool        d_iq_rev;           /*!< Whether I/Q is reversed or not. */
     bool        d_dc_cancel;        /*!< Enable automatic DC removal. */
     bool        d_iq_balance;       /*!< Enable automatic IQ balance. */
+    bool        d_udp_streaming;    /*!< UDP streamin active. */
 
     std::string input_devstr;  /*!< Current input device string. */
     std::string output_devstr; /*!< Current output device string. */

--- a/src/dsp/sniffer_f.cpp
+++ b/src/dsp/sniffer_f.cpp
@@ -40,7 +40,7 @@ sniffer_f_sptr make_sniffer_f(int buffsize)
  *  - How often the data will be popped.
  */
 sniffer_f::sniffer_f(int buffsize)
-    : gr::sync_block ("rx_fft_c",
+    : gr::sync_block ("sniffer_f",
           gr::io_signature::make(1, 1, sizeof(float)),
           gr::io_signature::make(0, 0, 0)),
       d_minsamp(1000)


### PR DESCRIPTION
Disconnect iq_swap and udp_sink when not in use to reduce cpu load.
Connect audio consumers to audio_gain# to prevent clipping in recorded files/prevent sending clipped samples to AFSK1200 decoder and external programs and to make rx_fft reflect gain changes.