### PR TITLE
Simplify setFrequencyFocus()

### DIFF
--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -876,13 +876,12 @@ void CFreqCtrl::cursorEnd()
 
 void CFreqCtrl::setFrequencyFocus()
 {
-    uint8_t position = floor(log10(m_freq));
-    position = (uint8_t)fmax(position, 4);      // restrict min to 100s of kHz
+    // Select last digit or 5th digit (100s of kHz), whatever is bigger.
+    int position = std::max(int(log10(m_freq)), 5);
 
-    QMouseEvent mouseEvent(QEvent::MouseMove,
-                           m_DigitInfo[position].dQRect.center(),
-                           Qt::NoButton,
-                           Qt::NoButton,
-                           Qt::NoModifier);
-    mouseMoveEvent(&mouseEvent);
+    if (!hasFocus()) {
+        setFocus(Qt::ShortcutFocusReason);
+    }
+
+    setActiveDigit(position);
 }


### PR DESCRIPTION
- Replace deprecated QMouseEvent constructor (Deprecated since Qt 6.4)
- Focus only if not already focuses
- Keep the current position if focused

