### PR TITLE
IQ Tool: Fix jumpy scrollbar of IQ player

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -4,6 +4,7 @@
        NEW: Restore FFT zoom level between sessions.
        NEW: Restore peak detect & peak hold between sessions.
      FIXED: Remove empty frame from bottom of I/Q tool window.
+     FIXED: Sudden scrolling of file list in I/Q tool window.
   IMPROVED: AGC performance.
 
 

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -29,6 +29,7 @@
 #include <QString>
 #include <QStringList>
 #include <QTime>
+#include <QScrollBar>
 
 #include <math.h>
 
@@ -302,6 +303,8 @@ void CIqTool::timeoutFunction(void)
 void CIqTool::refreshDir()
 {
     int selection = ui->listWidget->currentRow();
+    QScrollBar * sc = ui->listWidget->verticalScrollBar();
+    int lastScroll = sc->sliderPosition();
 
     recdir->refresh();
     QStringList files = recdir->entryList();
@@ -310,6 +313,7 @@ void CIqTool::refreshDir()
     ui->listWidget->clear();
     ui->listWidget->insertItems(0, files);
     ui->listWidget->setCurrentRow(selection);
+    sc->setSliderPosition(lastScroll);
     ui->listWidget->blockSignals(false);
 
     if (is_recording)


### PR DESCRIPTION
When file list grows long and the user tries to scroll the list to a new position, the list continues to return it's scroll to the last selected item. That's really annoying.
Return the list to last seen position after refreshing it's contents.
Demonstration: https://www.youtube.com/watch?v=DW3LpVRxGoA

Closes https://github.com/gqrx-sdr/gqrx/issues/1037