### PR TITLE
Clean up CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,17 +241,24 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Finish configuring compiler / linker settings & flags
 include_directories(
     ${CMAKE_SOURCE_DIR}/include
-    ${Boost_INCLUDE_DIRS}
-    ${GNURADIO_RUNTIME_INCLUDE_DIRS}
     ${GNURADIO_OSMOSDR_INCLUDE_DIRS}
 )
 
 link_directories(
-    ${Boost_LIBRARY_DIRS}
     ${GNURADIO_RUNTIME_LIBRARY_DIRS}
     ${ICU4C_LIBRARY_DIRS}
 )
 
+if(Gnuradio_VERSION VERSION_LESS "3.8")
+    include_directories(
+        ${Boost_INCLUDE_DIRS}
+        ${GNURADIO_RUNTIME_INCLUDE_DIRS}
+    )
+
+    link_directories(
+        ${Boost_LIBRARY_DIRS}
+    )
+endif()
 
 # Add subdirectories
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,14 +123,11 @@ find_package(Gnuradio-osmosdr REQUIRED)
 
 set(GR_REQUIRED_COMPONENTS RUNTIME ANALOG AUDIO BLOCKS DIGITAL FILTER FFT PMT)
 find_package(Gnuradio REQUIRED COMPONENTS analog audio blocks digital filter fft network)
-if(Gnuradio_VERSION VERSION_LESS "3.8")
-    find_package(Volk)
-endif()
-
 if(NOT Gnuradio_FOUND)
     message(FATAL_ERROR "GnuRadio Runtime required to compile gqrx")
 endif()
 
+find_package(Volk)
 
 # Pass the GNU Radio version as 0xMMNNPP BCD.
 math(EXPR GNURADIO_BCD_VERSION

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,13 +64,10 @@ target_link_libraries(${PROJECT_NAME}
     Qt5::Network
     Qt5::Widgets
     Qt5::Svg
-    ${Boost_LIBRARIES}
-    ${GNURADIO_ALL_LIBRARIES}
     ${GNURADIO_OSMOSDR_LIBRARIES}
     ${PULSEAUDIO_LIBRARY}
     ${PULSE-SIMPLE}
     ${PORTAUDIO_LIBRARIES}
-    ${VOLK_LIBRARIES}
 )
 
 if(NOT Gnuradio_VERSION VERSION_LESS "3.10")
@@ -91,6 +88,12 @@ elseif(NOT Gnuradio_VERSION VERSION_LESS "3.8")
         gnuradio::gnuradio-filter
         gnuradio::gnuradio-audio
         Volk::volk
+    )
+else()
+    target_link_libraries(${PROJECT_NAME}
+        ${Boost_LIBRARIES}
+        ${GNURADIO_ALL_LIBRARIES}
+        ${VOLK_LIBRARIES}
     )
 endif()
 


### PR DESCRIPTION
This pull request makes two improvements:

1. Unconditionally run `find_package(Volk)`, since VOLK is a direct dependency of Gqrx.
2. Move legacy code that is only needed for GNU Radio 3.7 into conditional blocks. This will make cleanup easier when support for GNU Radio 3.7 is eventually dropped.