### PR TITLE
New rx_agc implementation (2/4)

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -225,11 +225,12 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(uiDockRxOpt, SIGNAL(amSyncDcrToggled(bool)), this, SLOT(setAmSyncDcr(bool)));
     connect(uiDockRxOpt, SIGNAL(amSyncPllBwSelected(float)), this, SLOT(setAmSyncPllBw(float)));
     connect(uiDockRxOpt, SIGNAL(agcToggled(bool)), this, SLOT(setAgcOn(bool)));
-    connect(uiDockRxOpt, SIGNAL(agcHangToggled(bool)), this, SLOT(setAgcHang(bool)));
-    connect(uiDockRxOpt, SIGNAL(agcThresholdChanged(int)), this, SLOT(setAgcThreshold(int)));
-    connect(uiDockRxOpt, SIGNAL(agcSlopeChanged(int)), this, SLOT(setAgcSlope(int)));
+    connect(uiDockRxOpt, SIGNAL(agcTargetLevelChanged(int)), this, SLOT(setAgcTargetLevel(int)));
     connect(uiDockRxOpt, SIGNAL(agcGainChanged(int)), this, SLOT(setAgcGain(int)));
+    connect(uiDockRxOpt, SIGNAL(agcMaxGainChanged(int)), this, SLOT(setAgcMaxGain(int)));
+    connect(uiDockRxOpt, SIGNAL(agcAttackChanged(int)), this, SLOT(setAgcAttack(int)));
     connect(uiDockRxOpt, SIGNAL(agcDecayChanged(int)), this, SLOT(setAgcDecay(int)));
+    connect(uiDockRxOpt, SIGNAL(agcHangChanged(int)), this, SLOT(setAgcHang(int)));
     connect(uiDockRxOpt, SIGNAL(noiseBlankerChanged(int,bool,float)), this, SLOT(setNoiseBlanker(int,bool,float)));
     connect(uiDockRxOpt, SIGNAL(sqlLevelChanged(double)), this, SLOT(setSqlLevel(double)));
     connect(uiDockRxOpt, SIGNAL(sqlAutoClicked()), this, SLOT(setSqlLevelAuto()));
@@ -1189,6 +1190,14 @@ void MainWindow::selectDemod(int mode_idx)
     rx->set_cw_offset(cwofs);
     rx->set_sql_level(uiDockRxOpt->currentSquelchLevel());
 
+    rx->set_agc_on(uiDockRxOpt->getAgcOn());
+    rx->set_agc_target_level(uiDockRxOpt->getAgcTargetLevel());
+    rx->set_agc_manual_gain(uiDockRxOpt->getAgcManualGain());
+    rx->set_agc_max_gain(uiDockRxOpt->getAgcMaxGain());
+    rx->set_agc_attack(uiDockRxOpt->getAgcAttack());
+    rx->set_agc_decay(uiDockRxOpt->getAgcDecay());
+    rx->set_agc_hang(uiDockRxOpt->getAgcHang());
+
     remote->setMode(mode_idx);
     remote->setPassband(flo, fhi);
 
@@ -1275,27 +1284,33 @@ void MainWindow::setAgcOn(bool agc_on)
 }
 
 /** AGC hang ON/OFF. */
-void MainWindow::setAgcHang(bool use_hang)
+void MainWindow::setAgcHang(int hang)
 {
-    rx->set_agc_hang(use_hang);
+    rx->set_agc_hang(hang);
 }
 
 /** AGC threshold changed. */
-void MainWindow::setAgcThreshold(int threshold)
+void MainWindow::setAgcTargetLevel(int targetLevel)
 {
-    rx->set_agc_threshold(threshold);
+    rx->set_agc_target_level(targetLevel);
 }
 
 /** AGC slope factor changed. */
-void MainWindow::setAgcSlope(int factor)
+void MainWindow::setAgcAttack(int attack)
 {
-    rx->set_agc_slope(factor);
+    rx->set_agc_attack(attack);
 }
 
 /** AGC manual gain changed. */
 void MainWindow::setAgcGain(int gain)
 {
     rx->set_agc_manual_gain(gain);
+}
+
+/** AGC maximum gain changed. */
+void MainWindow::setAgcMaxGain(int gain)
+{
+    rx->set_agc_max_gain(gain);
 }
 
 /** AGC decay changed. */

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -157,11 +157,12 @@ private slots:
     void setAmSyncDcr(bool enabled);
     void setAmSyncPllBw(float pll_bw);
     void setAgcOn(bool agc_on);
-    void setAgcHang(bool use_hang);
-    void setAgcThreshold(int threshold);
-    void setAgcSlope(int factor);
+    void setAgcHang(int hang);
+    void setAgcTargetLevel(int targetLevel);
+    void setAgcAttack(int attack);
     void setAgcDecay(int msec);
     void setAgcGain(int gain);
+    void setAgcMaxGain(int gain);
     void setNoiseBlanker(int nbid, bool on, float threshold);
     void setSqlLevel(double level_db);
     double setSqlLevelAuto();

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -806,38 +806,20 @@ receiver::status receiver::set_agc_on(bool agc_on)
     return STATUS_OK; // FIXME
 }
 
-/** Enable/disable AGC hang. */
-receiver::status receiver::set_agc_hang(bool use_hang)
+/** Set AGC hang. */
+receiver::status receiver::set_agc_hang(int hang_ms)
 {
     if (rx->has_agc())
-        rx->set_agc_hang(use_hang);
+        rx->set_agc_hang(hang_ms);
 
     return STATUS_OK; // FIXME
 }
 
-/** Set AGC threshold. */
-receiver::status receiver::set_agc_threshold(int threshold)
+/** Set AGC target level. */
+receiver::status receiver::set_agc_target_level(int target_level)
 {
     if (rx->has_agc())
-        rx->set_agc_threshold(threshold);
-
-    return STATUS_OK; // FIXME
-}
-
-/** Set AGC slope. */
-receiver::status receiver::set_agc_slope(int slope)
-{
-    if (rx->has_agc())
-        rx->set_agc_slope(slope);
-
-    return STATUS_OK; // FIXME
-}
-
-/** Set AGC decay time. */
-receiver::status receiver::set_agc_decay(int decay_ms)
-{
-    if (rx->has_agc())
-        rx->set_agc_decay(decay_ms);
+        rx->set_agc_target_level(target_level);
 
     return STATUS_OK; // FIXME
 }
