### PR TITLE
Remove dependency on QRegExp

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
     2.15.8: In progress...
 
      FIXED: Crash when DSP is restarted after a long pause.
+     FIXED: Remove usage of deprecated Qt APIs.
 
 
     2.15.7: Released January 23, 2022

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -519,14 +519,7 @@ bool MainWindow::loadConfig(const QString& cfgfile, bool check_crash,
         }
 
         // Update window title
-        QRegExp regexp(R"('([a-zA-Z0-9 \-\_\/\.\,\(\)]+)')");
-        QString devlabel;
-        if (regexp.indexIn(indev, 0) != -1)
-            devlabel = regexp.cap(1);
-        else
-            devlabel = indev; //"Unknown";
-
-        setWindowTitle(QString("Gqrx %1 - %2").arg(VERSION).arg(devlabel));
+        setWindowTitle(QString("Gqrx %1 - %2").arg(VERSION).arg(indev));
 
         // Add available antenna connectors to the UI
         std::vector<std::string> antennas = rx->get_antennas();

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -627,13 +627,13 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
     {
         answer = QString("%1\n").arg(squelch_level, 0, 'f', 1);
     }
-    else if (lvl.contains(QRegExp("_GAIN$")))
+    else if (lvl.endsWith("_GAIN"))
     {
-        QString name = lvl.remove(QRegExp("_GAIN$"));
+        lvl.chop(5);
         answer = QString("RPRT 1\n");
         for(auto &g : gains)
         {
-            if(name == QString::fromStdString(g.name))
+            if(lvl == QString::fromStdString(g.name))
             {
                 answer = QString("%1\n").arg(g.value);
                 break;
@@ -676,13 +676,13 @@ QString RemoteControl::cmd_set_level(QStringList cmdlist)
             answer = QString("RPRT 1\n");
         }
     }
-    else if (lvl.contains(QRegExp("_GAIN$")))
+    else if (lvl.endsWith("_GAIN"))
     {
-        QString name = lvl.remove(QRegExp("_GAIN$"));
+        lvl.chop(5);
 
         bool ok;
         double gain = cmdlist.value(2, "ERR").toDouble(&ok);
-        if (ok && setGain(name, gain))
+        if (ok && setGain(lvl, gain))
             answer = QString("RPRT 0\n");
         else
             answer = QString("RPRT 1\n");

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -24,7 +24,6 @@
 #include <QDebug>
 #include <QFile>
 #include <QPushButton>
-#include <QRegExp>
 #include <QSettings>
 #include <QString>
 #include <QtGlobal>


### PR DESCRIPTION
This is a continuation of the Qt modernization work started in #1079, which should eventually allow #1073 to be solved.

QRegExp has been removed from Qt 6 and replaced with QRegularExpression. Although we could switch, it's just as easy to remove Gqrx's dependency on regular expression processing.

In the RemoteControl class, we ean easily replace the regular expressions with ordinary string processing functions. The MainWindow class tries to extract a single-quoted portion of the device string for display in the window title, but this doesn't seem useful (and could do more harm than good). I've changed it to always display the raw device string.