### PR TITLE
Build against Qt6 if it is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,13 @@ endfunction(add_source_files)
 
 if(APPLE AND EXISTS /usr/local/opt/qt5)
     # Homebrew installs Qt5 (up to at least 5.9.1) in
-    # /usr/local/qt5, ensure it can be found by CMake since
+    # /usr/local/opt/qt5, ensure it can be found by CMake since
     # it is not in the default /usr/local prefix.
     list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
+endif()
+
+if(APPLE AND EXISTS /usr/local/opt/qt6)
+    list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt6")
 endif()
 
 if(APPLE AND EXISTS /usr/local/opt/icu4c/lib)
@@ -117,7 +121,10 @@ else()
 endif()
 
 # 3rd Party Dependency Stuff
-find_package(Qt5 COMPONENTS Core Network Widgets Svg REQUIRED)
+find_package(Qt6 QUIET COMPONENTS Core Network Widgets Svg SvgWidgets)
+if(NOT Qt6_FOUND)
+    find_package(Qt5 REQUIRED COMPONENTS Core Network Widgets Svg)
+endif()
 include(FindPkgConfig)
 find_package(Gnuradio-osmosdr REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,16 +29,29 @@ get_property(${PROJECT_NAME}_UI_SOURCE GLOBAL PROPERTY UI_SRCS_LIST)
 
 ###############################################################################
 # Process the UI files
-QT5_WRAP_UI(UIS_HDRS
-    ${${PROJECT_NAME}_UI_SOURCE}
-)
+if(Qt6_FOUND)
+    QT_WRAP_UI(UIS_HDRS
+        ${${PROJECT_NAME}_UI_SOURCE}
+    )
+else()
+    QT5_WRAP_UI(UIS_HDRS
+        ${${PROJECT_NAME}_UI_SOURCE}
+    )
+endif()
 
 ###############################################################################
 # Process the resources
-QT5_ADD_RESOURCES(RESOURCES_LIST
-    ../resources/icons.qrc
-    ../resources/textfiles.qrc
-)
+if(Qt6_FOUND)
+    QT_ADD_RESOURCES(RESOURCES_LIST
+        ../resources/icons.qrc
+        ../resources/textfiles.qrc
+    )
+else()
+    QT5_ADD_RESOURCES(RESOURCES_LIST
+        ../resources/icons.qrc
+        ../resources/textfiles.qrc
+    )
+endif()
 
 ###############################################################################
 # Resource file - adds an icon to GQRX executable
@@ -56,14 +69,32 @@ endif(WIN32)
 ###############################################################################
 # Build the program
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCE} ${UIS_HDRS} ${RESOURCES_LIST})
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
+if(Qt6_FOUND)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+else()
+    set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
+endif()
 # The pulse libraries are only needed on Linux. On other platforms they will
 # not be found, so having them here is fine.
+
+if(Qt6_FOUND)
+    target_link_libraries(${PROJECT_NAME}
+        Qt6::Core
+        Qt6::Network
+        Qt6::Widgets
+        Qt6::Svg
+        Qt6::SvgWidgets
+    )
+else()
+    target_link_libraries(${PROJECT_NAME}
+        Qt5::Core
+        Qt5::Network
+        Qt5::Widgets
+        Qt5::Svg
+    )
+endif()
+
 target_link_libraries(${PROJECT_NAME}
-    Qt5::Core
-    Qt5::Network
-    Qt5::Widgets
-    Qt5::Svg
     ${GNURADIO_OSMOSDR_LIBRARIES}
     ${PULSEAUDIO_LIBRARY}
     ${PULSE-SIMPLE}


### PR DESCRIPTION
This is a continuation of the Qt modernization work started in #1079, which should eventually allow #1073 to be solved.

Here I've updated the CMake build to use Qt6 if it is available. I've tested this on Arch Linux, where Qt6 is available in the package manager (`pacman -S qt6-base qt6-svg`), and Gqrx works well. I haven't spotted any bugs yet.