@@ -847,6 +829,33 @@ receiver::status receiver::set_agc_manual_gain(int gain)
 {
     if (rx->has_agc())
         rx->set_agc_manual_gain(gain);
+
+    return STATUS_OK; // FIXME
+}
+
+/** Set maximum gain used when AGC is ON. */
+receiver::status receiver::set_agc_max_gain(int gain)
+{
+    if (rx->has_agc())
+        rx->set_agc_max_gain(gain);
+
+    return STATUS_OK; // FIXME
+}
+
+/** Set AGC attack. */
+receiver::status receiver::set_agc_attack(int attack_ms)
+{
+    if (rx->has_agc())
+        rx->set_agc_attack(attack_ms);
+
+    return STATUS_OK; // FIXME
+}
+
+/** Set AGC decay time. */
+receiver::status receiver::set_agc_decay(int decay_ms)
+{
+    if (rx->has_agc())
+        rx->set_agc_decay(decay_ms);
 
     return STATUS_OK; // FIXME
 }

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -180,11 +180,12 @@ public:
 
     /* AGC */
     status      set_agc_on(bool agc_on);
-    status      set_agc_hang(bool use_hang);
-    status      set_agc_threshold(int threshold);
-    status      set_agc_slope(int slope);
-    status      set_agc_decay(int decay_ms);
+    status      set_agc_target_level(int target_level);
     status      set_agc_manual_gain(int gain);
+    status      set_agc_max_gain(int gain);
+    status      set_agc_attack(int attack_ms);
+    status      set_agc_decay(int decay_ms);
+    status      set_agc_hang(int hang_ms);
 
     status      set_demod(rx_demod demod, bool force=false);
 

--- a/src/dsp/agc_impl.h
+++ b/src/dsp/agc_impl.h
@@ -26,7 +26,8 @@ public:
     void SetParameters(double sample_rate, bool agc_on, int target_level,
                        int manual_gain, int max_gain, int attack, int decay,
                        int hang, bool force = false);
-    void ProcessData(TYPECPX * pOutData, const TYPECPX * pInData, int Length);
+    void ProcessData(float * pOutData0,float * pOutData1, const float * pInData0, const float * pInData1, int Length);
+    float CurrentGainDb();
 
 private:
     float get_peak();

--- a/src/dsp/agc_impl.h
+++ b/src/dsp/agc_impl.h
@@ -7,73 +7,58 @@
 //  2010-09-15  Initial creation MSW
 //  2011-03-27  Initial release
 //  2011-09-24  Adapted for gqrx
+//  2022-01-10  Rewritten with low complexity alogo
 //////////////////////////////////////////////////////////////////////
 #ifndef AGC_IMPL_H
 #define AGC_IMPL_H
 
 #include <complex>
-#include <deque>
-
-#define MAX_DELAY_BUF 2048
-
-/*
-typedef struct _dCplx
-{
-    double re;
-    double im;
-} tDComplex;
-
-#define TYPECPX tDComplex
-*/
+#include <vector>
 
 #define TYPECPX std::complex<float>
-
+#define TYPEFLOAT float
 
 class CAgc
 {
 public:
     CAgc();
     virtual ~CAgc();
-    void SetParameters(bool AgcOn, bool UseHang, int Threshold, int ManualGain, int Slope, int Decay, double SampleRate);
-    void ProcessData(int Length, const TYPECPX * pInData, TYPECPX * pOutData);
+    void SetParameters(double sample_rate, bool agc_on, int target_level,
+                       int manual_gain, int max_gain, int attack, int decay,
+                       int hang, bool force = false);
+    void ProcessData(TYPECPX * pOutData, const TYPECPX * pInData, int Length);
 
 private:
-    bool        m_AgcOn;
-    bool        m_UseHang;
-    int         m_Threshold;
-    int         m_ManualGain;
-    int         m_Decay;
+    float get_peak();
+    void update_buffer(int p);
 
-    float       m_SampleRate;
+    float d_sample_rate;
+    bool d_agc_on;
+    int d_target_level;
+    int d_manual_gain;
+    int d_max_gain;
+    int d_attack;
+    int d_decay;
+    int d_hang;
 
-    float       m_SlopeFactor;
-    float       m_ManualAgcGain;
+    TYPEFLOAT d_target_mag;
+    int d_hang_samp;
+    int d_buf_samples;
+    int d_buf_size;
+    int d_max_idx;
+    int d_buf_p;
+    int d_hang_counter;
+    TYPEFLOAT d_max_gain_mag;
+    TYPEFLOAT d_current_gain;
+    TYPEFLOAT d_target_gain;
+    TYPEFLOAT d_decay_step;
+    TYPEFLOAT d_attack_step;
+    TYPEFLOAT d_floor;
 
-    float       m_DecayAve;
-    float       m_AttackAve;
+    std::vector<TYPECPX> d_sample_buf;
+    std::vector<float>   d_mag_buf;
 
-    float       m_AttackRiseAlpha;
-    float       m_AttackFallAlpha;
-    float       m_DecayRiseAlpha;
-    float       m_DecayFallAlpha;
-
-    float       m_FixedGain;
-    float       m_Knee;
-    float       m_GainSlope;
-    float       m_Peak;
-
-    int         m_SigDelayPtr;
-    int         m_MagBufPos;
-    int         m_DelaySamples;
-    int         m_WindowSamples;
-    int         m_HangTime;
-    int         m_HangTimer;
-
-    TYPECPX     m_SigDelayBuf[MAX_DELAY_BUF];
-    float*      m_SigDelayBuf_r;
-
-    float       m_MagBuf[MAX_DELAY_BUF];
-    std::deque<int> m_MagDeque;
+    TYPEFLOAT d_prev_dbg;
 };
 
 #endif //  AGC_IMPL_H

--- a/src/dsp/rx_agc_xx.h
+++ b/src/dsp/rx_agc_xx.h
@@ -28,12 +28,12 @@
 #include <gnuradio/gr_complex.h>
 #include <dsp/agc_impl.h>
 
-class rx_agc_cc;
+class rx_agc_2f;
 
 #if GNURADIO_VERSION < 0x030900
-typedef boost::shared_ptr<rx_agc_cc> rx_agc_cc_sptr;
+typedef boost::shared_ptr<rx_agc_2f> rx_agc_2f_sptr;
 #else
-typedef std::shared_ptr<rx_agc_cc> rx_agc_cc_sptr;
+typedef std::shared_ptr<rx_agc_2f> rx_agc_2f_sptr;
 #endif
 
 
@@ -56,7 +56,7 @@ typedef std::shared_ptr<rx_agc_cc> rx_agc_cc_sptr;
  * To avoid accidental use of raw pointers, the rx_agc_cc constructor is private.
  * make_rx_agc_cc is the public interface for creating new instances.
  */
