### PR TITLE
Work around GNU Radio issue 5436

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -4,6 +4,7 @@
        NEW: Save & restore center frequency when playing I/Q files.
      FIXED: Device selection fails for some SoapySDR devices.
      FIXED: Segfault when starting AppImage on some systems.
+     FIXED: Crash/freeze after stopping audio recorder or AFSK1200 decoder.
   IMPROVED: Frequency accuracy of plots at high zoom levels.
 
 

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -1060,6 +1060,12 @@ receiver::status receiver::stop_audio_recording()
     wav_sink->close();
     tb->disconnect(rx, 0, wav_sink, 0);
     tb->disconnect(rx, 1, wav_sink, 1);
+
+    // Temporary workaround for https://github.com/gnuradio/gnuradio/issues/5436
+    tb->disconnect(ddc, 0, rx, 0);
+    tb->connect(ddc, 0, rx, 0);
+    // End temporary workaronud
+
     tb->unlock();
     wav_sink.reset();
     d_recording_wav = false;
@@ -1284,6 +1290,12 @@ receiver::status receiver::stop_sniffer()
 
     tb->lock();
     tb->disconnect(rx, 0, sniffer_rr, 0);
+
+    // Temporary workaround for https://github.com/gnuradio/gnuradio/issues/5436
+    tb->disconnect(ddc, 0, rx, 0);
+    tb->connect(ddc, 0, rx, 0);
+    // End temporary workaronud
+
     tb->disconnect(sniffer_rr, 0, sniffer, 0);
     tb->unlock();
     d_sniffer_active = false;


### PR DESCRIPTION
Fixes #1030.

This is a workaround for https://github.com/gnuradio/gnuradio/issues/5436. If an external block is disconnected from a hierarchical block, and the hierarchical block is subsequently locked before a new connection is made, then a crash or freeze occurs. We can work around this in Gqrx by adding an extra `connect` call to any place where the bug conditions can be triggered. As far as I can tell, `receiver::stop_audio_recording()` and `receiver::stop_sniffer()` are the only two places where this occurs.

@vladisslav2011 I'd appreciate your help with testing.