### PR TITLE
Fix deprecation warnings reported by Qt 5.15

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -2360,7 +2360,7 @@ void MainWindow::on_actionAddBookmark_triggered()
 {
     bool ok=false;
     QString name;
-    QString tags; // list of tags separated by comma
+    QStringList tags;
 
     // Create and show the Dialog for a new Bookmark.
     // Write the result into variable 'name'.
@@ -2398,7 +2398,7 @@ void MainWindow::on_actionAddBookmark_triggered()
         if (ok)
         {
             name = textfield->text();
-            tags = taglist->getSelectedTagsAsString();
+            tags = taglist->getSelectedTags();
             qDebug() << "Tags: " << tags;
         }
         else
@@ -2418,14 +2418,13 @@ void MainWindow::on_actionAddBookmark_triggered()
         info.bandwidth = ui->plotter->getFilterBw();
         info.modulation = uiDockRxOpt->currentDemodAsString();
         info.name=name;
-        auto listTags = tags.split(",",QString::SkipEmptyParts);
         info.tags.clear();
-        if (listTags.empty())
+        if (tags.empty())
             info.tags.append(&Bookmarks::Get().findOrAddTag(""));
 
 
-        for (i = 0; i < listTags.size(); ++i)
-            info.tags.append(&Bookmarks::Get().findOrAddTag(listTags[i]));
+        for (i = 0; i < tags.size(); ++i)
+            info.tags.append(&Bookmarks::Get().findOrAddTag(tags[i]));
 
         Bookmarks::Get().add(info);
         uiDockBookmarks->updateTags();

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -459,7 +459,7 @@ bool MainWindow::loadConfig(const QString& cfgfile, bool check_crash,
     {
         if (m_settings->value("crashed", false).toBool())
         {
-            qDebug() << "Crash guard triggered!" << endl;
+            qDebug() << "Crash guard triggered!";
             auto* askUserAboutConfig =
                     new QMessageBox(QMessageBox::Warning, tr("Crash Detected!"),
                                     tr("<p>Gqrx has detected problems with the current configuration. "

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -197,7 +197,11 @@ void RemoteControl::startRead()
     if (bytes_read < 2)  // command + '\n'
         return;
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     QStringList cmdlist = QString(buffer).trimmed().split(" ", QString::SkipEmptyParts);
+#else
+    QStringList cmdlist = QString(buffer).trimmed().split(" ", Qt::SkipEmptyParts);
+#endif
 
     if (cmdlist.size() == 0)
         return;

--- a/src/qtgui/bookmarks.cpp
+++ b/src/qtgui/bookmarks.cpp
@@ -156,7 +156,7 @@ bool Bookmarks::save()
         QTextStream stream(&file);
 
         stream << QString("# Tag name").leftJustified(20) + "; " +
-                  QString(" color") << endl;
+                  QString(" color") << '\n';
 
         QSet<TagInfo*> usedTags;
         for (int iBookmark = 0; iBookmark < m_BookmarkList.size(); iBookmark++)
@@ -172,16 +172,16 @@ bool Bookmarks::save()
         for (QSet<TagInfo*>::iterator i = usedTags.begin(); i != usedTags.end(); i++)
         {
             TagInfo& info = **i;
-            stream << info.name.leftJustified(20) + "; " + info.color.name() << endl;
+            stream << info.name.leftJustified(20) + "; " + info.color.name() << '\n';
         }
 
-        stream << endl;
+        stream << '\n';
 
         stream << QString("# Frequency").leftJustified(12) + "; " +
                   QString("Name").leftJustified(25)+ "; " +
                   QString("Modulation").leftJustified(20) + "; " +
                   QString("Bandwidth").rightJustified(10) + "; " +
-                  QString("Tags") << endl;
+                  QString("Tags") << '\n';
 
         for (int i = 0; i < m_BookmarkList.size(); i++)
         {
@@ -200,7 +200,7 @@ bool Bookmarks::save()
                 line.append(tag.name);
             }
 
-            stream << line << endl;
+            stream << line << '\n';
         }
 
         file.close();

--- a/src/qtgui/bookmarkstaglist.cpp
+++ b/src/qtgui/bookmarkstaglist.cpp
@@ -162,23 +162,20 @@ void BookmarksTagList::setSelectedTags(QList<TagInfo*> tags)
     setSortingEnabled(true);
 }
 
-QString BookmarksTagList::getSelectedTagsAsString()
+QStringList BookmarksTagList::getSelectedTags()
 {
-    QString strResult;
+    QStringList tags;
 
     int iRows = rowCount();
-    bool bFirst = true;
     for(int i=0; i<iRows; ++i)
     {
         QTableWidgetItem* pItem = item(i,1);
         if(pItem->checkState() == Qt::Checked)
         {
-            if(!bFirst) strResult += ", ";
-            strResult += pItem->text();
-            bFirst = false;
+            tags << pItem->text();
         }
     }
-    return strResult;
+    return tags;
 }
 
 void BookmarksTagList::ShowContextMenu(const QPoint& pos)

--- a/src/qtgui/bookmarkstaglist.h
+++ b/src/qtgui/bookmarkstaglist.h
@@ -32,7 +32,7 @@ class BookmarksTagList : public QTableWidget
     Q_OBJECT
 public:
     explicit BookmarksTagList(QWidget *parent = 0, bool bShowUntagged = true);
-    QString getSelectedTagsAsString();
+    QStringList getSelectedTags();
     void setSelectedTagsAsString(const QString& strTags);
     void setSelectedTags(QList<TagInfo*> tags);
     bool m_bUpdating;

--- a/src/qtgui/dockbookmarks.cpp
+++ b/src/qtgui/dockbookmarks.cpp
@@ -233,7 +233,7 @@ void ComboBoxDelegateModulation::setModelData(QWidget *editor, QAbstractItemMode
 void DockBookmarks::changeBookmarkTags(int row, int /*column*/)
 {
     bool ok = false;
-    QString tags; // list of tags separated by comma
+    QStringList tags;
 
     int iIdx = bookmarksTableModel->GetBookmarksIndexForRow(row);
     BookmarkInfo& bmi = Bookmarks::Get().getBookmark(iIdx);
@@ -261,19 +261,17 @@ void DockBookmarks::changeBookmarkTags(int row, int /*column*/)
         ok = dialog.exec();
         if (ok)
         {
-            tags = taglist->getSelectedTagsAsString();
-            // list of selected tags is now in string 'tags'.
+            tags = taglist->getSelectedTags();
 
             // Change Tags of Bookmark
-            QStringList listTags = tags.split(",",QString::SkipEmptyParts);
             bmi.tags.clear();
-            if (listTags.size() == 0)
+            if (tags.size() == 0)
             {
                 bmi.tags.append(&Bookmarks::Get().findOrAddTag("")); // "Untagged"
             }
-            for (int i = 0; i < listTags.size(); ++i)
+            for (int i = 0; i < tags.size(); ++i)
             {
-                bmi.tags.append(&Bookmarks::Get().findOrAddTag(listTags[i]));
+                bmi.tags.append(&Bookmarks::Get().findOrAddTag(tags[i]));
             }
             Bookmarks::Get().save();
         }

--- a/src/qtgui/dxc_options.cpp
+++ b/src/qtgui/dxc_options.cpp
@@ -115,7 +115,11 @@ void DXCOptions::readyToRead()
         else if(incomingMessage.contains("DX de", Qt::CaseInsensitive) &&
                 incomingMessage.contains(ui->lineEdit_DXCFilter->text()))
         {
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
             spot = incomingMessage.split(" ", QString::SkipEmptyParts);
+#else
+            spot = incomingMessage.split(" ", Qt::SkipEmptyParts);
+#endif
             if (spot.length() >= 5)
             {
                 info.name = spot[4].trimmed();

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -86,7 +86,7 @@ QSize CFreqCtrl::sizeHint() const
     return QSize(100, 20);
 }
 
-bool CFreqCtrl::inRect(QRect &rect, QPoint &point)
+bool CFreqCtrl::inRect(QRect &rect, QPointF &point)
 {
     if ((point.x() < rect.right()) && (point.x() > rect.x()) &&
         (point.y() < rect.bottom()) && (point.y() > rect.y()))
@@ -417,7 +417,7 @@ void CFreqCtrl::paintEvent(QPaintEvent *)
 
 void CFreqCtrl::mouseMoveEvent(QMouseEvent *event)
 {
-    QPoint    pt = event->pos();
+    QPointF pt = event->localPos();
     // find which digit is to be edited
     if (isActiveWindow())
     {
@@ -436,7 +436,7 @@ void CFreqCtrl::mouseMoveEvent(QMouseEvent *event)
 
 void CFreqCtrl::mousePressEvent(QMouseEvent *event)
 {
-    QPoint    pt = event->pos();
+    QPointF pt = event->localPos();
     if (event->button() == Qt::LeftButton)
     {
         for (int i = m_DigStart; i < m_NumDigits; i++)
@@ -478,7 +478,11 @@ void CFreqCtrl::mousePressEvent(QMouseEvent *event)
 
 void CFreqCtrl::wheelEvent(QWheelEvent *event)
 {
-    QPoint    pt = event->pos();
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    QPointF   pt = QPointF(event->pos());
+#else
+    QPointF   pt = event->position();
+#endif
     int       delta = m_InvertScrolling ? -event->angleDelta().y() : event->angleDelta().y();
     int       numDegrees = delta / 8;
     int       numSteps = numDegrees / 15;

--- a/src/qtgui/freqctrl.h
+++ b/src/qtgui/freqctrl.h
@@ -85,7 +85,7 @@ private:
     void    cursorEnd();
     void    moveCursorLeft();
     void    moveCursorRight();
-    bool    inRect(QRect &rect, QPoint &point);
+    bool    inRect(QRect &rect, QPointF &point);
     void    setActiveDigit(int idx);
 
     bool        m_UpdateAll;

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -790,7 +790,11 @@ void CPlotter::zoomOnXAxis(float level)
 // Called when a mouse wheel is turned
 void CPlotter::wheelEvent(QWheelEvent * event)
 {
-    QPoint pt = event->pos();
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    QPointF pt = QPointF(event->pos());
+#else
+    QPointF pt = event->position();
+#endif
     int delta = m_InvertScrolling? -event->angleDelta().y() : event->angleDelta().y();
     int numDegrees = delta / 8;
     int numSteps = numDegrees / 15;  /** FIXME: Only used for direction **/


### PR DESCRIPTION
I'd like to update Gqrx to Qt 6, because development on Qt 5 has now stopped. Updating will also make it possible to solve the UI bug reported in #1073.

According to the [Qt 6 porting guide](https://doc.qt.io/qt-6/portingguide.html), the first step is to remove use of deprecated API, as reported by Qt 5.15. I've done that here, with each commit addressing one source of deprecation warnings.

I'll merge this once CI is happy and I've had a chance to test the parts that have changed.