-rx_agc_cc_sptr make_rx_agc_cc(double sample_rate, bool agc_on, int target_level,
+rx_agc_2f_sptr make_rx_agc_2f(double sample_rate, bool agc_on, int target_level,
                               int manual_gain, int max_gain, int attack,
                               int decay, int hang);
 
@@ -67,19 +67,19 @@ rx_agc_cc_sptr make_rx_agc_cc(double sample_rate, bool agc_on, int target_level,
  * This block performs automatic gain control.
  * To be written...
  */
-class rx_agc_cc : public gr::sync_block
+class rx_agc_2f : public gr::sync_block
 {
-    friend rx_agc_cc_sptr make_rx_agc_cc(double sample_rate, bool agc_on,
+    friend rx_agc_2f_sptr make_rx_agc_2f(double sample_rate, bool agc_on,
                                          int target_level, int manual_gain,
                                          int max_gain, int attack, int decay,
                                          int hang);
 
 protected:
-    rx_agc_cc(double sample_rate, bool agc_on, int target_level,
+    rx_agc_2f(double sample_rate, bool agc_on, int target_level,
               int manual_gain, int max_gain, int attack, int decay, int hang);
 
 public:
-    ~rx_agc_cc();
+    ~rx_agc_2f();
 
     int work(int noutput_items,
              gr_vector_const_void_star &input_items,

--- a/src/qtgui/agc_options.cpp
+++ b/src/qtgui/agc_options.cpp
@@ -55,38 +55,51 @@ int CAgcOptions::gain()
     return ui->gainSlider->value();
 }
 
+/*! \brief Get current max gain slider value. */
+int CAgcOptions::maxGain()
+{
+    return ui->maxGainSlider->value();
+}
+
 /*! \brief Set AGC preset. */
 void CAgcOptions::setPreset(agc_preset_e preset)
 {
     switch (preset)
     {
     case AGC_FAST:
+        setAttack(20);
         setDecay(100);
+        setHang(0);
+        enableAttack(false);
         enableDecay(false);
-        setSlope(0);
-        enableSlope(false);
+        enableHang(false);
         enableGain(false);
         break;
 
     case AGC_MEDIUM:
+        setAttack(50);
         setDecay(500);
+        setHang(0);
+        enableAttack(false);
         enableDecay(false);
-        setSlope(0);
-        enableSlope(false);
+        enableHang(false);
         enableGain(false);
         break;
 
     case AGC_SLOW:
+        setAttack(100);
         setDecay(2000);
+        setHang(0);
+        enableAttack(false);
         enableDecay(false);
-        setSlope(0);
-        enableSlope(false);
+        enableHang(false);
         enableGain(false);
         break;
 
     case AGC_USER:
+        enableAttack(true);
         enableDecay(true);
-        enableSlope(true);
+        enableHang(true);
         enableGain(false);
         break;
 
@@ -108,6 +121,13 @@ void CAgcOptions::setGain(int value)
     ui->gainLabel->setText(QString("%1 dB").arg(ui->gainSlider->value()));
 }
 
+/*! \brief Set new max gain slider value. */
+void CAgcOptions::setMaxGain(int value)
+{
+    ui->maxGainSlider->setValue(value);
+    ui->maxGainLabel->setText(QString("%1 dB").arg(ui->maxGainSlider->value()));
+}
+
 /*! \brief Enable or disable gain slider.
  *  \param enabled Whether the slider should be enabled or not.
  *
@@ -118,45 +138,46 @@ void CAgcOptions::enableGain(bool enabled)
 {
     ui->gainLabel->setEnabled(enabled);
     ui->gainSlider->setEnabled(enabled);
-    ui->label1->setEnabled(enabled);
+    ui->gainTitle->setEnabled(enabled);
 }
 
-/*! \brief Get current AGC threshold. */
-int CAgcOptions::threshold()
+/*! \brief Get current AGC target level. */
+int CAgcOptions::targetLevel()
 {
-    return ui->thresholdSlider->value();
+    return ui->targetLevelSlider->value();
 }
 
-/*! \brief Set new AGC threshold. */
-void CAgcOptions::setThreshold(int value)
+/*! \brief Set new AGC target level. */
+void CAgcOptions::setTargetLevel(int value)
 {
-    ui->thresholdSlider->setValue(value);
-    ui->thresholdLabel->setText(QString("%1 dB").arg(ui->thresholdSlider->value()));
+    ui->targetLevelSlider->setValue(value);
+    ui->targetLevelLabel->setText(QString("%1 dB").arg(ui->targetLevelSlider->value()));
 }
 
-/*! \brief Get current AGC slope. */
-int CAgcOptions::slope()
+
+/*! \brief Get current attack value. */
+int CAgcOptions::attack()
 {
-    return ui->slopeSlider->value();
+    return ui->attackSlider->value();
 }
 
-/*! \brief Set new AGC slope. */
-void CAgcOptions::setSlope(int value)
+/*! \brief Set new attack value. */
+void CAgcOptions::setAttack(int value)
 {
-    ui->slopeSlider->setValue(value);
-    ui->slopeLabel->setText(QString("%1 dB").arg(ui->slopeSlider->value()));
+    ui->attackSlider->setValue(value);
+    ui->attackLabel->setText(QString("%1 ms").arg(ui->attackSlider->value()));
 }
 
-/*! \brief Enable or disable AGC slope slider.
+/*! \brief Enable or disable AGC attack slider.
  *  \param enabled Whether the slider should be enabled or not.
  *
- * The slope slider is enabled when AGC is in user mode.
+ * The attack slider is enabled when AGC is in user mode.
  */
-void CAgcOptions::enableSlope(bool enabled)
+void CAgcOptions::enableAttack(bool enabled)
 {
-    ui->slopeSlider->setEnabled(enabled);
-    ui->slopeLabel->setEnabled(enabled);
-    ui->label3->setEnabled(enabled);
+    ui->attackSlider->setEnabled(enabled);
+    ui->attackLabel->setEnabled(enabled);
+    ui->attackTitle->setEnabled(enabled);
 }
 
 /*! \brief Get current decay value. */
@@ -181,54 +202,75 @@ void CAgcOptions::enableDecay(bool enabled)
 {
     ui->decaySlider->setEnabled(enabled);
     ui->decayLabel->setEnabled(enabled);
-    ui->label4->setEnabled(enabled);
+    ui->decayTitle->setEnabled(enabled);
 }
 
-/*! \brief Get current state of AGC hang button. */
-bool CAgcOptions::hang()
+/*! \brief Get current hang value. */
+int CAgcOptions::hang()
 {
-    return ui->hangButton->isChecked();
+    return ui->hangSlider->value();
 }
 
-/*! \brief Set state og AGC hang button. */
-void CAgcOptions::setHang(bool checked)
+/*! \brief Set new hang value. */
+void CAgcOptions::setHang(int value)
 {
-    ui->hangButton->setChecked(checked);
+    ui->hangSlider->setValue(value);
+    ui->hangLabel->setText(QString("%1 ms").arg(ui->hangSlider->value()));
+}
+
+/*! \brief Enable or disable AGC hang slider.
+ *  \param enabled Whether the slider should be enabled or not.
+ *
+ * The hang slider is enabled when AGC is in user mode.
+ */
+void CAgcOptions::enableHang(bool enabled)
+{
+    ui->hangSlider->setEnabled(enabled);
+    ui->hangLabel->setEnabled(enabled);
+    ui->hangTitle->setEnabled(enabled);
 }
 
 
 
 /*! \brief AGC gain slider value has changed. */
-void CAgcOptions::on_gainSlider_valueChanged(int gain)
+void CAgcOptions::on_gainSlider_valueChanged(int value)
 {
     ui->gainLabel->setText(QString("%1 dB").arg(ui->gainSlider->value()));
-    emit gainChanged(gain);
+    emit gainChanged(value);
 }
 
-/*! \brief AGC threshold slider value has changed. */
-void CAgcOptions::on_thresholdSlider_valueChanged(int threshold)
+/*! \brief AGC max gain slider value has changed. */
+void CAgcOptions::on_maxGainSlider_valueChanged(int value)
 {
-    ui->thresholdLabel->setText(QString("%1 dB").arg(ui->thresholdSlider->value()));
-    emit thresholdChanged(threshold);
+    ui->maxGainLabel->setText(QString("%1 dB").arg(ui->maxGainSlider->value()));
+    emit maxGainChanged(value);
 }
 
-/*! \brief AGC slope slider value has changed. */
-void CAgcOptions::on_slopeSlider_valueChanged(int slope)
+/*! \brief AGC target level slider value has changed. */
+void CAgcOptions::on_targetLevelSlider_valueChanged(int value)
 {
-    ui->slopeLabel->setText(QString("%1 dB").arg(ui->slopeSlider->value()));
-    emit slopeChanged(slope);
+    ui->targetLevelLabel->setText(QString("%1 dB").arg(ui->targetLevelSlider->value()));
+    emit targetLevelChanged(value);
+}
+
+/*! \brief AGC attack slider value has changed. */
+void CAgcOptions::on_attackSlider_valueChanged(int value)
+{
+    ui->attackLabel->setText(QString("%1 ms").arg(ui->attackSlider->value()));
+    emit attackChanged(value);
 }
 
 /*! \brief AGC decay slider value has changed. */
-void CAgcOptions::on_decaySlider_valueChanged(int decay)
+void CAgcOptions::on_decaySlider_valueChanged(int value)
 {
     ui->decayLabel->setText(QString("%1 ms").arg(ui->decaySlider->value()));
-    emit decayChanged(decay);
+    emit decayChanged(value);
 }
 
-/*! \brief AGC hang button has been toggled. */
-void CAgcOptions::on_hangButton_toggled(bool checked)
+/*! \brief AGC hang slider value has changed. */
+void CAgcOptions::on_hangSlider_valueChanged(int value)
 {
-    ui->hangButton->setText(checked ? tr("Enabled") : tr("Disabled"));
-    emit hangChanged(checked);
+    ui->hangLabel->setText(QString("%1 ms").arg(ui->hangSlider->value()));
+    emit hangChanged(value);
 }
+

--- a/src/qtgui/agc_options.h
+++ b/src/qtgui/agc_options.h
@@ -51,24 +51,29 @@ public:
     ~CAgcOptions();
 
     void closeEvent(QCloseEvent *event);
-    
+
     int gain();
     void setGain(int value);
     void enableGain(bool enabled);
 
-    int threshold();
-    void setThreshold(int value);
+    int maxGain();
+    void setMaxGain(int value);
 
-    int slope();
-    void setSlope(int value);
-    void enableSlope(bool enabled);
+    int targetLevel();
+    void setTargetLevel(int value);
+
+    int attack();
+    void setAttack(int value);
+    void enableAttack(bool enabled);
 
     int decay();
     void setDecay(int value);
     void enableDecay(bool enabled);
 
-    bool hang();
-    void setHang(bool checked);
+    int hang();
+    void setHang(int value);
+    void enableHang(bool enabled);
+
 
     enum agc_preset_e
     {
@@ -83,17 +88,19 @@ public:
 
 signals:
     void gainChanged(int gain);
-    void thresholdChanged(int threshold);
-    void slopeChanged(int slope);
+    void maxGainChanged(int gain);
+    void targetLevelChanged(int level);
+    void attackChanged(int decay);
     void decayChanged(int decay);
-    void hangChanged(bool on);
+    void hangChanged(int hang);
 
 private slots:
-    void on_gainSlider_valueChanged(int gain);
-    void on_thresholdSlider_valueChanged(int threshold);
-    void on_slopeSlider_valueChanged(int slope);
-    void on_decaySlider_valueChanged(int decay);
-    void on_hangButton_toggled(bool checked);
+    void on_gainSlider_valueChanged(int value);
+    void on_maxGainSlider_valueChanged(int value);
+    void on_targetLevelSlider_valueChanged(int value);
+    void on_attackSlider_valueChanged(int value);
+    void on_decaySlider_valueChanged(int value);
+    void on_hangSlider_valueChanged(int value);
 
 private:
     Ui::CAgcOptions *ui;

--- a/src/qtgui/agc_options.ui
+++ b/src/qtgui/agc_options.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>263</width>
-    <height>197</height>
+    <width>293</width>
+    <height>253</height>
    </rect>
   </property>
   <property name="focusPolicy">
@@ -33,58 +33,20 @@
       <property name="verticalSpacing">
        <number>5</number>
       </property>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label3">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
+      <item row="3" column="0">
+       <widget class="QLabel" name="targetLevelTitle">
         <property name="text">
-         <string>Slope</string>
+         <string>Target</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label2">
+      <item row="3" column="2">
+       <widget class="QLabel" name="targetLevelLabel">
         <property name="text">
-         <string>Threshold</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QSlider" name="slopeSlider">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>AGC slope</string>
-        </property>
-        <property name="maximum">
-         <number>10</number>
-        </property>
-        <property name="pageStep">
-         <number>1</number>
-        </property>
-        <property name="value">
-         <number>0</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QLabel" name="thresholdLabel">
-        <property name="text">
-         <string>-100 dB</string>
+         <string>0 dB</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -92,7 +54,7 @@
        </widget>
       </item>
       <item row="5" column="0">
-       <widget class="QLabel" name="label4">
+       <widget class="QLabel" name="decayTitle">
         <property name="enabled">
          <bool>false</bool>
         </property>
@@ -101,25 +63,6 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QPushButton" name="hangButton">
-        <property name="toolTip">
-         <string>Enable / disable AGC hang</string>
-        </property>
-        <property name="text">
-         <string>Disabled</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoDefault">
-         <bool>false</bool>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -148,7 +91,7 @@
          <enum>Qt::StrongFocus</enum>
         </property>
         <property name="toolTip">
-         <string>AGC decay time</string>
+         <string>AGC decay time.  Time to change from min gain to max gain. Smaller gain changes are faster.</string>
         </property>
         <property name="minimum">
          <number>50</number>
@@ -197,6 +140,9 @@
         <property name="toolTip">
          <string>Manual gain. Used when AGC is switched off</string>
         </property>
+        <property name="minimum">
+         <number>-100</number>
+        </property>
         <property name="maximum">
          <number>100</number>
         </property>
@@ -206,7 +152,7 @@
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="label1">
+       <widget class="QLabel" name="gainTitle">
         <property name="enabled">
          <bool>false</bool>
         </property>
@@ -218,21 +164,8 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="2">
-       <widget class="QLabel" name="slopeLabel">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>0 dB</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
       <item row="6" column="0">
-       <widget class="QLabel" name="label5">
+       <widget class="QLabel" name="hangTitle">
         <property name="text">
          <string>Hang</string>
         </property>
@@ -241,25 +174,186 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QSlider" name="thresholdSlider">
+      <item row="3" column="1">
+       <widget class="QSlider" name="targetLevelSlider">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
         </property>
         <property name="toolTip">
-         <string>AGC threshold (aka. knee)</string>
+         <string>Target output level.</string>
         </property>
         <property name="minimum">
-         <number>-160</number>
+         <number>-100</number>
         </property>
         <property name="maximum">
          <number>0</number>
         </property>
         <property name="value">
-         <number>-100</number>
+         <number>0</number>
         </property>
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="maxGainTitle">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Max Gain</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSlider" name="maxGainSlider">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Maximum automatic gain.</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>150</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="maxGainLabel">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Manual gain. Used when AGC is switched off</string>
+        </property>
+        <property name="text">
+         <string>100 dB</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSlider" name="attackSlider">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>AGC attack time. Time to change from max gain to min gain. Smaller gain changes are faster.</string>
+        </property>
+        <property name="minimum">
+         <number>20</number>
+        </property>
+        <property name="maximum">
+         <number>1000</number>
+        </property>
+        <property name="singleStep">
+         <number>10</number>
+        </property>
+        <property name="pageStep">
+         <number>50</number>
+        </property>
+        <property name="value">
+         <number>500</number>
+        </property>
+        <property name="sliderPosition">
+         <number>500</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="attackTitle">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Attack</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QLabel" name="attackLabel">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>500 ms</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QSlider" name="hangSlider">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>AGC hang time. Time to wait before trying to increase the gain after the peak.</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>5000</number>
+        </property>
+        <property name="singleStep">
+         <number>10</number>
+        </property>
+        <property name="pageStep">
+         <number>50</number>
+        </property>
+        <property name="value">
+         <number>500</number>
+        </property>
+        <property name="sliderPosition">
+         <number>500</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="QLabel" name="hangLabel">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>500 ms</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -270,10 +364,8 @@
  </widget>
  <tabstops>
   <tabstop>gainSlider</tabstop>
-  <tabstop>thresholdSlider</tabstop>
-  <tabstop>slopeSlider</tabstop>
+  <tabstop>targetLevelSlider</tabstop>
   <tabstop>decaySlider</tabstop>
-  <tabstop>hangButton</tabstop>
  </tabstops>
  <resources>
   <include location="../../resources/icons.qrc"/>

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -119,10 +119,11 @@ DockRxOpt::DockRxOpt(qint64 filterOffsetRange, QWidget *parent) :
     // AGC options dialog
     agcOpt = new CAgcOptions(this);
     connect(agcOpt, SIGNAL(gainChanged(int)), this, SLOT(agcOpt_gainChanged(int)));
-    connect(agcOpt, SIGNAL(thresholdChanged(int)), this, SLOT(agcOpt_thresholdChanged(int)));
+    connect(agcOpt, SIGNAL(maxGainChanged(int)), this, SLOT(agcOpt_maxGainChanged(int)));
+    connect(agcOpt, SIGNAL(targetLevelChanged(int)), this, SLOT(agcOpt_targetLevelChanged(int)));
+    connect(agcOpt, SIGNAL(attackChanged(int)), this, SLOT(agcOpt_attackChanged(int)));
     connect(agcOpt, SIGNAL(decayChanged(int)), this, SLOT(agcOpt_decayChanged(int)));
-    connect(agcOpt, SIGNAL(slopeChanged(int)), this, SLOT(agcOpt_slopeChanged(int)));
-    connect(agcOpt, SIGNAL(hangChanged(bool)), this, SLOT(agcOpt_hangToggled(bool)));
+    connect(agcOpt, SIGNAL(hangChanged(int)), this, SLOT(agcOpt_hangChanged(int)));
 
     // Noise blanker options
     nbOpt = new CNbOptions(this);
@@ -396,6 +397,42 @@ int DockRxOpt::getCwOffset() const
     return demodOpt->getCwOffset();
 }
 
+/** Get agc settings */
+bool DockRxOpt::getAgcOn()
+{
+    return agc_is_on;
+}
+
+int DockRxOpt::getAgcTargetLevel()
+{
+    return agcOpt->targetLevel();
+}
+
+int DockRxOpt::getAgcManualGain()
+{
+    return agcOpt->gain();
+}
+
+int DockRxOpt::getAgcMaxGain()
+{
+    return agcOpt->maxGain();
+}
+
+int DockRxOpt::getAgcAttack()
+{
+    return agcOpt->attack();
+}
+
+int DockRxOpt::getAgcDecay()
+{
+    return agcOpt->decay();
+}
+
+int DockRxOpt::getAgcHang()
+{
+    return agcOpt->hang();
+}
+
 /** Read receiver configuration from settings data. */
 void DockRxOpt::readSettings(QSettings *settings)
 {
@@ -427,10 +464,17 @@ void DockRxOpt::readSettings(QSettings *settings)
         ui->sqlSpinBox->setValue(dbl_val);
 
     // AGC settings
+    //TODO: cleanup config
+    #if 0
     int_val = settings->value("receiver/agc_threshold", -100).toInt(&conv_ok);
     if (conv_ok)
         agcOpt->setThreshold(int_val);
+    #endif
+    int_val = settings->value("receiver/agc_target_level", 0).toInt(&conv_ok);
+    if (conv_ok)
+        agcOpt->setTargetLevel(int_val);
 
+    //TODO: store/restore the preset correctly
     int_val = settings->value("receiver/agc_decay", 500).toInt(&conv_ok);
     if (conv_ok)
     {
@@ -445,15 +489,21 @@ void DockRxOpt::readSettings(QSettings *settings)
             ui->agcPresetCombo->setCurrentIndex(3);
     }
 
-    int_val = settings->value("receiver/agc_slope", 0).toInt(&conv_ok);
+    int_val = settings->value("receiver/agc_attack", 20).toInt(&conv_ok);
     if (conv_ok)
-        agcOpt->setSlope(int_val);
+        agcOpt->setAttack(int_val);
+
+    int_val = settings->value("receiver/agc_hang", 0).toInt(&conv_ok);
+    if (conv_ok)
+        agcOpt->setHang(int_val);
 
     int_val = settings->value("receiver/agc_gain", 0).toInt(&conv_ok);
     if (conv_ok)
         agcOpt->setGain(int_val);
 
-    agcOpt->setHang(settings->value("receiver/agc_usehang", false).toBool());
+    int_val = settings->value("receiver/agc_maxgain", 100).toInt(&conv_ok);
+    if (conv_ok)
+        agcOpt->setMaxGain(int_val);
 
     if (settings->value("receiver/agc_off", false).toBool())
         ui->agcPresetCombo->setCurrentIndex(4);
@@ -514,11 +564,17 @@ void DockRxOpt::saveSettings(QSettings *settings)
         settings->remove("receiver/sql_level");
 
     // AGC settings
-    int_val = agcOpt->threshold();
-    if (int_val != -100)
-        settings->setValue("receiver/agc_threshold", int_val);
+    int_val = agcOpt->targetLevel();
+    if (int_val != 0)
+        settings->setValue("receiver/agc_target_level", int_val);
     else
-        settings->remove("receiver/agc_threshold");
+        settings->remove("receiver/agc_target_level");
+
+    int_val = agcOpt->attack();
+    if (int_val != 20)
+        settings->setValue("receiver/agc_attack", int_val);
+    else
+        settings->remove("receiver/agc_decay");
 
     int_val = agcOpt->decay();
     if (int_val != 500)
@@ -526,11 +582,11 @@ void DockRxOpt::saveSettings(QSettings *settings)
     else
         settings->remove("receiver/agc_decay");
 
-    int_val = agcOpt->slope();
+    int_val = agcOpt->hang();
     if (int_val != 0)
-        settings->setValue("receiver/agc_slope", int_val);
+        settings->setValue("receiver/agc_hang", int_val);
     else
-        settings->remove("receiver/agc_slope");
+        settings->remove("receiver/agc_hang");
 
     int_val = agcOpt->gain();
     if (int_val != 0)
@@ -538,10 +594,11 @@ void DockRxOpt::saveSettings(QSettings *settings)
     else
         settings->remove("receiver/agc_gain");
 
-    if (agcOpt->hang())
-        settings->setValue("receiver/agc_usehang", true);
+    int_val = agcOpt->maxGain();
+    if (int_val != 100)
+        settings->setValue("receiver/agc_maxgain", int_val);
     else
-        settings->remove("receiver/agc_usehang");
+        settings->remove("receiver/agc_maxgain");
 
     // AGC Off
     if (ui->agcPresetCombo->currentIndex() == 4)
@@ -702,27 +759,31 @@ void DockRxOpt::on_agcPresetCombo_currentIndexChanged(int index)
     }
 }
 
-void DockRxOpt::agcOpt_hangToggled(bool checked)
+/**
+ * @brief AGC hang time changed.
+ * @param value The new AGC hang time in ms.
+ */
+void DockRxOpt::agcOpt_hangChanged(int value)
 {
-    emit agcHangToggled(checked);
+    emit agcHangChanged(value);
 }
 
 /**
- * @brief AGC threshold ("knee") changed.
- * @param value The new AGC threshold in dB.
+ * @brief AGC target level changed.
+ * @param value The new AGC target level in dB.
  */
-void DockRxOpt::agcOpt_thresholdChanged(int value)
+void DockRxOpt::agcOpt_targetLevelChanged(int value)
 {
-    emit agcThresholdChanged(value);
+    emit agcTargetLevelChanged(value);
 }
 
 /**
- * @brief AGC slope factor changed.
- * @param value The new slope factor in dB.
+ * @brief AGC attack changed.
+ * @param value The new attack rate in ms (tbc).
  */
-void DockRxOpt::agcOpt_slopeChanged(int value)
+void DockRxOpt::agcOpt_attackChanged(int value)
 {
-    emit agcSlopeChanged(value);
+    emit agcAttackChanged(value);
 }
 
 /**
@@ -741,6 +802,15 @@ void DockRxOpt::agcOpt_decayChanged(int value)
 void DockRxOpt::agcOpt_gainChanged(int gain)
 {
     emit agcGainChanged(gain);
+}
+
+/**
+ * @brief AGC maimum gain changed.
+ * @param gain The new gain in dB.
+ */
+void DockRxOpt::agcOpt_maxGainChanged(int gain)
+{
+    emit agcMaxGainChanged(gain);
 }
 
 /**

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -112,6 +112,14 @@ public:
 
     double  getSqlLevel(void) const;
 
+    bool    getAgcOn();
+    int     getAgcTargetLevel();
+    int     getAgcManualGain();
+    int     getAgcMaxGain();
+    int     getAgcAttack();
+    int     getAgcDecay();
+    int     getAgcHang();
+
     static QStringList ModulationStrings;
     static QString GetStringForModulationIndex(int iModulationIndex);
     static int GetEnumForModulationString(QString param);
@@ -185,20 +193,23 @@ signals:
     /** Signal emitted when AGC is togglen ON/OFF. */
     void agcToggled(bool agc_on);
 
-    /** Signal emitted when AGC hang is toggled. */
-    void agcHangToggled(bool use_hang);
+    /** Signal emitted when AGC target level has changed. Level in dB. */
+    void agcTargetLevelChanged(int value);
 
-    /** Signal emitted when AGC threshold has changed. Threshold in dB. */
-    void agcThresholdChanged(int value);
+    /** Signal emitted when AGC manual gain has changed. Gain is in dB.*/
+    void agcGainChanged(int gain);
 
-    /** Signal emitted when AGC slope has changed. Slope is in dB.*/
-    void agcSlopeChanged(int slope);
+    /** Signal emitted when AGC maximum gain has changed. Gain is in dB.*/
+    void agcMaxGainChanged(int gain);
+
+    /** Signal emitted when AGC attack has changed. Decay is in millisec.*/
+    void agcAttackChanged(int attack);
 
     /** Signal emitted when AGC decay has changed. Decay is in millisec.*/
     void agcDecayChanged(int decay);
 
-    /** Signal emitted when AGC manual gain has changed. Gain is in dB.*/
-    void agcGainChanged(int gain);
+    /** Signal emitted when AGC hang is changed. Hang is in millisec.*/
+    void agcHangChanged(int hang);
 
     /** Signal emitted when noise blanker status has changed. */
     void noiseBlankerChanged(int nbid, bool on, float threshold);
@@ -233,11 +244,12 @@ private slots:
     void demodOpt_amSyncPllBwSelected(float pll_bw);
 
     // Signals coming from AGC options popup
-    void agcOpt_hangToggled(bool checked);
     void agcOpt_gainChanged(int value);
-    void agcOpt_thresholdChanged(int value);
-    void agcOpt_slopeChanged(int value);
+    void agcOpt_maxGainChanged(int value);
+    void agcOpt_targetLevelChanged(int value);
+    void agcOpt_attackChanged(int value);
     void agcOpt_decayChanged(int value);
+    void agcOpt_hangChanged(int value);
 
 private:
     Ui::DockRxOpt *ui;        /** The Qt designer UI file. */

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -44,7 +44,7 @@ nbrx::nbrx(float quad_rate, float audio_rate)
 
     nb = make_rx_nb_cc(PREF_QUAD_RATE, 3.3, 2.5);
     filter = make_rx_filter(PREF_QUAD_RATE, -5000.0, 5000.0, 1000.0);
-    agc = make_rx_agc_cc(PREF_QUAD_RATE, true, -100, 0, 0, 500, false);
+    agc = make_rx_agc_cc(PREF_QUAD_RATE, true, 0, 0, 100, 500, 500, 0);
     sql = gr::analog::simple_squelch_cc::make(-150.0, 0.001);
     meter = make_rx_meter_c(PREF_QUAD_RATE);
     demod_raw = gr::blocks::complex_to_float::make(1);
@@ -158,19 +158,24 @@ void nbrx::set_agc_on(bool agc_on)
     agc->set_agc_on(agc_on);
 }
 
-void nbrx::set_agc_hang(bool use_hang)
+void nbrx::set_agc_target_level(int target_level)
 {
-    agc->set_use_hang(use_hang);
+    agc->set_target_level(target_level);
 }
 
-void nbrx::set_agc_threshold(int threshold)
+void nbrx::set_agc_manual_gain(int gain)
 {
-    agc->set_threshold(threshold);
+    agc->set_manual_gain(gain);
 }
 
-void nbrx::set_agc_slope(int slope)
+void nbrx::set_agc_max_gain(int gain)
 {
-    agc->set_slope(slope);
+    agc->set_max_gain(gain);
+}
+
+void nbrx::set_agc_attack(int attack_ms)
+{
+    agc->set_attack(attack_ms);
 }
 
 void nbrx::set_agc_decay(int decay_ms)
@@ -178,9 +183,9 @@ void nbrx::set_agc_decay(int decay_ms)
     agc->set_decay(decay_ms);
 }
 
-void nbrx::set_agc_manual_gain(int gain)
+void nbrx::set_agc_hang(int hang_ms)
 {
-    agc->set_manual_gain(gain);
+    agc->set_hang(hang_ms);
 }
 
 void nbrx::set_demod(int rx_demod)

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -44,7 +44,7 @@ nbrx::nbrx(float quad_rate, float audio_rate)
 
     nb = make_rx_nb_cc(PREF_QUAD_RATE, 3.3, 2.5);
     filter = make_rx_filter(PREF_QUAD_RATE, -5000.0, 5000.0, 1000.0);
-    agc = make_rx_agc_cc(PREF_QUAD_RATE, true, 0, 0, 100, 500, 500, 0);
+    agc = make_rx_agc_2f(d_audio_rate, true, 0, 0, 100, 500, 500, 0);
     sql = gr::analog::simple_squelch_cc::make(-150.0, 0.001);
     meter = make_rx_meter_c(PREF_QUAD_RATE);
     demod_raw = gr::blocks::complex_to_float::make(1);
@@ -69,21 +69,24 @@ nbrx::nbrx(float quad_rate, float audio_rate)
     connect(nb, 0, filter, 0);
     connect(filter, 0, meter, 0);
     connect(filter, 0, sql, 0);
-    connect(sql, 0, agc, 0);
-    connect(agc, 0, demod, 0);
+    connect(sql, 0, demod, 0);
+//    connect(sql, 0, agc, 0);
+//    connect(agc, 0, demod, 0);
 
     if (audio_rr0)
     {
         connect(demod, 0, audio_rr0, 0);
 
-        connect(audio_rr0, 0, self(), 0); // left  channel
-        connect(audio_rr0, 0, self(), 1); // right channel
+        connect(audio_rr0, 0, agc, 0); // left  channel
+        connect(audio_rr0, 0, agc, 1); // right channel
     }
     else
     {
-        connect(demod, 0, self(), 0);
-        connect(demod, 0, self(), 1);
+        connect(demod, 0, agc, 0);
+        connect(demod, 0, agc, 1);
     }
+    connect(agc, 0, self(), 0);
+    connect(agc, 1, self(), 1);
 }
 
 bool nbrx::start()
@@ -201,7 +204,7 @@ void nbrx::set_demod(int rx_demod)
         return;
     }
 
-    disconnect(agc, 0, demod, 0);
+    disconnect(sql, 0, demod, 0);
     if (audio_rr0)
     {
         if (current_demod == NBRX_DEMOD_NONE)
@@ -209,28 +212,28 @@ void nbrx::set_demod(int rx_demod)
             disconnect(demod, 0, audio_rr0, 0);
             disconnect(demod, 1, audio_rr1, 0);
 
-            disconnect(audio_rr0, 0, self(), 0);
-            disconnect(audio_rr1, 0, self(), 1);
+            disconnect(audio_rr0, 0, agc, 0);
+            disconnect(audio_rr1, 0, agc, 1);
         }
         else
         {
             disconnect(demod, 0, audio_rr0, 0);
 
-            disconnect(audio_rr0, 0, self(), 0);
-            disconnect(audio_rr0, 0, self(), 1);
+            disconnect(audio_rr0, 0, agc, 0);
+            disconnect(audio_rr0, 0, agc, 1);
         }
     }
     else
     {
         if (current_demod == NBRX_DEMOD_NONE)
         {
-            disconnect(demod, 0, self(), 0);
-            disconnect(demod, 1, self(), 1);
+            disconnect(demod, 0, agc, 0);
+            disconnect(demod, 1, agc, 1);
         }
         else
         {
-            disconnect(demod, 0, self(), 0);
-            disconnect(demod, 0, self(), 1);
+            disconnect(demod, 0, agc, 0);
+            disconnect(demod, 0, agc, 1);
         }
     }
 
