### PR TITLE
Build against Qt6 on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install airspy airspyhf boost dylibbundler gnuradio hackrf libbladerf librtlsdr libserialport portaudio pybind11 uhd
+          brew install airspy airspyhf boost dylibbundler gnuradio hackrf libbladerf librtlsdr libserialport portaudio pybind11 uhd qt@6
           brew tap pothosware/homebrew-pothos
           brew install soapysdr soapyremote
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install airspy boost gnuradio hackrf libbladerf librtlsdr pybind11 uhd
+          brew install airspy boost gnuradio hackrf libbladerf librtlsdr pybind11 uhd qt@6
 
           cd /tmp
           git clone git://git.osmocom.org/gr-osmosdr

--- a/macos_bundle.sh
+++ b/macos_bundle.sh
@@ -55,9 +55,11 @@ chmod 644 Gqrx.app/Contents/soapy-modules/*
 
 dylibbundler -s /usr/local/opt/icu4c/lib/ -od -b -x Gqrx.app/Contents/MacOS/gqrx -x Gqrx.app/Contents/soapy-modules/libPlutoSDRSupport.so -x Gqrx.app/Contents/soapy-modules/libremoteSupport.so -d Gqrx.app/Contents/libs/
 ln -sf /usr/local/opt/python@3.9/Frameworks/Python.framework /usr/local/opt/python@3.9/lib/Python.framework
-/usr/local/opt/qt@5/bin/macdeployqt Gqrx.app -no-strip -always-overwrite -sign-for-notarization=$IDENTITY
+/usr/local/opt/qt@6/bin/macdeployqt Gqrx.app -no-strip -always-overwrite
+/usr/local/opt/qt@6/bin/macdeployqt Gqrx.app -no-strip -always-overwrite -sign-for-notarization=$IDENTITY
+cp /usr/local/lib/libbrotlicommon.1.dylib Gqrx.app/Contents/Frameworks
 
-for f in Gqrx.app/Contents/libs/*.dylib Gqrx.app/Contents/soapy-modules/*.so Gqrx.app/Contents/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python Gqrx.app/Contents/Frameworks/*.framework Gqrx.app/Contents/MacOS/gqrx
+for f in Gqrx.app/Contents/libs/*.dylib Gqrx.app/Contents/soapy-modules/*.so Gqrx.app/Contents/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python Gqrx.app/Contents/Frameworks/*.framework Gqrx.app/Contents/Frameworks/libbrotlicommon.1.dylib Gqrx.app/Contents/MacOS/gqrx
 do
     codesign --force --verify --verbose --timestamp --options runtime --entitlements /tmp/Entitlements.plist --sign $IDENTITY $f
 done

--- a/macos_bundle.sh
+++ b/macos_bundle.sh
@@ -55,9 +55,9 @@ chmod 644 Gqrx.app/Contents/soapy-modules/*
 
 dylibbundler -s /usr/local/opt/icu4c/lib/ -od -b -x Gqrx.app/Contents/MacOS/gqrx -x Gqrx.app/Contents/soapy-modules/libPlutoSDRSupport.so -x Gqrx.app/Contents/soapy-modules/libremoteSupport.so -d Gqrx.app/Contents/libs/
 ln -sf /usr/local/opt/python@3.9/Frameworks/Python.framework /usr/local/opt/python@3.9/lib/Python.framework
-/usr/local/opt/qt@6/bin/macdeployqt Gqrx.app -no-strip -always-overwrite
+/usr/local/opt/qt@6/bin/macdeployqt Gqrx.app -no-strip -always-overwrite # TODO: Remove macdeployqt workaround
 /usr/local/opt/qt@6/bin/macdeployqt Gqrx.app -no-strip -always-overwrite -sign-for-notarization=$IDENTITY
-cp /usr/local/lib/libbrotlicommon.1.dylib Gqrx.app/Contents/Frameworks
+cp /usr/local/lib/libbrotlicommon.1.dylib Gqrx.app/Contents/Frameworks # TODO: Remove macdeployqt workaround
 
 for f in Gqrx.app/Contents/libs/*.dylib Gqrx.app/Contents/soapy-modules/*.so Gqrx.app/Contents/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python Gqrx.app/Contents/Frameworks/*.framework Gqrx.app/Contents/Frameworks/libbrotlicommon.1.dylib Gqrx.app/Contents/MacOS/gqrx
 do

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,10 @@
 
+    2.15.9: In progress...
+
+       NEW: Qt 6 support.
+     FIXED: Slider widgets don't work correctly on MacOS Monterey.
+
+
     2.15.8: Released January 25, 2022
 
      FIXED: Crash when DSP is restarted after a long pause.


### PR DESCRIPTION
Fixes #1073.

Now that Gqrx has been updated with Qt6 support (#1079, #1081, #1082, #1083, #1084, #1085, #1086, #1087, #1090), we should be able to switch over the macOS build.

For some reason, macdeployqt fails with a bunch of errors on the first run:
```
ERROR: Cannot resolve rpath "@rpath/QtGui.framework/Versions/A/QtGui"
ERROR:  using QSet("/Users/runner/work/gqrx/gqrx/lib")
ERROR: Cannot resolve rpath "@rpath/QtCore.framework/Versions/A/QtCore"
ERROR:  using QSet("/Users/runner/work/gqrx/gqrx/lib")
...
```
Running it a second time works around that problem.

Also, macdeployqt fails to copy in the libbrotlicommon.1.dylib dependency, so I've added a step to manually copy it over and sign it.

I've added reminders to remove both of these workarounds once macdeployqt is updated or a better solution is found.

I'd appreciate help testing the new build, which is available at the bottom of this page: https://github.com/gqrx-sdr/gqrx/actions/runs/1758484287