### PR TITLE
Allow recording IQ samples in the SigMF format

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ The following people and organisations have contributed to gqrx:
 * Kenji Rikitake, JJ1BDX
 * Kitware Inc.
 * Konrad Beckmann
+* Luna Gräfje
 * luzpaz
 * Marco Savelli
 * Markus Kolb

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
     2.17.1: In progress...
 
        NEW: Delete key clears the waterfall.
+       NEW: I/Q tool can save recordings in SigMF format.
   IMPROVED: Reduced CPU utilization of waterfall display.
    CHANGED: DMG release requires macOS 12.7 or later.
 

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -195,7 +195,7 @@ private slots:
     void stopAudioStreaming();
 
     /* I/Q playback and recording*/
-    void startIqRecording(const QString& recdir);
+    void startIqRecording(const QString& recdir, const QString& format);
     void stopIqRecording();
     void startIqPlayback(const QString& filename, float samprate, qint64 center_freq);
     void stopIqPlayback();

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -52,6 +52,7 @@ CIqTool::CIqTool(QWidget *parent) :
     //ui->recDirEdit->setText(QDir::currentPath());
 
     recdir = new QDir(QDir::homePath(), "*.raw");
+    recdir->setNameFilters(recdir->nameFilters() << "*.sigmf-data");
 
     error_palette = new QPalette();
     error_palette->setColor(QPalette::Text, Qt::red);
@@ -173,7 +174,7 @@ void CIqTool::on_recButton_clicked(bool checked)
     if (checked)
     {
         ui->playButton->setEnabled(false);
-        emit startRecording(recdir->path());
+        emit startRecording(recdir->path(), ui->formatCombo->currentText());
 
         refreshDir();
         ui->listWidget->setCurrentRow(ui->listWidget->count()-1);

--- a/src/qtgui/iq_tool.h
+++ b/src/qtgui/iq_tool.h
@@ -62,7 +62,7 @@ public:
     void readSettings(QSettings *settings);
 
 signals:
-    void startRecording(const QString recdir);
+    void startRecording(const QString recdir, const QString format);
     void stopRecording();
     void startPlayback(const QString filename, float samprate, qint64 center_freq);
     void stopPlayback();

--- a/src/qtgui/iq_tool.ui
+++ b/src/qtgui/iq_tool.ui
@@ -33,6 +33,30 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QLabel" name="formatLabel">
+       <property name="text">
+        <string>Format:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+       <widget class="QComboBox" name="formatCombo">
+        <property name="toolTip">
+         <string>File format</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Raw</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>SigMF</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     <item>
       <widget class="QLabel" name="recDirLabel">
        <property name="text">
         <string>Location:</string>


### PR DESCRIPTION
This implements part 1 of #988. Users can choose between the old format (raw) and SigMF with a chooser in the iq tool window.

Since SigMF keeps metadata and signal data separate, the actual recording remains unchanged regardless of which format is selected (except for the file name). For this reason, `.sigmf-data` files are made available for playback in the iq tool as well (this does not work in the general case (yet) but `.raw` isn't super well defined either).

One potential improvement would be to do some refactoring to separate formats into different classes that can be interacted with during the recording. This would 1. more cleanly separate the code paths for raw and sigmf recordings and 2. allow adding more metadata during the recording (e.g. we could start a new `capture` object when we tune the radio to a different frequency or change the gain).