### PR TITLE
dk.gqrx.gqrx.desktop: fix typo in Czech translation

### DIFF
--- a/dk.gqrx.gqrx.desktop
+++ b/dk.gqrx.gqrx.desktop
@@ -5,7 +5,7 @@ GenericName=Software Defined Radio
 Comment=Software defined radio receiver implemented using GNU Radio and the Qt GUI toolkit
 # FIXME add comments in other languages
 GenericName[cs]=Softwarově definované rádio (SDR)
-Comment[cs]=Příjímač na bázi softwarově definovaného rádia implementovaný s použitím GNU Radio a Qt
+Comment[cs]=Přijímač na bázi softwarově definovaného rádia implementovaný s použitím GNU Radio a Qt
 GenericName[ru]=Программно-определённое радио
 Comment[ru]=Приемник для программно-определенного радио (SDR) использующий GNU Radio и библиотеку Qt.
 GenericName[nl]=Software Defined Radio


### PR DESCRIPTION
The correct term for Receiver in Czech is "Př**i**jímač", not "Př**í**jímač". See [this Wikipedia page](https://cs.wikipedia.org/wiki/P%C5%99ij%C3%ADma%C4%8D) and [this Wiktionary page](https://cs.wiktionary.org/wiki/p%C5%99ij%C3%ADma%C4%8D).

/cc @jiri-pinkava @argilo