### PR TITLE
Stop using obsolete QComboBox signals

### DIFF
--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -380,18 +380,18 @@ void DockFft::setZoomLevel(float level)
 }
 
 /** FFT size changed. */
-void DockFft::on_fftSizeComboBox_currentIndexChanged(const QString &text)
+void DockFft::on_fftSizeComboBox_currentIndexChanged(int index)
 {
-    int value = text.toInt();
+    int value = ui->fftSizeComboBox->itemText(index).toInt();
     emit fftSizeChanged(value);
     updateInfoLabels();
 }
 
 /** FFT rate changed. */
-void DockFft::on_fftRateComboBox_currentIndexChanged(const QString & text)
+void DockFft::on_fftRateComboBox_currentIndexChanged(int index)
 {
     int fps = fftRate();
-    Q_UNUSED(text);
+    Q_UNUSED(index);
 
     emit fftRateChanged(fps);
     updateInfoLabels();

--- a/src/qtgui/dockfft.h
+++ b/src/qtgui/dockfft.h
@@ -77,8 +77,8 @@ public slots:
     void setZoomLevel(float level);
 
 private slots:
-    void on_fftSizeComboBox_currentIndexChanged(const QString & text);
-    void on_fftRateComboBox_currentIndexChanged(const QString & text);
+    void on_fftSizeComboBox_currentIndexChanged(int index);
+    void on_fftRateComboBox_currentIndexChanged(int index);
     void on_fftWinComboBox_currentIndexChanged(int index);
     void on_wfSpanComboBox_currentIndexChanged(int index);
     void on_fftSplitSlider_valueChanged(int value);

--- a/src/qtgui/dockinputctl.cpp
+++ b/src/qtgui/dockinputctl.cpp
@@ -507,9 +507,9 @@ void DockInputCtl::on_ignoreButton_toggled(bool checked)
 }
 
 /** Antenna selection has changed. */
-void DockInputCtl::on_antSelector_currentIndexChanged(const QString &antenna)
+void DockInputCtl::on_antSelector_currentIndexChanged(int index)
 {
-    emit antennaSelected(antenna);
+    emit antennaSelected(ui->antSelector->itemText(index));
 }
 
 /** Reset box has changed */

--- a/src/qtgui/dockinputctl.h
+++ b/src/qtgui/dockinputctl.h
@@ -129,7 +129,7 @@ private slots:
     void on_dcCancelButton_toggled(bool checked);
     void on_iqBalanceButton_toggled(bool checked);
     void on_ignoreButton_toggled(bool checked);
-    void on_antSelector_currentIndexChanged(const QString &antenna);
+    void on_antSelector_currentIndexChanged(int index);
     void on_freqCtrlResetButton_toggled(bool checked);
     void on_invertScrollingButton_toggled(bool checked);
 


### PR DESCRIPTION
Fixes the issue described in this comment: https://github.com/gqrx-sdr/gqrx/pull/1094#issuecomment-1025176873

The `currentIndexChanged(const QString &text)` signal is obsolete in Qt5 and removed completely in Qt6. Instead we can use the `currentIndexChanged(int index)` signal.

After this change, it is possible to switch antenna inputs, and change FFT size & rate when Gqrx is built against Qt6.