### PR TITLE
Stop building airspyhf, dylibbundler, and portaudio from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,19 +86,9 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install --HEAD --build-from-source dylibbundler portaudio
-          brew install airspy boost gnuradio hackrf libbladerf librtlsdr libserialport pybind11 uhd
+          brew install airspy airspyhf boost dylibbundler gnuradio hackrf libbladerf librtlsdr libserialport portaudio pybind11 uhd
           brew tap pothosware/homebrew-pothos
           brew install soapysdr soapyremote
-
-          cd /tmp
-          git clone https://github.com/airspy/airspyhf.git
-          cd airspyhf
-          mkdir build
-          cd build
-          cmake ..
-          make -j4
-          make install
 
           cd /tmp
           git clone https://github.com/analogdevicesinc/libiio.git


### PR DESCRIPTION
The following packages no longer need to be built from source:

* airspyhf: A homebrew package did not exist when I added airspyhf support in e21ddbaeac71c6d4aee73c24317d3cbd5e93f400, but now it does: https://formulae.brew.sh/formula/airspyhf
* dylibbundler: The homebrew release used to be too old to include the required features, but now it's good.
* portaudio: The version in Homebrew did not work with Big Sur (#904) but now it's been updated.

I test a build using the homebrew versions of these packages, and both audio and Airspy HF support are working properly.