### PR TITLE
rx_fft: normalize fft windows

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -6,6 +6,7 @@
      FIXED: Remove empty frame from bottom of I/Q tool window.
      FIXED: Sudden scrolling of file list in I/Q tool window.
   IMPROVED: AGC performance.
+  IMPROVED: Apply amplitude normalization to FFT window functions.
 
 
     2.15.9: Released April 9, 2022

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -204,6 +204,7 @@ unsigned int rx_fft_c::get_fft_size() const
 /*! \brief Set new window type. */
 void rx_fft_c::set_window_type(int wintype)
 {
+    float tmp;
     if (wintype == d_wintype)
     {
         /* nothing to do */
@@ -219,6 +220,8 @@ void rx_fft_c::set_window_type(int wintype)
 
     d_window.clear();
     d_window = gr::fft::window::build((gr::fft::window::win_type)d_wintype, d_fftsize, 6.76);
+    volk_32f_accumulator_s32f(&tmp, d_window.data(), d_fftsize);
+    volk_32f_s32f_normalize(d_window.data(), tmp / float(d_fftsize), d_fftsize);
 }
 
 /*! \brief Get currently used window type. */
@@ -391,6 +394,7 @@ unsigned int rx_fft_f::get_fft_size() const
 /*! \brief Set new window type. */
 void rx_fft_f::set_window_type(int wintype)
 {
+    float tmp;
     if (wintype == d_wintype)
     {
         /* nothing to do */
@@ -406,6 +410,8 @@ void rx_fft_f::set_window_type(int wintype)
 
     d_window.clear();
     d_window = gr::fft::window::build((gr::fft::window::win_type)d_wintype, d_fftsize, 6.76);
+    volk_32f_accumulator_s32f(&tmp, d_window.data(), d_fftsize);
+    volk_32f_s32f_normalize(d_window.data(), tmp / float(d_fftsize), d_fftsize);
 }
 
 /*! \brief Get currently used window type. */


### PR DESCRIPTION
Always show correct signal magnitude on the panadapter independent of selected FFT window type.

Panadapter levels with this fix applied
![rectangular-fixed](https://user-images.githubusercontent.com/17007837/218274954-1ecc3567-4a83-4b45-a0f8-daf6cb700a4b.png)
![hamming-fixed](https://user-images.githubusercontent.com/17007837/218274955-245753e7-47f3-4ca6-9d82-7c3de0ba17d2.png)
![flattop-fixed](https://user-images.githubusercontent.com/17007837/218274956-4efd7fa1-1ebe-4617-bd05-036c909ed114.png)

Fix #1189