### PR TITLE
Update rx_fft_f to match rx_fft_c

### DIFF
--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -36,6 +36,7 @@
 
 
 #define MAX_FFT_SIZE 1048576
+#define AUDIO_BUFFER_SIZE 65536
 
 class rx_fft_c;
 class rx_fft_f;


### PR DESCRIPTION
It's good to keep rx_fft_c and rx_fft_f in sync, so I've copied over most of the changes from #1051 here.

65536 should be a sufficient buffer size; previously it was 48000 + 8192 = 56192.