### PR TITLE
Remove deprecated BackgroundColorRole

### DIFF
--- a/src/qtgui/bookmarkstablemodel.cpp
+++ b/src/qtgui/bookmarkstablemodel.cpp
@@ -75,7 +75,7 @@ QVariant BookmarksTableModel::data ( const QModelIndex & index, int role ) const
 {
     BookmarkInfo& info = *m_Bookmarks[index.row()];
 
-    if(role==Qt::BackgroundColorRole)
+    if(role==Qt::BackgroundRole)
     {
         QColor bg(info.GetColor());
         bg.setAlpha(0x60);


### PR DESCRIPTION
This is a continuation of the Qt modernization work started in #1079, which should eventually allow #1073 to be solved.

BackgroundColorRole no longer exists in Qt 6; the Qt 5 documentation states that BackgroundRole should be used instead.