### PR TITLE
Revert "Fix #1018"

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -4,8 +4,6 @@
        NEW: Save & restore center frequency when playing I/Q files.
      FIXED: Device selection fails for some SoapySDR devices.
      FIXED: Segfault when starting AppImage on some systems.
-     FIXED: Waterfall & sound stop working after playing invalid I/Q file.
-     FIXED: Crash when using I/Q playback and audio recording simultaneously.
   IMPROVED: Frequency accuracy of plots at high zoom levels.
 
 


### PR DESCRIPTION
Reverts gqrx-sdr/gqrx#1036

As discussed in #1040, I've decided to revert this change since it caused regressions. We can fix #1030 another way, and hopefully find a better approach to #1018 as well.