### PR TITLE
Fix compilation on Qt < 5.8

### DIFF
--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -171,7 +171,11 @@ void RemoteControl::acceptConnection()
 
     for (auto allowed_host : rc_allowed_hosts)
     {
+#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
+        if (address == QHostAddress(allowed_host))
+#else
         if (address.isEqual(QHostAddress(allowed_host)))
+#endif
         {
             connect(rc_socket, SIGNAL(readyRead()), this, SLOT(startRead()));
             return;


### PR DESCRIPTION
Use QHostAddress::operator==(const QHostAddress &) instead of isEqual(const QHostAddress &)on Qt < 5.8

Fix regression introduced in 5e92357.
Close https://github.com/gqrx-sdr/gqrx/issues/1091