### PR TITLE
Fix buffer overruns in AFSK1200 decoder

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
     2.15.3: In progress...
 
      FIXED: RDS receiver skips some messages.
+     FIXED: Buffer overruns in AFSK1200 decoder.
 
 
     2.15.2: Released January 8, 2022

--- a/src/qtgui/afsk1200win.cpp
+++ b/src/qtgui/afsk1200win.cpp
@@ -31,7 +31,8 @@
 
 Afsk1200Win::Afsk1200Win(QWidget *parent) :
     QMainWindow(parent),
-    ui(new Ui::Afsk1200Win)
+    ui(new Ui::Afsk1200Win),
+    tmpbuf(CORRLEN, 0.0)
 {
     ui->setupUi(this);
 
@@ -61,21 +62,14 @@ Afsk1200Win::~Afsk1200Win()
 /*! \brief Process new set of samples. */
 void Afsk1200Win::process_samples(float *buffer, int length)
 {
-    int overlap = 18;
-    int i;
-
-    for (i = 0; i < length; i++) {
-        tmpbuf.append(buffer[i]);
+    for (int i = 0; i < length; i++) {
+        tmpbuf.push_back(buffer[i]);
     }
 
     decoder->demod(tmpbuf.data(), length);
 
     /* clear tmpbuf and store "overlap" */
-    tmpbuf.clear();
-    for (i = length-overlap; i < length; i++) {
-        tmpbuf.append(buffer[i]);
-    }
-
+    tmpbuf.erase(tmpbuf.begin(), tmpbuf.begin() + length);
 }
 
 

--- a/src/qtgui/afsk1200win.h
+++ b/src/qtgui/afsk1200win.h
@@ -59,7 +59,7 @@ private:
 
     CAfsk12 *decoder;     /*! The AFSK1200 decoder object. */
 
-    QVarLengthArray<float, 16384> tmpbuf;   /*! Needed to remember "overlap" smples. */
+    std::vector<float> tmpbuf;   /*! Needed to remember "overlap" smples. */
 };
 
 #endif // AFSK1200WIN_H


### PR DESCRIPTION
While testing #1042 with valgrind, I noticed buffer overruns in the AFSK1200 decoder. They are present on the master branch as well.

The problem occurs because `CAfsk12::demod` expects its input buffer to have `length + CORRLEN` samples. `Afsk1200Win::process_samples` fails to ensure that the extra `CORRLEN` samples are present on the first invocation, leading to a buffer overrun in `CAfsk12::demod`. Additionally, `Afsk1200Win::process_samples` underruns `buffer` whenever `length` is less than `CORRLEN`, which can happen if the AFSK1200 window is opened before the DSP is turned on.

I've corrected these problems by initializing `tmpbuf` with `CORRLEN` zeroes, and removing `length` samples from the beginning of `tmpbuf` after each invocation.

I also replaced `QVarLengthArray` with `std::vector`, since the Qt documentation says:
> QVarLengthArray is a low-level optimization class that only makes sense in very specific cases. It is used a few places inside Qt and was added to Qt's public API for the convenience of advanced users.