### PR TITLE
Add FFT control to remote control commands

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -307,6 +307,8 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(remote, SIGNAL(dspChanged(bool)), this, SLOT(on_actionDSP_triggered(bool)));
     connect(uiDockRDS, SIGNAL(rdsPI(QString)), remote, SLOT(rdsPI(QString)));
     connect(remote, SIGNAL(centerDemodViewEvent()), uiDockFft, SIGNAL(gotoDemodFreq()));
+    connect(remote, SIGNAL(resetFftZoomEvent()), uiDockFft, SIGNAL(resetFftZoom()));
+    connect(remote, SIGNAL(centerFftViewEvent()), uiDockFft, SIGNAL(gotoFftCenter()));
 
     rds_timer = new QTimer(this);
     connect(rds_timer, SIGNAL(timeout()), this, SLOT(rdsTimeout()));

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -309,6 +309,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(remote, SIGNAL(centerDemodViewEvent()), uiDockFft, SIGNAL(gotoDemodFreq()));
     connect(remote, SIGNAL(resetFftZoomEvent()), uiDockFft, SIGNAL(resetFftZoom()));
     connect(remote, SIGNAL(centerFftViewEvent()), uiDockFft, SIGNAL(gotoFftCenter()));
+    connect(remote, SIGNAL(fftZoomChangedEvent(float)), uiDockFft, SIGNAL(fftZoomChanged(float)));
 
     rds_timer = new QTimer(this);
     connect(rds_timer, SIGNAL(timeout()), this, SLOT(rdsTimeout()));

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -306,6 +306,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(remote, SIGNAL(gainChanged(QString, double)), uiDockInputCtl, SLOT(setGain(QString,double)));
     connect(remote, SIGNAL(dspChanged(bool)), this, SLOT(on_actionDSP_triggered(bool)));
     connect(uiDockRDS, SIGNAL(rdsPI(QString)), remote, SLOT(rdsPI(QString)));
+    connect(remote, SIGNAL(centerDemodViewEvent()), uiDockFft, SIGNAL(gotoDemodFreq()));
 
     rds_timer = new QTimer(this);
     connect(rds_timer, SIGNAL(timeout()), this, SLOT(rdsTimeout()));

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -242,8 +242,12 @@ void RemoteControl::startRead()
         answer = cmd_AOS();
     else if (cmd == "LOS")
         answer = cmd_LOS();
-    else if (cmd == "DC")
+    else if (cmd == "SDC")
         answer = cmd_set_demod_center();
+    else if (cmd == "RFZ")
+        answer = cmd_reset_FftZoom();
+    else if (cmd == "SFC")
+        answer = cmd_center_FftView();
     else if (cmd == "LNB_LO")
         answer = cmd_lnb_lo(cmdlist);
     else if (cmd == "\\dump_state")
@@ -855,6 +859,21 @@ QString RemoteControl::cmd_set_demod_center()
     emit centerDemodViewEvent();
     return QString("RPRT 0\n");
 }
+
+/* Centralize the demod window within the FFT window*/
+QString RemoteControl::cmd_reset_FftZoom()
+{
+    emit resetFftZoomEvent();
+    return QString("RPRT 0\n");
+}
+
+/* Centralize the demod window within the FFT window*/
+QString RemoteControl::cmd_center_FftView()
+{
+    emit centerFftViewEvent();
+    return QString("RPRT 0\n");
+}
+
 /* Set the LNB LO value */
 QString RemoteControl::cmd_lnb_lo(QStringList cmdlist)
 {

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -860,14 +860,14 @@ QString RemoteControl::cmd_set_demod_center()
     return QString("RPRT 0\n");
 }
 
-/* Centralize the demod window within the FFT window*/
+/* Reset zoom of FFT window*/
 QString RemoteControl::cmd_reset_FftZoom()
 {
     emit resetFftZoomEvent();
     return QString("RPRT 0\n");
 }
 
