### PR TITLE
Put desktop categories back as they were in #154

### DIFF
--- a/gqrx.desktop
+++ b/gqrx.desktop
@@ -14,5 +14,5 @@ Comment[zh_CN]=使用 GNU Radio 和 Qt GUI 实现的软件无线电接收器
 Exec=gqrx
 Terminal=false
 Icon=gqrx
-Categories=Network;HamRadio;
+Categories=AudioVideo;Audio;Qt;HamRadio;
 Keywords=SDR;Radio;HAM;


### PR DESCRIPTION
Gqrx's desktop entry has had many different category values over the years:

* https://github.com/gqrx-sdr/gqrx/pull/152 `Categories=Audio;Qt;HamRadio;` (invalid!)

* https://github.com/gqrx-sdr/gqrx/pull/154 `Categories=AudioVideo;Audio;Qt;HamRadio;`
* https://github.com/gqrx-sdr/gqrx/commit/c4868f59f1b02e7055a0f08eb32a1afc50624347 `Categories=Hamradio;` (invalid!)
* https://github.com/gqrx-sdr/gqrx/pull/187 `Categories=Utility;HamRadio;`
* https://github.com/gqrx-sdr/gqrx/issues/222 https://github.com/gqrx-sdr/gqrx/commit/bc6ec5f3617d87869c1059d80399dd4e13a8668c `Categories=Network;HamRadio;`
* https://github.com/gqrx-sdr/gqrx/pull/503 `Categories=Network;HamRadio;Accessories;` (invalid!)
* https://github.com/gqrx-sdr/gqrx/commit/a36123552b83607fe7304c322a1a237ca13c3ef8 `Categories=Network;HamRadio;`

The [spec](https://specifications.freedesktop.org/menu-spec/latest/apas02.html) suggests that applications in the "HamRadio" additional category should appear in either the "Network" or the "Audio" categories. Gqrx is much more audio-focused than network-focused, so I think switching back to the categories proposed in #154 is best. I'm doing that here.

"AudioVideo" appears because it is mandatory for applications in the "Audio" category. "Qt" is for applications based on Qt libraries, which Gqrx is.

This change should address https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1000331.