### PR TITLE
Increase max fft size to 4M and reduce scope of locking in rx_fft

### DIFF
--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -95,16 +95,18 @@ int rx_fft_c::work(int noutput_items,
     (void) output_items;
 
     /* just throw new samples into the buffer */
-    std::lock_guard<std::mutex> lock(d_mutex);
-
     int items_to_copy = std::min(noutput_items, (int)d_writer->bufsize());
     if (items_to_copy < noutput_items)
         in += (noutput_items - items_to_copy);
 
-    if (d_writer->space_available() < items_to_copy)
-        d_reader->update_read_pointer(items_to_copy - d_writer->space_available());
-    memcpy(d_writer->write_pointer(), in, sizeof(gr_complex) * items_to_copy);
-    d_writer->update_write_pointer(items_to_copy);
+    {
+        std::lock_guard<std::mutex> lock(d_mutex);
+
+        if (d_writer->space_available() < items_to_copy)
+            d_reader->update_read_pointer(items_to_copy - d_writer->space_available());
+        memcpy(d_writer->write_pointer(), in, sizeof(gr_complex) * items_to_copy);
+        d_writer->update_write_pointer(items_to_copy);
+    }
 
     return noutput_items;
 }
@@ -115,17 +117,17 @@ int rx_fft_c::work(int noutput_items,
  */
 void rx_fft_c::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSize)
 {
-    std::unique_lock<std::mutex> lock(d_mutex);
-
     std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
     std::chrono::duration<double> diff = now - d_lasttime;
     diff = std::min(diff, std::chrono::duration<double>(d_writer->bufsize() / d_quadrate));
     d_lasttime = now;
 
-    /* perform FFT */
-    d_reader->update_read_pointer(std::min((int)(diff.count() * d_quadrate * 1.001), d_reader->items_available() - MAX_FFT_SIZE));
-    apply_window(d_fftsize);
-    lock.unlock();
+    {
+        std::lock_guard<std::mutex> lock(d_mutex);
+
+        d_reader->update_read_pointer(std::min((int)(diff.count() * d_quadrate * 1.001), d_reader->items_available() - MAX_FFT_SIZE));
+        apply_window(d_fftsize);
+    }
 
     /* compute FFT */
     d_fft->execute();
@@ -298,16 +300,18 @@ int rx_fft_f::work(int noutput_items,
     (void) output_items;
 
     /* just throw new samples into the buffer */
-    std::lock_guard<std::mutex> lock(d_mutex);
-
     int items_to_copy = std::min(noutput_items, (int)d_writer->bufsize());
     if (items_to_copy < noutput_items)
         in += (noutput_items - items_to_copy);
 
-    if (d_writer->space_available() < items_to_copy)
-        d_reader->update_read_pointer(items_to_copy - d_writer->space_available());
-    memcpy(d_writer->write_pointer(), in, sizeof(float) * items_to_copy);
-    d_writer->update_write_pointer(items_to_copy);
+    {
+        std::lock_guard<std::mutex> lock(d_mutex);
+
+        if (d_writer->space_available() < items_to_copy)
+            d_reader->update_read_pointer(items_to_copy - d_writer->space_available());
+        memcpy(d_writer->write_pointer(), in, sizeof(float) * items_to_copy);
+        d_writer->update_write_pointer(items_to_copy);
+    }
 
     return noutput_items;
 }
@@ -318,17 +322,18 @@ int rx_fft_f::work(int noutput_items,
  */
 void rx_fft_f::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSize)
 {
-    std::unique_lock<std::mutex> lock(d_mutex);
-
     std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
     std::chrono::duration<double> diff = now - d_lasttime;
     diff = std::min(diff, std::chrono::duration<double>(d_writer->bufsize() / d_audiorate));
     d_lasttime = now;
 
     /* perform FFT */
-    d_reader->update_read_pointer(std::min((unsigned int)(diff.count() * d_audiorate * 1.001), d_reader->items_available() - d_fftsize));
-    apply_window(d_fftsize);
-    lock.unlock();
+    {
+        std::lock_guard<std::mutex> lock(d_mutex);
+
+        d_reader->update_read_pointer(std::min((unsigned int)(diff.count() * d_audiorate * 1.001), d_reader->items_available() - d_fftsize));
+        apply_window(d_fftsize);
+    }
 
     /* compute FFT */
     d_fft->execute();

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -35,7 +35,7 @@
 #include <chrono>
 
 
-#define MAX_FFT_SIZE 1048576
+#define MAX_FFT_SIZE (1024 * 1024 * 4)
 #define AUDIO_BUFFER_SIZE 65536
 
 class rx_fft_c;

--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -955,6 +955,16 @@
             </property>
             <item>
              <property name="text">
+              <string>4194304</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2097152</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
               <string>1048576</string>
              </property>
             </item>


### PR DESCRIPTION
More FFT, less lock (just a little). This PR replaces #1195 which messed with the locking a little too much.