### PR TITLE
Stop audio rec if dsp off

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -29,6 +29,10 @@ Supported commands:
     Get status of audio recorder
  U RECORD <status>
     Set status of audio recorder to <status>
+ u IQRECORD
+    Get status of IQ recorder
+ U IQRECORD <status>
+    Set status of IQ recorder to <status>
  u DSP
     Get DSP status
  U DSP <status>

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -281,8 +281,8 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(&DXCSpots::Get(), SIGNAL(dxcSpotsUpdated()), this, SLOT(updateClusterSpots()));
 
     // I/Q playback
-    connect(iq_tool, SIGNAL(startRecording(QString)), this, SLOT(startIqRecording(QString)));
-    connect(iq_tool, SIGNAL(stopRecording()), this, SLOT(stopIqRecording()));
+    connect(iq_tool, SIGNAL(startRecording(QString)), this, SLOT(startIqRec(QString)));
+    connect(iq_tool, SIGNAL(stopRecording()), this, SLOT(stopIqRec()));
     connect(iq_tool, SIGNAL(startPlayback(QString,float,qint64)), this, SLOT(startIqPlayback(QString,float,qint64)));
     connect(iq_tool, SIGNAL(stopPlayback()), this, SLOT(stopIqPlayback()));
     connect(iq_tool, SIGNAL(seek(qint64)), this,SLOT(seekIqFile(qint64)));
@@ -301,6 +301,8 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(uiDockRxOpt, SIGNAL(sqlLevelChanged(double)), remote, SLOT(setSquelchLevel(double)));
     connect(remote, SIGNAL(startAudioRecorderEvent()), uiDockAudio, SLOT(startAudioRecorder()));
     connect(remote, SIGNAL(stopAudioRecorderEvent()), uiDockAudio, SLOT(stopAudioRecorder()));
+    connect(remote, SIGNAL(startIqRecorderEvent()), iq_tool, SLOT(startIqRecorder()));
+    connect(remote, SIGNAL(stopIqRecorderEvent()), iq_tool, SLOT(stopIqRecorder()));
     connect(ui->plotter, SIGNAL(newFilterFreq(int, int)), remote, SLOT(setPassband(int, int)));
     connect(remote, SIGNAL(newPassband(int)), this, SLOT(setPassband(int)));
     connect(remote, SIGNAL(gainChanged(QString, double)), uiDockInputCtl, SLOT(setGain(QString,double)));
@@ -1540,7 +1542,7 @@ void MainWindow::stopAudioStreaming()
 }
 
 /** Start I/Q recording. */
-void MainWindow::startIqRecording(const QString& recdir)
+void MainWindow::startIqRec(const QString& recdir)
 {
     qDebug() << __func__;
     // generate file name using date, time, rf freq in kHz and BW in Hz
@@ -1574,7 +1576,7 @@ void MainWindow::startIqRecording(const QString& recdir)
 }
 
 /** Stop current I/Q recording. */
-void MainWindow::stopIqRecording()
+void MainWindow::stopIqRec()
 {
     qDebug() << __func__;
 

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -178,8 +178,8 @@ private slots:
     void stopAudioStreaming();
 
     /* I/Q playback and recording*/
-    void startIqRecording(const QString& recdir);
-    void stopIqRecording();
+    void startIqRec(const QString& recdir);
+    void stopIqRec();
     void startIqPlayback(const QString& filename, float samprate, qint64 center_freq);
     void stopIqPlayback();
     void seekIqFile(qint64 seek_pos);

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -733,17 +733,25 @@ QString RemoteControl::cmd_set_func(QStringList cmdlist)
     else if ((func.compare("RECORD", Qt::CaseInsensitive) == 0) && ok)
     {
         if (rc_mode == 0 || !receiver_running)
+        audio_recorder_status = status;
+        if (status)
         {
             answer = QString("RPRT 1\n");
+            if (rc_mode > 0 && receiver_running)
+            {
+                emit startAudioRecorderEvent();
+                answer = QString("RPRT 0\n");
+            }
+            else
+                answer = QString("RPRT 1\n");
         }
         else
         {
+            emit stopAudioRecorderEvent();
             answer = QString("RPRT 0\n");
             audio_recorder_status = status;
             if (status)
                 emit startAudioRecorderEvent();
-            else
-                emit stopAudioRecorderEvent();
         }
     }
     else if ((func.compare("DSP", Qt::CaseInsensitive) == 0) && ok)

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -94,6 +94,8 @@ public slots:
     void setSquelchLevel(double level);
     void startAudioRecorder(QString unused);
     void stopAudioRecorder();
+    void startIqRecorder(QString unused);
+    void stopIqRecorder();
     bool setGain(QString name, double gain);
     void setRDSstatus(bool enabled);
     void rdsPI(QString program_id);
@@ -107,6 +109,8 @@ signals:
     void newSquelchLevel(double level);
     void startAudioRecorderEvent();
     void stopAudioRecorderEvent();
+    void startIqRecorderEvent();
+    void stopIqRecorderEvent();
     void gainChanged(QString name, double value);
     void dspChanged(bool value);
     void newRDSmode(bool value);
@@ -135,6 +139,7 @@ private:
     double      squelch_level;     /*!< Squelch level in dBFS */
     QString     rc_program_id;     /*!< RDS Program identification */
     bool        audio_recorder_status; /*!< Recording enabled */
+    bool        iq_recorder_status;    /*!< Iq Recording enabled */
     bool        receiver_running;  /*!< Whether the receiver is running or not */
     bool        hamlib_compatible;
     gain_list_t gains;             /*!< Possible and current gain settings */

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -164,7 +164,6 @@ void CIqTool::on_slider_valueChanged(int value)
     emit seek(seek_pos);
 }
 
-
 /*! \brief Start/stop recording */
 void CIqTool::on_recButton_clicked(bool checked)
 {
@@ -183,6 +182,34 @@ void CIqTool::on_recButton_clicked(bool checked)
         ui->playButton->setEnabled(true);
         emit stopRecording();
     }
+}
+
+/*! Public slot to trig iq recording by external events (e.g. remote control).
+ *
+ * If a recording is already in progress we ignore the event.
+ */
+void CIqTool::startIqRecorder(void)
+{
+    if (ui->recButton->isChecked())
+    {
+        qDebug() << __func__ << "An iq recording is already in progress";
+        return;
+    }
+
+    // emulate a button click
+    ui->recButton->click();
+}
+
+/*! Public slot to stop stop recording by external events (e.g. remote control).
+ *
+ * The event is ignored if no recording is in progress.
+ */
+void CIqTool::stopIqRecorder(void)
+{
+    if (ui->recButton->isChecked())
+        ui->recButton->click(); // emulate a button click
+    else
+        qDebug() << __func__ << "No iq recording in progress";
 }
 
 /*! \brief Cancel a recording.

--- a/src/qtgui/iq_tool.h
+++ b/src/qtgui/iq_tool.h
@@ -71,6 +71,8 @@ signals:
 public slots:
     void cancelRecording();
     void cancelPlayback();
+    void startIqRecorder(void);     /*!< Used if Iq Recorder is started e.g from remote control */
+    void stopIqRecorder(void);      /*!< Used if Iq Recorder is stopped e.g. from remote control */
 
 private slots:
     void on_recDirEdit_textChanged(const QString &text);


### PR DESCRIPTION
Added a fix for audio recording: if dsp was stopped before audio recording, stopping of audio recording was no more possible, unless the dsp was started again. 