@@ -263,7 +266,7 @@ void nbrx::set_demod(int rx_demod)
         break;
     }
 
-    connect(agc, 0, demod, 0);
+    connect(sql, 0, demod, 0);
     if (audio_rr0)
     {
         if (d_demod == NBRX_DEMOD_NONE)
@@ -271,28 +274,28 @@ void nbrx::set_demod(int rx_demod)
             connect(demod, 0, audio_rr0, 0);
             connect(demod, 1, audio_rr1, 0);
 
-            connect(audio_rr0, 0, self(), 0);
-            connect(audio_rr1, 0, self(), 1);
+            connect(audio_rr0, 0, agc, 0);
+            connect(audio_rr1, 0, agc, 1);
         }
         else
         {
             connect(demod, 0, audio_rr0, 0);
 
-            connect(audio_rr0, 0, self(), 0);
-            connect(audio_rr0, 0, self(), 1);
+            connect(audio_rr0, 0, agc, 0);
+            connect(audio_rr0, 0, agc, 1);
         }
     }
     else
     {
         if (d_demod == NBRX_DEMOD_NONE)
         {
-            connect(demod, 0, self(), 0);
-            connect(demod, 1, self(), 1);
+            connect(demod, 0, agc, 0);
+            connect(demod, 1, agc, 1);
         }
         else
         {
-            connect(demod, 0, self(), 0);
-            connect(demod, 0, self(), 1);
+            connect(demod, 0, agc, 0);
+            connect(demod, 0, agc, 1);
         }
     }
 }

