### PR TITLE
Install the icon, desktop entry, and appstream metadata in cmake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y cmake qt5-default libqt5svg5-dev libboost-dev libpulse-dev portaudio19-dev liblog4cpp5-dev gnuradio-dev gr-osmosdr gr-fcdproplus liborc-0.4-dev desktop-file-utils
+        run: sudo apt-get update -qq && sudo apt-get install -y cmake qt5-default libqt5svg5-dev libboost-dev libpulse-dev portaudio19-dev liblog4cpp5-dev gnuradio-dev gr-osmosdr gr-fcdproplus liborc-0.4-dev appstream desktop-file-utils
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Configure
@@ -22,6 +22,8 @@ jobs:
         run: make
       - name: Validate desktop entry
         run: desktop-file-validate gqrx.desktop
+      - name: Validate appstream metadata
+        run: appstreamcli validate gqrx.appdata.xml
   macos-build:
     name: MacOS CI
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,15 @@ if(Gnuradio_VERSION VERSION_LESS "3.8")
     )
 endif()
 
+# Install desktop
+install(FILES gqrx.desktop DESTINATION share/applications)
+
+# Install appstream / metainfo file
+install(FILES gqrx.appdata.xml DESTINATION share/metainfo)
+
+# Install icon
+install(FILES resources/icons/gqrx.svg DESTINATION share/icons/hicolor/scalable/apps)
+
 # Add subdirectories
 add_subdirectory(src)
 

--- a/gqrx.appdata.xml
+++ b/gqrx.appdata.xml
@@ -25,7 +25,7 @@
   <screenshots>
     <screenshot type="default">
       <!-- <caption></caption> -->
-      <image height="722" width="1024">https://c2.staticflickr.com/2/1567/23593127703_11fc1ac026_b.jpg</image>
+      <image width="1850" height="1055">https://raw.githubusercontent.com/gqrx-sdr/gqrx/master/resources/screenshots/gqrx-main.png</image>
     </screenshot>
   </screenshots>
   <update_contact>daveo@fedoraproject.org</update_contact>

--- a/gqrx.appdata.xml
+++ b/gqrx.appdata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>gqrx.desktop</id>
+  <id>dk.gqrx.gqrx</id>
   <name>Gqrx</name>
   <summary>Software defined radio receiver implemented using GNU Radio and the Qt GUI toolkit</summary>
   <summary xml:lang="nl">Software defined radio ontvanger geïmplementeerd met GNU Radio en de Qt GUI toolkit</summary>
-  <summary xml:lang="ru">Приемник для программно-определенного радио (SDR) использующий GNU Radio и библиотеку Qt.</summary>
+  <summary xml:lang="ru">Приемник для программно-определенного радио (SDR) использующий GNU Radio и библиотеку Qt</summary>
   <developer_name>Alexandru Csete</developer_name>
   <description>
    <p>

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.15.6: In progress...
+
+  IMPROVED: Install icon, desktop entry, and appstream metadata.
+
+
     2.15.5: Released January 20, 2022
 
      FIXED: Use correct categories in desktop entry file.


### PR DESCRIPTION
Gqrx doesn't currently install its icon, desktop entry file, or appstream metadata file. Debian takes care of installing the icon and desktop entry file (but not the appstream metadata file) in its `debian/gqrx-sdr.install` file. I think it would be best for Gqrx to install all these files in its own build process, so that they'll also be installed when users build Gqrx from source. This is similar to what GNU Radio does: https://github.com/gnuradio/gnuradio/blob/b42996b1569722d34dad2057406e4a6c3de99366/grc/scripts/freedesktop/CMakeLists.txt#L24-L40