### PR TITLE
Get rid of boost::circular_buffer to improve performance

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
      FIXED: RDS receiver skips some messages.
      FIXED: Buffer overruns in AFSK1200 decoder.
+  IMPROVED: FFT performance.
 
 
     2.15.2: Released January 8, 2022

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -56,7 +56,8 @@ rx_fft_c::rx_fft_c(unsigned int fftsize, double quad_rate, int wintype)
 #endif
 
     /* allocate circular buffer */
-    d_cbuf.set_capacity(d_fftsize + d_quadrate);
+    d_writer = gr::make_buffer(d_fftsize + d_quadrate, sizeof(gr_complex));
+    d_reader = gr::buffer_add_reader(d_writer, 0);
 
     /* create FFT window */
     set_window_type(wintype);
@@ -82,17 +83,14 @@ int rx_fft_c::work(int noutput_items,
                    gr_vector_const_void_star &input_items,
                    gr_vector_void_star &output_items)
 {
-    int i;
-    const gr_complex *in = (const gr_complex*)input_items[0];
     (void) output_items;
 
     /* just throw new samples into the buffer */
     std::lock_guard<std::mutex> lock(d_mutex);
-    for (i = 0; i < noutput_items; i++)
-    {
-        d_cbuf.push_back(in[i]);
-    }
-
+    if (d_writer->space_available() < noutput_items)
+        d_reader->update_read_pointer(noutput_items - d_writer->space_available());
+    memcpy(d_writer->write_pointer(), input_items[0], sizeof(gr_complex) * noutput_items);
+    d_writer->update_write_pointer(noutput_items);
     return noutput_items;
 
 }