-/* Centralize the demod window within the FFT window*/
+/* Centralize the FFT window*/
 QString RemoteControl::cmd_center_FftView()
 {
     emit centerFftViewEvent();

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -246,6 +246,8 @@ void RemoteControl::startRead()
         answer = cmd_set_demod_center();
     else if (cmd == "RFZ")
         answer = cmd_reset_FftZoom();
+    else if (cmd == "SFZ")
+        answer = cmd_set_FftZoom(cmdlist);
     else if (cmd == "SFC")
         answer = cmd_center_FftView();
     else if (cmd == "LNB_LO")
@@ -285,6 +287,13 @@ void RemoteControl::setNewFrequency(qint64 freq)
 void RemoteControl::setFilterOffset(qint64 freq)
 {
     rc_filter_offset = freq;
+}
+
+/*! \brief Slot called when the FFT Zoom has changed
+ */
+void RemoteControl::setFFTZoomLevel(float level)
+{
+    fft_zoom_level = level;
 }
 
 /*! \brief Slot called when the LNB LO frequency has changed
@@ -896,6 +905,29 @@ QString RemoteControl::cmd_lnb_lo(QStringList cmdlist)
         return QString("%1\n").arg((qint64)(rc_lnb_lo_mhz * 1e6));
     }
 }
+/* Set the FFT zoom level */
+QString RemoteControl::cmd_set_FftZoom(QStringList cmdlist)
+{
+    if(cmdlist.size() == 2)
+    {
+        bool ok;
+        float zoom_lvl = cmdlist[1].toFloat(&ok);
+
+        if (ok)
+        {
+            fft_zoom_level = zoom_lvl;
+            emit fftZoomChangedEvent(fft_zoom_level);
+            return QString("RPRT 0\n");
+        }
+
+        return QString("RPRT 1\n");
+    }
+    else
+    {
+        return QString("%1\n").arg((float)(fft_zoom_level));
+    }
+}
+
 
 /*
  * '\dump_state' used by hamlib clients, e.g. xdx, fldigi, rigctl and etc

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -242,6 +242,8 @@ void RemoteControl::startRead()
         answer = cmd_AOS();
     else if (cmd == "LOS")
         answer = cmd_LOS();
+    else if (cmd == "DC")
+        answer = cmd_set_demod_center();
     else if (cmd == "LNB_LO")
         answer = cmd_lnb_lo(cmdlist);
     else if (cmd == "\\dump_state")
@@ -847,6 +849,12 @@ QString RemoteControl::cmd_LOS()
     return QString("RPRT 0\n");
 }
 
+/* Centralize the demod window within the FFT window*/
+QString RemoteControl::cmd_set_demod_center()
+{
+    emit centerDemodViewEvent();
+    return QString("RPRT 0\n");
+}
 /* Set the LNB LO value */
 QString RemoteControl::cmd_lnb_lo(QStringList cmdlist)
 {

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -92,6 +92,7 @@ public slots:
     void setMode(int mode);
     void setPassband(int passband_lo, int passband_hi);
     void setSquelchLevel(double level);
+    void setFFTZoomLevel(float level);
     void startAudioRecorder(QString unused);
     void stopAudioRecorder();
     bool setGain(QString name, double gain);
@@ -108,6 +109,7 @@ signals:
     void startAudioRecorderEvent();
     void stopAudioRecorderEvent();
     void centerDemodViewEvent();
+    void fftZoomChangedEvent(float zoom);
     void resetFftZoomEvent();
     void centerFftViewEvent();
     void gainChanged(QString name, double value);
@@ -129,6 +131,7 @@ private:
     qint64      rc_filter_offset;
     qint64      bw_half;
     double      rc_lnb_lo_mhz;     /*!< Current LNB LO freq in MHz */
+    float       fft_zoom_level;    /*!< Current FFT Zoom level */
 
     int         rc_mode;           /*!< Current mode. */
     int         rc_passband_lo;    /*!< Current low cutoff. */
@@ -165,6 +168,7 @@ private:
     QString     cmd_LOS();
     QString     cmd_set_demod_center();
     QString     cmd_reset_FftZoom();
+    QString     cmd_set_FftZoom(QStringList cmdlist);
     QString     cmd_center_FftView();
     QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -107,6 +107,7 @@ signals:
     void newSquelchLevel(double level);
     void startAudioRecorderEvent();
     void stopAudioRecorderEvent();
+    void centerDemodViewEvent();
     void gainChanged(QString name, double value);
     void dspChanged(bool value);
     void newRDSmode(bool value);
@@ -160,6 +161,7 @@ private:
     QString     cmd_get_param(QStringList cmdlist);
     QString     cmd_AOS();
     QString     cmd_LOS();
+    QString     cmd_set_demod_center();
     QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;
 };

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -108,6 +108,8 @@ signals:
     void startAudioRecorderEvent();
     void stopAudioRecorderEvent();
     void centerDemodViewEvent();
+    void resetFftZoomEvent();
+    void centerFftViewEvent();
     void gainChanged(QString name, double value);
     void dspChanged(bool value);
     void newRDSmode(bool value);
@@ -162,8 +164,9 @@ private:
     QString     cmd_AOS();
     QString     cmd_LOS();
     QString     cmd_set_demod_center();
+    QString     cmd_reset_FftZoom();
+    QString     cmd_center_FftView();
     QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;
 };
-
 #endif // REMOTE_CONTROL_H


### PR DESCRIPTION
For applications were gqrx is controlled remotely, I missed the option to control some options of the FFT window.
Example: Using gqrx without mouse & keyboard but external hardware which changes frequencies and keeps the grey demod box centered in the middle of the FFT screen.


Therefore I added some new remote commands. I tried to stay within the name convention:

- SDC: Centers the demodulator area in the middle of the FFT window
- RFZ: Resets the FFT zoom
- SFZ: Sets the FFT zoom
- SFC: Centers the whole FFT window

