### PR TITLE
Don't lock the buffer mutex while changing FFT size

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.15.4: In progress...
+
+     FIXED: Audio is delayed when FFT size is changed.
+
+
     2.15.3: Released January 15, 2022
 
      FIXED: RDS receiver skips some messages.

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -160,8 +160,6 @@ void rx_fft_c::apply_window(unsigned int size)
 /*! \brief Update circular buffer and FFT object. */
 void rx_fft_c::set_params()
 {
-    std::lock_guard<std::mutex> lock(d_mutex);
-
     /* reset window */
     int wintype = d_wintype; // FIXME: would be nicer with a window_reset()
     d_wintype = -1;
@@ -365,8 +363,6 @@ void rx_fft_f::set_fft_size(unsigned int fftsize)
 {
     if (fftsize != d_fftsize)
     {
-        std::lock_guard<std::mutex> lock(d_mutex);
-
         d_fftsize = fftsize;
 
         /* reset window */


### PR DESCRIPTION
Replaces #1068.

Fixes the issue described in https://github.com/gqrx-sdr/gqrx/pull/1051#issuecomment-1013752360.

There's no need to lock the mutex in `rx_fft_c::set_params` or `rx_fft_f::set_fft_size` anymore, since they no longer access the circular buffer after #1051 and #1066 were merged.