### PR TITLE
Rx_fft rx_meter switch to volk

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,7 +3,7 @@
 
      FIXED: RDS receiver skips some messages.
      FIXED: Buffer overruns in AFSK1200 decoder.
-  IMPROVED: FFT performance.
+  IMPROVED: FFT and S-meter performance.
 
 
     2.15.2: Released January 8, 2022

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -21,6 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 #include <math.h>
+#include <volk/volk.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/gr_complex.h>
@@ -148,8 +149,7 @@ void rx_fft_c::do_fft(unsigned int size)
     if (d_window.size())
     {
         gr_complex *dst = d_fft->get_inbuf();
-        for (unsigned int i = 0; i < size; i++)
-            dst[i] = p[i] * d_window[i];
+        volk_32fc_32f_multiply_32fc(dst, p, &d_window[0], size);
     }
     else
     {

--- a/src/dsp/rx_meter.cpp
+++ b/src/dsp/rx_meter.cpp
@@ -21,6 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 #include <math.h>
+#include <volk/volk.h>
 #include <gnuradio/io_signature.h>
 #include <dsp/rx_meter.h>
 #include <iostream>
@@ -88,10 +89,8 @@ float rx_meter_c::get_level_db()
     d_lasttime = now;
 
     d_reader->update_read_pointer(std::min((unsigned int)(diff.count() * d_quadrate * 1.001), (unsigned int)d_reader->items_available() - d_avgsize));
-    gr_complex *p = (gr_complex *)d_reader->read_pointer();
     float sum = 0;
-    for (unsigned int i = 0; i < d_avgsize; i++)
-        sum += p[i].real()*p[i].real() + p[i].imag()*p[i].imag();
+    volk_32f_x2_dot_prod_32f(&sum, (float *)d_reader->read_pointer(), (float *)d_reader->read_pointer(), d_avgsize * 2);
     float power = sum / (float)(d_avgsize);
     return (float) 10. * log10f(power + 1.0e-20);
 }


### PR DESCRIPTION
Switch to using appropriate libvolk functions instead of trivial
for-loops. This should improve performance and reduce cpu load in some cases.

Requires https://github.com/gqrx-sdr/gqrx/pull/1042