### PR TITLE
Fix remaining Qt 6 deprecation warnings

### DIFF
--- a/src/applications/gqrx/main.cpp
+++ b/src/applications/gqrx/main.cpp
@@ -56,7 +56,9 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationDomain(GQRX_ORG_DOMAIN);
     QCoreApplication::setApplicationName(GQRX_APP_NAME);
     QCoreApplication::setApplicationVersion(VERSION);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
+#endif
     QLoggingCategory::setFilterRules("*.debug=false");
 
     QString plugin_path = QDir::cleanPath(QCoreApplication::applicationDirPath() + "/../soapy-modules");

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -417,7 +417,11 @@ void CFreqCtrl::paintEvent(QPaintEvent *)
 
 void CFreqCtrl::mouseMoveEvent(QMouseEvent *event)
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QPointF pt = event->localPos();
+#else
+    QPointF pt = event->position();
+#endif
     // find which digit is to be edited
     if (isActiveWindow())
     {
@@ -436,7 +440,11 @@ void CFreqCtrl::mouseMoveEvent(QMouseEvent *event)
 
 void CFreqCtrl::mousePressEvent(QMouseEvent *event)
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QPointF pt = event->localPos();
+#else
+    QPointF pt = event->position();
+#endif
     if (event->button() == Qt::LeftButton)
     {
         for (int i = m_DigStart; i < m_NumDigits; i++)

--- a/src/qtgui/ioconfig.ui
+++ b/src/qtgui/ioconfig.ui
@@ -67,7 +67,7 @@
          <string>Select an input device</string>
         </property>
         <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         <enum>QComboBox::AdjustToContents</enum>
         </property>
         <property name="minimumContentsLength">
          <number>15</number>
@@ -292,7 +292,7 @@
 Leave it at default unless you know what you are doing.</string>
         </property>
         <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         <enum>QComboBox::AdjustToContents</enum>
         </property>
         <property name="minimumContentsLength">
          <number>15</number>

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -228,10 +228,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                     setCursor(QCursor(Qt::SizeHorCursor));
                 m_CursorCaptured = CENTER;
                 if (m_TooltipsEnabled)
-                    QToolTip::showText(event->globalPos(),
-                                       QString("Demod: %1 kHz")
-                                               .arg(m_DemodCenterFreq/1.e3, 0, 'f', 3),
-                                       this);
+                    showToolTip(event, QString("Demod: %1 kHz").arg(m_DemodCenterFreq/1.e3, 0, 'f', 3));
             }
             else if (isPointCloseTo(pt.x(), m_DemodHiCutFreqX, m_CursorCaptureDelta))
             {
@@ -240,10 +237,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                     setCursor(QCursor(Qt::SizeFDiagCursor));
                 m_CursorCaptured = RIGHT;
                 if (m_TooltipsEnabled)
-                    QToolTip::showText(event->globalPos(),
-                                       QString("High cut: %1 Hz")
-                                               .arg(m_DemodHiCutFreq),
-                                       this);
+                    showToolTip(event, QString("High cut: %1 Hz").arg(m_DemodHiCutFreq));
             }
             else if (isPointCloseTo(pt.x(), m_DemodLowCutFreqX, m_CursorCaptureDelta))
             {
@@ -252,10 +246,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                     setCursor(QCursor(Qt::SizeBDiagCursor));
                 m_CursorCaptured = LEFT;
                 if (m_TooltipsEnabled)
-                    QToolTip::showText(event->globalPos(),
-                                       QString("Low cut: %1 Hz")
-                                               .arg(m_DemodLowCutFreq),
-                                       this);
+                    showToolTip(event, QString("Low cut: %1 Hz").arg(m_DemodLowCutFreq));
             }
             else
             {	//if not near any grab boundaries
@@ -277,7 +268,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                         for (auto & hoverBand : hoverBands)
                             toolTipText.append("\n" + hoverBand.name);
                     }
-                    QToolTip::showText(event->globalPos(), toolTipText, this);
+                    showToolTip(event, toolTipText);
                 }
             }
             m_GrabPosition = 0;
@@ -299,11 +290,9 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
             QDateTime tt;
             tt.setMSecsSinceEpoch(msecFromY(pt.y()));
 
-            QToolTip::showText(event->globalPos(),
-                               QString("%1\n%2 kHz")
+            showToolTip(event, QString("%1\n%2 kHz")
                                        .arg(tt.toString("yyyy.MM.dd hh:mm:ss.zzz"))
-                                       .arg(freqFromX(pt.x())/1.e3, 0, 'f', 3),
-                               this);
+                                       .arg(freqFromX(pt.x())/1.e3, 0, 'f', 3));
         }
     }
     // process mouse moves while in cursor capture modes
@@ -1772,6 +1761,15 @@ void CPlotter::calcDivSize (qint64 low, qint64 high, int divswanted, qint64 &adj
     qCDebug(plotter) << "adjlow:" << adjlow;
     qCDebug(plotter) << "step:" << step;
     qCDebug(plotter) << "divs:" << divs;
+}
+
+void CPlotter::showToolTip(QMouseEvent* event, QString toolTipText)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QToolTip::showText(event->globalPos(), toolTipText, this);
+#else
+    QToolTip::showText(event->globalPosition().toPoint(), toolTipText, this);
+#endif
 }
 
 // contributed by Chris Kuethe @ckuethe

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -196,6 +196,7 @@ private:
                                  float *inBuf, qint32 *outBuf,
                                  qint32 *maxbin, qint32 *minbin) const;
     static void calcDivSize (qint64 low, qint64 high, int divswanted, qint64 &adjlow, qint64 &step, int& divs);
+    void        showToolTip(QMouseEvent* event, QString toolTipText);
 
     bool        m_PeakHoldActive;
     bool        m_PeakHoldValid;


### PR DESCRIPTION
This is a continuation of the Qt modernization work started in #1079, which should eventually allow #1073 to be solved.

This should address all the remaining deprecation warnings, giving a clean build in both Qt 5.15 and Qt 6.2.