### PR TITLE
Rx_fft reduce memory usage

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -5,6 +5,7 @@
      FIXED: Buffer overruns in AFSK1200 decoder.
      FIXED: Crash when opening APSK1200 decoder with demod off.
   IMPROVED: FFT and S-meter performance.
+  IMPROVED: Reduced FFT memory usage.
 
 
     2.15.2: Released January 8, 2022


### PR DESCRIPTION
Reduce memory usage by limiting maximum rx_fft buffer to MAX_FFT_SIZE * 2.
Wasting about 160Mb (HackRF @ 20Msps) or even 480Mb (LimeSDR @60Msps) of memory for nothing does not look like correct thing to.