### PR TITLE
Make zoom reset more reliable

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -6,6 +6,7 @@
        NEW: "Z" keyboard shortcut sets frequency offset to zero.
      FIXED: Remove empty frame from bottom of I/Q tool window.
      FIXED: Sudden scrolling of file list in I/Q tool window.
+     FIXED: Reset zoom slider after right click on panadapter / waterfall.
   IMPROVED: AGC performance.
   IMPROVED: Apply amplitude normalization to FFT window functions.
 

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1665,6 +1665,7 @@ void CPlotter::resetHorizontalZoom(void)
 {
     setFftCenterFreq(0);
     setSpanFreq((qint32)m_SampleFreq);
+    emit newZoomLevel(1.0);
 }
 
 /** Center FFT plot around 0 (corresponds to center freq). */


### PR DESCRIPTION
Especially at higher zooms, right click on the freq axis did not fully reset the zoom level on the fft dock. Add an emit to resetHorizontalZoom() as is done already in zoomStepX().