### PR TITLE
Prevent audio delay on lifftw plan generation

### DIFF
--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -102,6 +102,7 @@ private:
     int          d_wintype;   /*! Current window type. */
 
     std::mutex   d_mutex;  /*! Used to lock FFT output buffer. */
+    std::mutex   d_fft_mutex;  /*! Used to lock FFT configuration. */
 
 #if GNURADIO_VERSION < 0x030900
     gr::fft::fft_complex    *d_fft;    /*! FFT object. */
@@ -172,6 +173,7 @@ private:
     int          d_wintype;   /*! Current window type. */
 
     std::mutex   d_mutex;  /*! Used to lock FFT output buffer. */
+    std::mutex   d_fft_mutex;  /*! Used to lock FFT configuration. */
 
 #if GNURADIO_VERSION < 0x030900
     gr::fft::fft_complex    *d_fft;    /*! FFT object. */


### PR DESCRIPTION
When ~/.gr_fftw_wisdom is missing, and gqrx is run for the first time,
there is noticeable audio delay, that grows while switching the FFT to
larger sizes. The audio is skipping too.
This patch prevents this from happening by unlocking data mutex and
locking separate FFT mutex for the time of libfftw plan generation.