--- a/src/receivers/nbrx.h
+++ b/src/receivers/nbrx.h
@@ -128,7 +128,7 @@ private:
 
     rx_nb_cc_sptr             nb;         /*!< Noise blanker. */
     rx_meter_c_sptr           meter;      /*!< Signal strength. */
-    rx_agc_cc_sptr            agc;        /*!< Receiver AGC. */
+    rx_agc_2f_sptr            agc;        /*!< Receiver AGC. */
     gr::analog::simple_squelch_cc::sptr sql;        /*!< Squelch. */
     gr::blocks::complex_to_float::sptr  demod_raw;  /*!< Raw I/Q passthrough. */
     gr::blocks::complex_to_real::sptr   demod_ssb;  /*!< SSB demodulator. */

--- a/src/receivers/nbrx.h
+++ b/src/receivers/nbrx.h
@@ -93,11 +93,12 @@ public:
     /* AGC */
     bool has_agc() { return true; }
     void set_agc_on(bool agc_on);
-    void set_agc_hang(bool use_hang);
-    void set_agc_threshold(int threshold);
-    void set_agc_slope(int slope);
-    void set_agc_decay(int decay_ms);
+    void set_agc_target_level(int target_level);
     void set_agc_manual_gain(int gain);
+    void set_agc_max_gain(int gain);
+    void set_agc_attack(int attack_ms);
+    void set_agc_decay(int decay_ms);
+    void set_agc_hang(int hang_ms);
 
     void set_demod(int demod);
 