@@ -105,7 +103,7 @@ void rx_fft_c::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
 {
     std::lock_guard<std::mutex> lock(d_mutex);
 
-    if (d_cbuf.size() < d_fftsize)
+    if (d_reader->items_available() < d_fftsize)
     {
         // not enough samples in the buffer
         fftSize = 0;
@@ -118,12 +116,11 @@ void rx_fft_c::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
     d_lasttime = now;
 
     /* perform FFT */
-    d_cbuf.erase_begin(std::min((unsigned int)(diff.count() * d_quadrate * 1.001), (unsigned int)d_cbuf.size() - d_fftsize));
+    d_reader->update_read_pointer(std::min((int)(diff.count() * d_quadrate * 1.001), d_reader->items_available() - d_fftsize));
     do_fft(d_fftsize);
-    //d_cbuf.clear();
 
     /* get FFT data */
-    memcpy(fftPoints, d_fft->get_outbuf(), sizeof(gr_complex)*d_fftsize);
+    memcpy(fftPoints, d_fft->get_outbuf(), sizeof(gr_complex) * d_fftsize);
     fftSize = d_fftsize;
 }
 
@@ -137,15 +134,16 @@ void rx_fft_c::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
 void rx_fft_c::do_fft(unsigned int size)
 {
     /* apply window, if any */
+    gr_complex * p = (gr_complex *)d_reader->read_pointer();
     if (d_window.size())
     {
         gr_complex *dst = d_fft->get_inbuf();
         for (unsigned int i = 0; i < size; i++)
-            dst[i] = d_cbuf[i] * d_window[i];
+            dst[i] = p[i] * d_window[i];
     }
     else
     {
-        memcpy(d_fft->get_inbuf(), d_cbuf.linearize(), sizeof(gr_complex)*size);
+        memcpy(d_fft->get_inbuf(), p, sizeof(gr_complex) * size);
     }
 
     /* compute FFT */
@@ -156,10 +154,9 @@ void rx_fft_c::do_fft(unsigned int size)
 void rx_fft_c::set_params()
 {
     std::lock_guard<std::mutex> lock(d_mutex);
-
     /* clear and resize circular buffer */
-    d_cbuf.clear();
-    d_cbuf.set_capacity(d_fftsize + d_quadrate);
+    d_writer = gr::make_buffer(d_fftsize + d_quadrate, sizeof(gr_complex));
+    d_reader = gr::buffer_add_reader(d_writer, 0);
 
     /* reset window */
     int wintype = d_wintype; // FIXME: would be nicer with a window_reset()
@@ -176,7 +173,7 @@ void rx_fft_c::set_params()
 }
 
 /*! \brief Set new FFT size. */
-void rx_fft_c::set_fft_size(unsigned int fftsize)
+void rx_fft_c::set_fft_size(int fftsize)
 {
     if (fftsize != d_fftsize)
     {
@@ -257,7 +254,8 @@ rx_fft_f::rx_fft_f(unsigned int fftsize, double audio_rate, int wintype)
 #endif
 
     /* allocate circular buffer */
-    d_cbuf.set_capacity(d_fftsize + d_audiorate);
+    d_writer = gr::make_buffer(d_fftsize + d_audiorate, sizeof(float));
+    d_reader = gr::buffer_add_reader(d_writer, 0);
 
     /* create FFT window */
     set_window_type(wintype);
@@ -283,17 +281,14 @@ int rx_fft_f::work(int noutput_items,
                    gr_vector_const_void_star &input_items,
                    gr_vector_void_star &output_items)
 {
-    int i;
-    const float *in = (const float*)input_items[0];
     (void) output_items;
 
     /* just throw new samples into the buffer */
     std::lock_guard<std::mutex> lock(d_mutex);
-    for (i = 0; i < noutput_items; i++)
-    {
-        d_cbuf.push_back(in[i]);
-    }
-
+    if(d_writer->space_available() < noutput_items)
+        d_reader->update_read_pointer(noutput_items - d_writer->space_available());
+    memcpy(d_writer->write_pointer(), input_items[0], sizeof(gr_complex) * noutput_items);
+    d_writer->update_write_pointer(noutput_items);
     return noutput_items;
 }
 
@@ -305,7 +300,7 @@ void rx_fft_f::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
 {
     std::lock_guard<std::mutex> lock(d_mutex);
 
-    if (d_cbuf.size() < d_fftsize)
+    if (d_reader->items_available() < d_fftsize)
     {
         // not enough samples in the buffer
         fftSize = 0;
@@ -318,12 +313,11 @@ void rx_fft_f::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
     d_lasttime = now;
 
     /* perform FFT */
-    d_cbuf.erase_begin(std::min((unsigned int)(diff.count() * d_audiorate * 1.001), (unsigned int)d_cbuf.size() - d_fftsize));
+    d_reader->update_read_pointer(std::min((unsigned int)(diff.count() * d_audiorate * 1.001), (unsigned int)d_reader->items_available() - d_fftsize));
     do_fft(d_fftsize);
-    //d_cbuf.clear();
 
     /* get FFT data */
-    memcpy(fftPoints, d_fft->get_outbuf(), sizeof(gr_complex)*d_fftsize);
+    memcpy(fftPoints, d_fft->get_outbuf(), sizeof(gr_complex) * d_fftsize);
     fftSize = d_fftsize;
 }
 
@@ -337,18 +331,17 @@ void rx_fft_f::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
 void rx_fft_f::do_fft(unsigned int size)
 {
     gr_complex *dst = d_fft->get_inbuf();
-    unsigned int i;
-
+    float * p = (float *)d_reader->read_pointer();
     /* apply window, and convert to complex */
     if (d_window.size())
     {
-        for (i = 0; i < size; i++)
-            dst[i] = d_cbuf[i] * d_window[i];
+        for (unsigned int i = 0; i < size; i++)
+            dst[i] = p[i] * d_window[i];
     }
     else
     {
-        for (i = 0; i < size; i++)
-            dst[i] = d_cbuf[i];
+        for (unsigned int i = 0; i < size; i++)
+            dst[i] = p[i];
     }
 
     /* compute FFT */
@@ -357,7 +350,7 @@ void rx_fft_f::do_fft(unsigned int size)
 
 
 /*! \brief Set new FFT size. */
-void rx_fft_f::set_fft_size(unsigned int fftsize)
+void rx_fft_f::set_fft_size(int fftsize)
 {
     if (fftsize != d_fftsize)
     {
@@ -366,8 +359,8 @@ void rx_fft_f::set_fft_size(unsigned int fftsize)
         d_fftsize = fftsize;
 
         /* clear and resize circular buffer */
-        d_cbuf.clear();
-        d_cbuf.set_capacity(d_fftsize);
+        d_writer = gr::make_buffer(d_fftsize + d_audiorate,sizeof(float));
+        d_reader = gr::buffer_add_reader(d_writer, 0);
 
         /* reset window */
         int wintype = d_wintype; // FIXME: would be nicer with a window_reset()

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -29,6 +29,9 @@
 #include <gnuradio/filter/firdes.h>       /* contains enum win_type */
 #include <gnuradio/gr_complex.h>
 #include <gnuradio/buffer.h>
+#if GNURADIO_VERSION >= 0x031000
+#include <gnuradio/buffer_reader.h>
+#endif
 #include <chrono>
 
 
@@ -88,12 +91,12 @@ public:
     void set_window_type(int wintype);
     int  get_window_type() const;
 
-    void set_fft_size(int fftsize);
+    void set_fft_size(unsigned int fftsize);
     void set_quad_rate(double quad_rate);
     unsigned int get_fft_size() const;
 
 private:
-    int d_fftsize;   /*! Current FFT size. */
+    unsigned int d_fftsize;   /*! Current FFT size. */
     double       d_quadrate;
     int          d_wintype;   /*! Current window type. */
 
@@ -159,11 +162,11 @@ public:
     void set_window_type(int wintype);
     int  get_window_type() const;
 
-    void set_fft_size(int fftsize);
+    void set_fft_size(unsigned int fftsize);
     unsigned int get_fft_size() const;
 
 private:
-    int d_fftsize;   /*! Current FFT size. */
+    unsigned int d_fftsize;   /*! Current FFT size. */
     double       d_audiorate;
     int          d_wintype;   /*! Current window type. */
 

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -28,7 +28,7 @@
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/filter/firdes.h>       /* contains enum win_type */
 #include <gnuradio/gr_complex.h>
-#include <boost/circular_buffer.hpp>
+#include <gnuradio/buffer.h>
 #include <chrono>
 
 
@@ -88,12 +88,12 @@ public:
     void set_window_type(int wintype);
     int  get_window_type() const;
 
-    void set_fft_size(unsigned int fftsize);
+    void set_fft_size(int fftsize);
     void set_quad_rate(double quad_rate);
     unsigned int get_fft_size() const;
 
 private:
-    unsigned int d_fftsize;   /*! Current FFT size. */
+    int d_fftsize;   /*! Current FFT size. */
     double       d_quadrate;
     int          d_wintype;   /*! Current window type. */
 
@@ -106,7 +106,8 @@ private:
 #endif
     std::vector<float>  d_window; /*! FFT window taps. */
 
-    boost::circular_buffer<gr_complex> d_cbuf; /*! buffer to accumulate samples. */
+    gr::buffer_sptr d_writer;
+    gr::buffer_reader_sptr d_reader;
     std::chrono::time_point<std::chrono::steady_clock> d_lasttime;
 
     void do_fft(unsigned int size);
@@ -158,11 +159,11 @@ public:
     void set_window_type(int wintype);
     int  get_window_type() const;
 
-    void set_fft_size(unsigned int fftsize);
+    void set_fft_size(int fftsize);
     unsigned int get_fft_size() const;
 
 private:
-    unsigned int d_fftsize;   /*! Current FFT size. */
+    int d_fftsize;   /*! Current FFT size. */
     double       d_audiorate;
     int          d_wintype;   /*! Current window type. */
 
@@ -175,7 +176,8 @@ private:
 #endif
     std::vector<float>  d_window; /*! FFT window taps. */
 
-    boost::circular_buffer<float> d_cbuf; /*! buffer to accumulate samples. */
+    gr::buffer_sptr d_writer;
+    gr::buffer_reader_sptr d_reader;
     std::chrono::time_point<std::chrono::steady_clock> d_lasttime;
 
     void do_fft(unsigned int size);

--- a/src/dsp/rx_meter.h
+++ b/src/dsp/rx_meter.h
@@ -25,6 +25,9 @@
 
 #include <gnuradio/sync_block.h>
 #include <gnuradio/buffer.h>
+#if GNURADIO_VERSION >= 0x031000
+#include <gnuradio/buffer_reader.h>
+#endif
 #include <chrono>
 #include <mutex>
 
@@ -73,7 +76,7 @@ public:
 
 private:
     double d_quadrate;
-    int d_avgsize; /*! Number of samples to average. */
+    unsigned int d_avgsize; /*! Number of samples to average. */
 
     gr::buffer_sptr d_writer; /*! buffer to accumulate samples. */
     gr::buffer_reader_sptr d_reader;

--- a/src/dsp/rx_meter.h
+++ b/src/dsp/rx_meter.h
@@ -24,7 +24,7 @@
 #define RX_METER_H
 
 #include <gnuradio/sync_block.h>
-#include <boost/circular_buffer.hpp>
+#include <gnuradio/buffer.h>
 #include <chrono>
 #include <mutex>
 
@@ -73,9 +73,10 @@ public:
 
 private:
     double d_quadrate;
-    unsigned int d_avgsize; /*! Number of samples to average. */
+    int d_avgsize; /*! Number of samples to average. */
 
-    boost::circular_buffer<gr_complex> d_cbuf; /*! buffer to accumulate samples. */
+    gr::buffer_sptr d_writer; /*! buffer to accumulate samples. */
+    gr::buffer_reader_sptr d_reader;
     std::chrono::time_point<std::chrono::steady_clock> d_lasttime;
 
     std::mutex   d_mutex;  /*! Used to lock FFT output buffer. */

--- a/src/dsp/rx_rds.cpp
+++ b/src/dsp/rx_rds.cpp
@@ -135,7 +135,6 @@ rx_rds_store::rx_rds_store() : gr::block ("rx_rds_store",
 {
         message_port_register_in(pmt::mp("store"));
         set_msg_handler(pmt::mp("store"), std::bind(&rx_rds_store::store, this, std::placeholders::_1));
-        d_messages.set_capacity(100);
 }
 
 rx_rds_store::~rx_rds_store ()
@@ -146,7 +145,7 @@ rx_rds_store::~rx_rds_store ()
 void rx_rds_store::store(pmt::pmt_t msg)
 {
     std::lock_guard<std::mutex> lock(d_mutex);
-    d_messages.push_back(msg);
+    d_messages.push(msg);
 
 }
 
@@ -158,7 +157,7 @@ void rx_rds_store::get_message(std::string &out, int &type)
         pmt::pmt_t msg=d_messages.front();
         type=pmt::to_long(pmt::tuple_ref(msg,0));
         out=pmt::symbol_to_string(pmt::tuple_ref(msg,1));
-        d_messages.pop_front();
+        d_messages.pop();
     } else {
         type=-1;
     }

--- a/src/dsp/rx_rds.h
+++ b/src/dsp/rx_rds.h
@@ -50,7 +50,7 @@
 #include <gnuradio/digital/diff_decoder_bb.h>
 #include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/blocks/message_debug.h>
-#include <boost/circular_buffer.hpp>
+#include <queue>
 #include "dsp/rds/decoder.h"
 #include "dsp/rds/parser.h"
 
@@ -82,7 +82,7 @@ private:
     void store(pmt::pmt_t msg);
 
     std::mutex d_mutex;
-    boost::circular_buffer<pmt::pmt_t> d_messages;
+    std::queue<pmt::pmt_t> d_messages;
 
 };
 

--- a/src/dsp/sniffer_f.h
+++ b/src/dsp/sniffer_f.h
@@ -26,6 +26,9 @@
 #include <mutex>
 #include <gnuradio/sync_block.h>
 #include <gnuradio/buffer.h>
+#if GNURADIO_VERSION >= 0x031000
+#include <gnuradio/buffer_reader.h>
+#endif
 
 
 class sniffer_f;
@@ -79,7 +82,7 @@ public:
     void set_buffer_size(int newsize);
     int  buffer_size();
 
-    void set_min_samples(int num) {d_minsamp = num;}
+    void set_min_samples(unsigned int num) {d_minsamp = num;}
     int min_samples() {return d_minsamp;}
 
 private:
@@ -87,7 +90,7 @@ private:
     std::mutex d_mutex;                     /*! Used to prevent concurrent access to buffer. */
     gr::buffer_sptr d_writer;
     gr::buffer_reader_sptr d_reader;
-    int d_minsamp;                 /*! smallest number of samples we want to return. */
+    unsigned int d_minsamp;                 /*! smallest number of samples we want to return. */
 
 };
 

--- a/src/dsp/sniffer_f.h
+++ b/src/dsp/sniffer_f.h
@@ -25,7 +25,7 @@
 
 #include <mutex>
 #include <gnuradio/sync_block.h>
-#include <boost/circular_buffer.hpp>
+#include <gnuradio/buffer.h>
 
 
 class sniffer_f;
@@ -79,14 +79,15 @@ public:
     void set_buffer_size(int newsize);
     int  buffer_size();
 
-    void set_min_samples(unsigned int num) {d_minsamp = num;}
+    void set_min_samples(int num) {d_minsamp = num;}
     int min_samples() {return d_minsamp;}
 
 private:
 
     std::mutex d_mutex;                     /*! Used to prevent concurrent access to buffer. */
-    boost::circular_buffer<float> d_buffer; /*! buffer to accumulate samples. */
-    unsigned int d_minsamp;                 /*! smallest number of samples we want to return. */
+    gr::buffer_sptr d_writer;
+    gr::buffer_reader_sptr d_reader;
+    int d_minsamp;                 /*! smallest number of samples we want to return. */
 
 };
 


### PR DESCRIPTION
Replace boost::circular_buffer with stdlib/GNU Radio alternatives
rx_fft_c,rx_fft_f: replace boost::circular_buffer with GNU Radio buffer/reader
rx_meter_c: replace boost::circular_buffer with GNU Radio buffer/reader
rx_rds: replace boost::circular_buffer with std:queue as it fits better here
sniffer_f: replace boost::circular_buffer with GNU Radio buffer/reader