### PR TITLE
Fix deprecation in QtColorPicker

### DIFF
--- a/src/qtgui/qtcolorpicker.cpp
+++ b/src/qtgui/qtcolorpicker.cpp
@@ -860,7 +860,7 @@ void ColorPickerPopup::regenerateGrid()
     // one.
     if (grid) delete grid;
     grid = new QGridLayout(this);
-    grid->setMargin(1);
+    grid->setContentsMargins(1, 1, 1, 1);
     grid->setSpacing(0);
 
     int ccol = 0, crow = 0;


### PR DESCRIPTION
This is a continuation of the Qt modernization work started in #1079, which should eventually allow #1073 to be solved.

The setMargin method in QGridLayout is deprecated and replaced by setContentsMargin. After this change, Gqrx builds against Qt 6!