### PR TITLE
CMeter: increase resolution to 0.1dB

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -6,6 +6,7 @@
      FIXED: Crash when opening APSK1200 decoder with demod off.
   IMPROVED: FFT and S-meter performance.
   IMPROVED: Reduced FFT memory usage.
+  IMPROVED: Increased S-meter resolution to 0.1 dB.
 
 
     2.15.2: Released January 8, 2022

--- a/src/qtgui/meter.cpp
+++ b/src/qtgui/meter.cpp
@@ -196,7 +196,7 @@ void CMeter::draw()
 
     painter.setPen(QColor(0xDA, 0xDA, 0xDA, 0xFF));
     painter.setOpacity(1.0);
-    m_Str.setNum(m_dBFS);
+    m_Str.setNum(m_dBFS, 'f', 1);
     painter.drawText(marg, h - 2, m_Str + " dBFS" );
 
     update();

--- a/src/qtgui/meter.h
+++ b/src/qtgui/meter.h
@@ -73,7 +73,7 @@ private:
     QString m_Str;
     qreal   m_pixperdb;     // pixels / dB
     int     m_Siglevel;
-    int     m_dBFS;
+    float   m_dBFS;
     qreal   m_Sql;
     qreal   m_SqlLevel;
 };


### PR DESCRIPTION
To match the resolution of the squelch setting.