### PR TITLE
iq_swap_cc: implement directly instead of as a hier block

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -10,6 +10,7 @@
      FIXED: Aliasing when input rate is higher than 2 Msps.
   IMPROVED: AGC performance.
   IMPROVED: WFM stereo & OIRT performance.
+  IMPROVED: I/Q swap performance.
   IMPROVED: Apply amplitude normalization to FFT window functions.
 
 

--- a/src/dsp/correct_iq_cc.h
+++ b/src/dsp/correct_iq_cc.h
@@ -87,7 +87,7 @@ iq_swap_cc_sptr make_iq_swap_cc(bool enabled);
 /*! \brief Block to swap I and Q channels.
  *  \ingroup DSP
  */
-class iq_swap_cc : public gr::hier_block2
+class iq_swap_cc : public gr::sync_block
 {
     friend iq_swap_cc_sptr make_iq_swap_cc(bool enabled);
 
@@ -97,10 +97,11 @@ protected:
 public:
     ~iq_swap_cc();
     void set_enabled(bool enabled);
+    int work(int noutput_items,
+             gr_vector_const_void_star& input_items,
+             gr_vector_void_star& output_items);
 
 private:
-    gr::blocks::complex_to_float::sptr d_c2f;
-    gr::blocks::float_to_complex::sptr d_f2c;
     bool d_enabled;
 };
 


### PR DESCRIPTION
Much faster, especially when off, and fewer buffers.

Saves about a half a core on my system at 56 MB/s.

Fixes #1205 