--- a/src/receivers/receiver_base.cpp
+++ b/src/receivers/receiver_base.cpp
@@ -84,19 +84,24 @@ void receiver_base_cf::set_agc_on(bool agc_on)
     (void) agc_on;
 }
 
-void receiver_base_cf::set_agc_hang(bool use_hang)
+void receiver_base_cf::set_agc_target_level(int target_level)
 {
-    (void) use_hang;
+    (void) target_level;
 }
 
-void receiver_base_cf::set_agc_threshold(int threshold)
+void receiver_base_cf::set_agc_manual_gain(int gain)
 {
-    (void) threshold;
+    (void) gain;
 }
 
-void receiver_base_cf::set_agc_slope(int slope)
+void receiver_base_cf::set_agc_max_gain(int gain)
 {
-    (void) slope;
+    (void) gain;
+}
+
+void receiver_base_cf::set_agc_attack(int attack_ms)
+{
+    (void) attack_ms;
 }
 
 void receiver_base_cf::set_agc_decay(int decay_ms)
@@ -104,9 +109,9 @@ void receiver_base_cf::set_agc_decay(int decay_ms)
     (void) decay_ms;
 }
 
-void receiver_base_cf::set_agc_manual_gain(int gain)
+void receiver_base_cf::set_agc_hang(int hang_ms)
 {
-    (void) gain;
+    (void) hang_ms;
 }
 
 bool receiver_base_cf::has_fm()

