### PR TITLE
Add bounds checks to prevent integer overflows

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.15.8: In progress...
+
+     FIXED: Crash when DSP is restarted after a long pause.
+
+
     2.15.7: Released January 23, 2022
 
      FIXED: Errors & warnings in appstream metadata & desktop entry.

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -119,6 +119,7 @@ void rx_fft_c::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
 
     std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
     std::chrono::duration<double> diff = now - d_lasttime;
+    diff = std::min(diff, std::chrono::duration<double>(d_writer->bufsize() / d_quadrate));
     d_lasttime = now;
 
     /* perform FFT */
@@ -318,6 +319,7 @@ void rx_fft_f::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
 
     std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
     std::chrono::duration<double> diff = now - d_lasttime;
+    diff = std::min(diff, std::chrono::duration<double>(d_writer->bufsize() / d_audiorate));
     d_lasttime = now;
 
     /* perform FFT */


### PR DESCRIPTION
Fixes #1078.

Integer overflows can happen in these two places, if the DSP is paused for long enough:

https://github.com/gqrx-sdr/gqrx/blob/60f6910bf65bad6129ef41af440dbceacd3b93dc/src/dsp/rx_fft.cpp#L125

https://github.com/gqrx-sdr/gqrx/blob/60f6910bf65bad6129ef41af440dbceacd3b93dc/src/dsp/rx_fft.cpp#L324

To fix this, I've added a bounds check to `diff` to ensure that it can't be longer than the duration necessary to fill the entire circular buffer.