### PR TITLE
Make it possible to control audio gain via the remote interface

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
       2.16: In progress...
 
        NEW: Restore AM & AM-Sync settings between sessions.
+       NEW: Set/get audio gain via remote control.
      FIXED: Loading of narrow FM tau setting.
    REMOVED: Support for GNU Radio 3.7.
 

--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -19,6 +19,10 @@ Supported commands:
     Get squelch threshold [dBFS]
  L SQL <sql>
     Set squelch threshold to <sql> [dBFS]
+ l AF
+    Get audio gain [dB]
+ L AF <gain>
+    Set audio gain to <gain> [dB]
  l <gain_name>_GAIN
     Get the value of the gain setting with the name <gain_name>
  L <gain_name>_GAIN <value>

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -238,6 +238,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(uiDockRxOpt, SIGNAL(sqlLevelChanged(double)), this, SLOT(setSqlLevel(double)));
     connect(uiDockRxOpt, SIGNAL(sqlAutoClicked()), this, SLOT(setSqlLevelAuto()));
     connect(uiDockAudio, SIGNAL(audioGainChanged(float)), this, SLOT(setAudioGain(float)));
+    connect(uiDockAudio, SIGNAL(audioGainChanged(float)), remote, SLOT(setAudioGain(float)));
     connect(uiDockAudio, SIGNAL(audioStreamingStarted(QString,int,bool)), this, SLOT(startAudioStream(QString,int,bool)));
     connect(uiDockAudio, SIGNAL(audioStreamingStopped()), this, SLOT(stopAudioStreaming()));
     connect(uiDockAudio, SIGNAL(audioRecStarted(QString)), this, SLOT(startAudioRec(QString)));
@@ -302,6 +303,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(remote, SIGNAL(newMode(int)), uiDockRxOpt, SLOT(setCurrentDemod(int)));
     connect(remote, SIGNAL(newSquelchLevel(double)), this, SLOT(setSqlLevel(double)));
     connect(remote, SIGNAL(newSquelchLevel(double)), uiDockRxOpt, SLOT(setSquelchLevel(double)));
+    connect(remote, SIGNAL(newAudioGain(float)), uiDockAudio, SLOT(setAudioGainDb(float)));
     connect(uiDockRxOpt, SIGNAL(sqlLevelChanged(double)), remote, SLOT(setSquelchLevel(double)));
     connect(remote, SIGNAL(startAudioRecorderEvent()), uiDockAudio, SLOT(startAudioRecorder()));
     connect(remote, SIGNAL(stopAudioRecorderEvent()), uiDockAudio, SLOT(stopAudioRecorder()));

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -626,7 +626,7 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
         QStringList names;
         for(auto &g : gains)
             names.push_back(QString("%1_GAIN").arg(QString::fromStdString(g.name)));
-        answer = QString("SQL STRENGTH %1\n").arg(names.join(" "));
+        answer = QString("SQL STRENGTH AF %1\n").arg(names.join(" "));
     }
     else if (lvl.compare("STRENGTH", Qt::CaseInsensitive) == 0 || lvl.isEmpty())
     {
@@ -672,7 +672,7 @@ QString RemoteControl::cmd_set_level(QStringList cmdlist)
         QStringList names;
         for(auto &g : gains)
             names.push_back(QString("%1_GAIN").arg(QString::fromStdString(g.name)));
-        answer = QString("SQL %1\n").arg(names.join(" "));
+        answer = QString("SQL AF %1\n").arg(names.join(" "));
     }
     else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
     {

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -46,6 +46,7 @@ RemoteControl::RemoteControl(QObject *parent) :
     rds_status = false;
     signal_level = -200.0;
     squelch_level = -150.0;
+    audio_gain = -6.0;
     audio_recorder_status = false;
     receiver_running = false;
     hamlib_compatible = false;

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -351,6 +351,12 @@ void RemoteControl::setSquelchLevel(double level)
     squelch_level = level;
 }
 
+/*! \brief Set audio gain (from mainwindow). */
+void RemoteControl::setAudioGain(float gain)
+{
+    audio_gain = gain;
+}
+
 /*! \brief Start audio recorder (from mainwindow). */
 void RemoteControl::startAudioRecorder(QString unused)
 {
@@ -630,6 +636,10 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
     {
         answer = QString("%1\n").arg(squelch_level, 0, 'f', 1);
     }
+    else if (lvl.compare("AF", Qt::CaseInsensitive) == 0)
+    {
+        answer = QString("%1\n").arg(audio_gain, 0, 'f', 1);
+    }
     else if (lvl.endsWith("_GAIN"))
     {
         lvl.chop(5);
@@ -673,6 +683,21 @@ QString RemoteControl::cmd_set_level(QStringList cmdlist)
             answer = QString("RPRT 0\n");
             squelch_level = std::max<double>(-150, std::min<double>(0, squelch));
             emit newSquelchLevel(squelch_level);
+        }
+        else
+        {
+            answer = QString("RPRT 1\n");
+        }
+    }
+    else if (lvl.compare("AF", Qt::CaseInsensitive) == 0)
+    {
+        bool ok;
+        float new_audio_gain = cmdlist.value(2, "ERR").toFloat(&ok);
+        if (ok)
+        {
+            answer = QString("RPRT 0\n");
+            new_audio_gain = std::max<float>(-80.0f, std::min<float>(50.0f, new_audio_gain));
+            emit newAudioGain(new_audio_gain);
         }
         else
         {

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -92,6 +92,7 @@ public slots:
     void setMode(int mode);
     void setPassband(int passband_lo, int passband_hi);
     void setSquelchLevel(double level);
+    void setAudioGain(float gain);
     void startAudioRecorder(QString unused);
     void stopAudioRecorder();
     bool setGain(QString name, double gain);
@@ -105,6 +106,7 @@ signals:
     void newMode(int mode);
     void newPassband(int passband);
     void newSquelchLevel(double level);
+    void newAudioGain(float gain);
     void startAudioRecorderEvent();
     void stopAudioRecorderEvent();
     void gainChanged(QString name, double value);
@@ -133,6 +135,7 @@ private:
     bool        rds_status;        /*!< RDS decoder enabled */
     float       signal_level;      /*!< Signal level in dBFS */
     double      squelch_level;     /*!< Squelch level in dBFS */
+    float       audio_gain;        /*!< Audio gain in dB */
     QString     rc_program_id;     /*!< RDS Program identification */
     bool        audio_recorder_status; /*!< Recording enabled */
     bool        receiver_running;  /*!< Whether the receiver is running or not */

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -122,6 +122,14 @@ void DockAudio::setAudioGain(int gain)
     ui->audioGainSlider->setValue(gain);
 }
 
+/*! \brief Set new audio gain.
+ *  \param gain the new audio gain in dB
+ */
+void DockAudio::setAudioGainDb(float gain)
+{
+    ui->audioGainSlider->setValue(int(std::round(gain*10.0)));
+}
+
 
 /*! \brief Get current audio gain.
  *  \returns The current audio gain in tens of dB (0 dB = 10).

--- a/src/qtgui/dockaudio.h
+++ b/src/qtgui/dockaudio.h
@@ -72,6 +72,7 @@ public slots:
     void stopAudioRecorder(void);
     void setRxFrequency(qint64 freq);
     void setWfColormap(const QString &cmap);
+    void setAudioGainDb(float gain);
 
 signals:
     /*! \brief Signal emitted when audio gain has changed. Gain is in dB. */


### PR DESCRIPTION
New gain control "AF"
Use "l AF" command to get current audio gain.
Use "L AF 10" to set current audio gain to 10.0 db.