### PR TITLE
Shortcut key "z" zeros the rx filter offset

### DIFF
--- a/resources/kbd-shortcuts.txt
+++ b/resources/kbd-shortcuts.txt
@@ -11,6 +11,7 @@ Main window actions:
  Ctrl+C         Open DX cluster dialog
  F11            Toggle full screen mode
  F              Set focus to the frequency controller
+ Z              Zero frequency offset
  Ctrl+Q         Quit the program
 
 Receiver modes:

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
        NEW: Restore FFT zoom level between sessions.
        NEW: Restore peak detect & peak hold between sessions.
+       NEW: "Z" keyboard shortcut sets frequency offset to zero.
      FIXED: Remove empty frame from bottom of I/Q tool window.
      FIXED: Sudden scrolling of file list in I/Q tool window.
   IMPROVED: AGC performance.

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -153,6 +153,10 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     auto *freq_shortcut = new QShortcut(QKeySequence(Qt::Key_F), this);
     QObject::connect(freq_shortcut, &QShortcut::activated, this, &MainWindow::frequencyFocusShortcut);
 
+    // zero cursor (rx filter offset)
+    auto *rx_offset_zero_shortcut = new QShortcut(QKeySequence(Qt::Key_Z), this);
+    QObject::connect(rx_offset_zero_shortcut, &QShortcut::activated, this, &MainWindow::rxOffsetZeroShortcut);
+
     setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
     setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
     setCorner(Qt::BottomLeftCorner, Qt::BottomDockWidgetArea);
@@ -2434,4 +2438,9 @@ void MainWindow::updateClusterSpots()
 void MainWindow::frequencyFocusShortcut()
 {
     ui->freqCtrl->setFrequencyFocus();
+}
+
+void MainWindow::rxOffsetZeroShortcut()
+{
+    uiDockRxOpt->setFilterOffset(0);
 }

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -126,8 +126,9 @@ private:
     void updateGainStages(bool read_from_device);
     void showSimpleTextFile(const QString &resource_path,
                             const QString &window_title);
-    /* key shortcut */
+    /* key shortcuts */
     void frequencyFocusShortcut();
+    void rxOffsetZeroShortcut();
 
 private slots:
     /* RecentConfig */


### PR DESCRIPTION
Instead of entering all zeroes in the filter offset field, hit "z" to re-center the cursor.