--- a/src/receivers/receiver_base.h
+++ b/src/receivers/receiver_base.h
@@ -79,11 +79,12 @@ public:
     /* AGC */
     virtual bool has_agc();
     virtual void set_agc_on(bool agc_on);
-    virtual void set_agc_hang(bool use_hang);
-    virtual void set_agc_threshold(int threshold);
-    virtual void set_agc_slope(int slope);
-    virtual void set_agc_decay(int decay_ms);
+    virtual void set_agc_target_level(int target_level);
     virtual void set_agc_manual_gain(int gain);
+    virtual void set_agc_max_gain(int gain);
+    virtual void set_agc_attack(int attack_ms);
+    virtual void set_agc_decay(int decay_ms);
+    virtual void set_agc_hang(int hang_ms);
 
     /* FM parameters */
     virtual bool has_fm();

--- a/src/receivers/wfmrx.h
+++ b/src/receivers/wfmrx.h
@@ -35,6 +35,7 @@
 #include "dsp/rx_rds.h"
 #include "dsp/rds/decoder.h"
 #include "dsp/rds/parser.h"
+#include "dsp/rx_agc_xx.h"
 
 class wfmrx;
 
@@ -87,13 +88,14 @@ public:
     void set_sql_alpha(double alpha);
 
     /* AGC */
