### PR TITLE
Fix IQ Tool playback when input decimation is enabled

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1603,6 +1603,7 @@ void MainWindow::startIqPlayback(const QString& filename, float samprate, qint64
 
     qDebug() << __func__ << ":" << devstr;
 
+    rx->set_input_decim(1);
     rx->set_input_device(devstr.toStdString());
     updateHWFrequencyRange(false);
 


### PR DESCRIPTION
Disable the input decimation decimation before starting IQ playback.
This should make waterfall/panadapter frequency display and fix distorted sound.
Close https://github.com/gqrx-sdr/gqrx/issues/1140