### PR TITLE
Improve accuracy and precision of S-meter display

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -7,6 +7,7 @@
   IMPROVED: FFT and S-meter performance.
   IMPROVED: Reduced FFT memory usage.
   IMPROVED: Increased S-meter resolution to 0.1 dB.
+  IMPROVED: Accuracy of S-meter display.
 
 
     2.15.2: Released January 8, 2022

--- a/src/qtgui/meter.cpp
+++ b/src/qtgui/meter.cpp
@@ -119,7 +119,7 @@ void CMeter::setLevel(float dbfs)
     float level = m_dBFS;
     float alpha  = dbfs < level ? ALPHA_DECAY : ALPHA_RISE;
     m_dBFS -= alpha * (level - dbfs);
-    m_Siglevel = (int)((level - MIN_DB) * m_pixperdb);
+    m_Siglevel = (level - MIN_DB) * m_pixperdb;
 
     draw();
 }
@@ -174,7 +174,7 @@ void CMeter::draw()
 
     // Qt 4.8+ has a 1-pixel error (or they fixed line drawing)
     // see http://stackoverflow.com/questions/16990326
-    painter.drawRect(marg - 1, ht + 1, x - marg, 6);
+    painter.drawRect(QRectF(marg - 1, ht + 1, x - marg, 6));
 
     if (m_SqlLevel > 0.0f)
     {

--- a/src/qtgui/meter.cpp
+++ b/src/qtgui/meter.cpp
@@ -169,12 +169,17 @@ void CMeter::draw()
     qreal ht = (qreal) h * CTRL_NEEDLE_TOP;
     qreal x = marg + m_Siglevel;
 
-    painter.setBrush(QBrush(QColor(0, 190, 0, 255)));
-    painter.setOpacity(1.0);
+    if (m_Siglevel > 0.0f)
+    {
+        QColor color(0, 190, 0, 255);
+        QPen pen(color);
+        pen.setJoinStyle(Qt::MiterJoin);
+        painter.setPen(pen);
+        painter.setBrush(QBrush(color));
+        painter.setOpacity(1.0);
 
-    // Qt 4.8+ has a 1-pixel error (or they fixed line drawing)
-    // see http://stackoverflow.com/questions/16990326
-    painter.drawRect(QRectF(marg - 1, ht + 1, x - marg, 6));
+        painter.drawRect(QRectF(marg, ht + 2, x - marg, 4));
+    }
 
     if (m_SqlLevel > 0.0f)
     {

--- a/src/qtgui/meter.h
+++ b/src/qtgui/meter.h
@@ -72,7 +72,7 @@ private:
     QSize   m_Size;
     QString m_Str;
     qreal   m_pixperdb;     // pixels / dB
-    int     m_Siglevel;
+    qreal   m_Siglevel;
     float   m_dBFS;
     qreal   m_Sql;
     qreal   m_SqlLevel;


### PR DESCRIPTION
As noted in https://github.com/gqrx-sdr/gqrx/pull/1054#issuecomment-1013549141, `m_Siglevel` is currently an `int`, limiting the precision of the displayed S-meter on high-DPI displays. I've fixed that in the first commit here.

While working on this, I also noticed that the S-meter rectangle is 2 pixels too short. It has a black pen stroke around it which is the correct length, but that cannot be seen. I've made the stroke visible by changing it to green. (It was easier to get the meter to the correct size this way, as opposed to removing the stroke completely.) This change is in the second commit.