-    bool has_agc() { return false; }
-    /*void set_agc_on(bool agc_on);
-    void set_agc_hang(bool use_hang);
-    void set_agc_threshold(int threshold);
-    void set_agc_slope(int slope);
+    bool has_agc() { return true; }
+    void set_agc_on(bool agc_on);
+    void set_agc_target_level(int target_level);
+    void set_agc_manual_gain(int gain);
+    void set_agc_max_gain(int gain);
+    void set_agc_attack(int attack_ms);
     void set_agc_decay(int decay_ms);
-    void set_agc_manual_gain(int gain);*/
+    void set_agc_hang(int hang_ms);
 
     void set_demod(int demod);
 
@@ -119,6 +121,7 @@ private:
     rx_filter_sptr            filter;    /*!< Non-translating bandpass filter.*/
 
     rx_meter_c_sptr           meter;     /*!< Signal strength. */
+    rx_agc_2f_sptr            agc;        /*!< Receiver AGC. */
     gr::analog::simple_squelch_cc::sptr sql;       /*!< Squelch. */
     rx_demod_fm_sptr          demod_fm;  /*!< FM demodulator. */
     stereo_demod_sptr         stereo;    /*!< FM stereo demodulator. */


### PR DESCRIPTION
Switch to float and move rx_agc to the output of demodulator.
Works for FM modes.
No more need to adjust gain while tuning between WFM stations.

Default presets may need to be adjusted.
New 'WFM' preset may be added.
Suggestions welcome.