### PR TITLE
Return correct RDS status in remote control

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
      FIXED: Crash when DSP is restarted after a long pause.
      FIXED: Remove usage of deprecated Qt APIs.
+     FIXED: Return correct RDS status in remote control.
   IMPROVED: Allow ordinary IP addresses to be used in remote control settings.
 
 

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -289,7 +289,6 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
 
     // remote control
     connect(remote, SIGNAL(newRDSmode(bool)), uiDockRDS, SLOT(setRDSmode(bool)));
-    connect(uiDockRDS, SIGNAL(rdsDecoderToggled(bool)), remote, SLOT(setRDSstatus(bool)));
     connect(remote, SIGNAL(newFilterOffset(qint64)), this, SLOT(setFilterOffset(qint64)));
     connect(remote, SIGNAL(newFilterOffset(qint64)), uiDockRxOpt, SLOT(setFilterOffset(qint64)));
     connect(remote, SIGNAL(newFrequency(qint64)), ui->freqCtrl, SLOT(setFrequency(qint64)));
@@ -2161,6 +2160,7 @@ void MainWindow::setRdsDecoder(bool checked)
         rx->stop_rds_decoder();
         rds_timer->stop();
     }
+    remote->setRDSstatus(checked);
 }
 
 void MainWindow::onBookmarkActivated(qint64 freq, const QString& demod, int bandwidth)

--- a/src/qtgui/dockrds.cpp
+++ b/src/qtgui/dockrds.cpp
@@ -143,13 +143,6 @@ void DockRDS::setRDSmode(bool cmd)
 {
     if (!ui->rdsCheckbox->isEnabled())
         return;
-    if (cmd == ui->rdsCheckbox->isChecked())
-        return;
 
-    ui->rdsCheckbox->setDisabled(true);
-    ui->rdsCheckbox->blockSignals(true);
-    emit rdsDecoderToggled(cmd);
     ui->rdsCheckbox->setChecked(cmd);
-    ui->rdsCheckbox->blockSignals(false);
-    ui->rdsCheckbox->setEnabled(true);
 }


### PR DESCRIPTION
#956 added remote control commands to enable & disable RDS, and fetch the program ID. I recently noticed a bug: if RDS is enabled using the GUI, and then the mode is switched (thereby disabling RDS), the the `u RDS` command incorrectly returns 1. This happens because the RDS status is only sent to the remote when the user clicks the RDS checkbox. To fix this, I've moved the `setRDSstatus` call to the place where RDS is actually turned on and off, namely `MainWindow::setRdsDecoder`.

I also noticed that the `DockRDS::setRDSmode` method is unnecessarily complicated; it blocks signals before toggling the UI checkbox and then manually emits the `rdsDecoderToggled` signal. We can instead leave signals enabled and just toggle the checkbox, which will result in `DockRDS::on_rdsCheckbox_toggled` sending the same signal.

/cc @kb8u-gqrx 