### PR TITLE
Perform double precision math in xFromFreq() and freqFromX()

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1565,9 +1565,11 @@ void CPlotter::makeFrequencyStrs()
 // Convert from frequency to screen coordinate
 int CPlotter::xFromFreq(qint64 freq)
 {
-    qint64 w = width();
-    qint64 StartFreq = m_CenterFreq + m_FftCenter - m_Span / 2;
-    int x = (int) (w * (freq - StartFreq) / m_Span);
+    double w = width();
+    double startFreq = (double)m_CenterFreq
+                       + (double)m_FftCenter
+                       - (double)m_Span / 2.0;
+    int x = qRound(w * ((double)freq - startFreq) / (double)m_Span);
     if (x < 0)
         return 0;
     if (x > (int)w)
@@ -1579,7 +1581,8 @@ int CPlotter::xFromFreq(qint64 freq)
 qint64 CPlotter::freqFromX(int x)
 {
     double ratio = (double)x / (double)width();
-    qint64 f = (m_CenterFreq + m_FftCenter - m_Span / 2) + ratio * m_Span;
+    qint64 f = qRound64((double)m_CenterFreq + (double)m_FftCenter
+                        - (double)m_Span / 2.0 + ratio * (double)m_Span);
     return f;
 }
 


### PR DESCRIPTION
An on-screen off-by-one pixel problem turned out to be rounding errors in one or both of these routines. Force all math to be double precision and round to integer results.

There's probably some more elegant way to code this, but I don't think the compiler cares, and it's easier to compare to the original computations this way.