### PR TITLE
Increase max fft size to 4M and reduce scope of locking in rx_fft

### DIFF
--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -35,7 +35,7 @@
 #include <chrono>
 
 
-#define MAX_FFT_SIZE 1048576
+#define MAX_FFT_SIZE (1024 * 1024 * 4)
 #define AUDIO_BUFFER_SIZE 65536
 
 class rx_fft_c;

--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -955,6 +955,16 @@
             </property>
             <item>
              <property name="text">
+              <string>4194304</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2097152</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
               <string>1048576</string>
              </property>
             </item>


### PR DESCRIPTION
Larger ffts would cause overruns (testing done with a B205mini) and the choke point was the write into the fft buffer. While the buffer data structures need to be protected by a mutex, the fft execute() does not, since it uses a separate buffer.

Further, since it is not critical which data gets fft'd (the timer is based on system time anyway), apply_window() can be done outside the critical section. There is some chance that the reader and writer will collide while apply_window() is being executed. I've made the assumption that the results won't be visible to the user and speed/overruns are of more interest.

Increasing the number of threads had some effect on the achievable fft rate for larger fft size, but was not the reason for the drops, so settable nthreads can be left to another commit.