### PR TITLE
Redraw panadapter bookmark marks on bookmark adding/deletion/tag selection

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -5,6 +5,7 @@
        NEW: Set/get audio gain via remote control.
      FIXED: Loading of narrow FM tau setting.
      FIXED: Crash when adding or removing bookmark tags.
+     FIXED: Redraw bookmarks immediately after changes.
    REMOVED: Support for GNU Radio 3.7.
 
 

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -281,6 +281,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     // Bookmarks
     connect(uiDockBookmarks, SIGNAL(newBookmarkActivated(qint64, QString, int)), this, SLOT(onBookmarkActivated(qint64, QString, int)));
     connect(uiDockBookmarks->actionAddBookmark, SIGNAL(triggered()), this, SLOT(on_actionAddBookmark_triggered()));
+    connect(&Bookmarks::Get(), SIGNAL(BookmarksChanged()), ui->plotter, SLOT(updateOverlay()));
 
     //DXC Spots
     connect(&DXCSpots::Get(), SIGNAL(dxcSpotsUpdated()), this, SLOT(updateClusterSpots()));
@@ -2430,8 +2431,6 @@ void MainWindow::on_actionAddBookmark_triggered()
 
         Bookmarks::Get().add(info);
         uiDockBookmarks->updateTags();
-        uiDockBookmarks->updateBookmarks();
-        ui->plotter->updateOverlay();
     }
 }
 

--- a/src/qtgui/bookmarks.cpp
+++ b/src/qtgui/bookmarks.cpp
@@ -61,14 +61,12 @@ void Bookmarks::add(BookmarkInfo &info)
     m_BookmarkList.append(info);
     std::stable_sort(m_BookmarkList.begin(),m_BookmarkList.end());
     save();
-    emit( BookmarksChanged() );
 }
 
 void Bookmarks::remove(int index)
 {
     m_BookmarkList.removeAt(index);
     save();
-    emit BookmarksChanged();
 }
 
 bool Bookmarks::load()
@@ -202,6 +200,7 @@ bool Bookmarks::save()
             stream << line << '\n';
         }
 
+        emit BookmarksChanged();
         file.close();
         return true;
     }


### PR DESCRIPTION
Update plotter overlay on bookmarks change (connect signal `Bookmarks::BookmarksChanged()` to `CPlotter::updateOverlay()`).
Emit the signal on bookmarks deletion/adding.
Implement panadpter bookmark mark tag filtering.
May close https://github.com/gqrx-sdr/gqrx/issues/263 and https://github.com/gqrx-sdr/gqrx/issues/965
