### PR TITLE
Check for demodulator before starting AFSK1200

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The following people and organisations have contributed to gqrx:
 * Pavel Milanes, CO7WT
 * Pavel Stano
 * Phil Vachon
+* Radoslav Gerganov
 * Rob Frohne
 * Ron Economos, W6RZ
 * Russell Dwarshuis, KB8U

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
      FIXED: RDS receiver skips some messages.
      FIXED: Buffer overruns in AFSK1200 decoder.
+     FIXED: Crash when opening APSK1200 decoder with demod off.
   IMPROVED: FFT and S-meter performance.
 
 

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1089,6 +1089,10 @@ void MainWindow::selectDemod(int mode_idx)
             stopAudioRec();
             uiDockAudio->setAudioRecButtonState(false);
         }
+        if (dec_afsk1200 != nullptr)
+        {
+            dec_afsk1200->close();
+        }
         rx->set_demod(receiver::RX_DEMOD_OFF);
         click_res = 1000;
         break;
@@ -2073,7 +2077,16 @@ void MainWindow::on_actionRemoteConfig_triggered()
  */
 void MainWindow::on_actionAFSK1200_triggered()
 {
-
+    if (!d_have_audio)
+    {
+        QMessageBox msg_box;
+        msg_box.setIcon(QMessageBox::Critical);
+        msg_box.setText(tr("AFSK1200 decoder requires a demodulator.\n"
+                           "Currently, demodulation is switched off "
+                           "(Mode->Demod off)."));
+        msg_box.exec();
+        return;
+    }
     if (dec_afsk1200 != nullptr)
     {
         qDebug() << "AFSK1200 decoder already active.";


### PR DESCRIPTION
AFSK1200 decoder doesn't work without demodulator. Make sure there is
selected demodulator before starting AFSK1200. Also make sure we stop
AFSK1200 when demodulation is turned off.

Closes #1057