### PR TITLE
stereo_demod: reduce CPU consumption

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -8,6 +8,7 @@
      FIXED: Sudden scrolling of file list in I/Q tool window.
      FIXED: Reset zoom slider after right click on panadapter / waterfall.
   IMPROVED: AGC performance.
+  IMPROVED: WFM stereo & OIRT performance.
   IMPROVED: Apply amplitude normalization to FFT window functions.
 
 

--- a/src/dsp/stereo_demod.cpp
+++ b/src/dsp/stereo_demod.cpp
@@ -68,12 +68,12 @@ stereo_demod::stereo_demod(float input_rate, float audio_rate, bool stereo, bool
     if (!d_oirt)
     {
         d_tone_taps = gr::filter::firdes::complex_band_pass(
-                                       20.0,         // gain,
+                                       1.0,          // gain,
 		                                   d_input_rate, // sampling_freq
                                        18980.,       // low_cutoff_freq
                                        19020.,       // high_cutoff_freq
-                                       1000.);       // transition_width
-        pll = gr::analog::pll_refout_cc::make(0.001,    // loop_bw FIXME
+                                       5000.);       // transition_width
+        pll = gr::analog::pll_refout_cc::make(0.0002,    // loop_bw FIXME
                                 2*M_PI * 19020 / input_rate,  // max_freq
                                 2*M_PI * 18980 / input_rate); // min_freq
         subtone = gr::blocks::multiply_cc::make();
@@ -83,8 +83,8 @@ stereo_demod::stereo_demod(float input_rate, float audio_rate, bool stereo, bool
                                        d_input_rate, // sampling_freq
                                        31200.,       // low_cutoff_freq
                                        31300.,       // high_cutoff_freq
-                                       100.);        // transition_width
-        pll = gr::analog::pll_refout_cc::make(0.001,    // loop_bw FIXME
+                                       5000.);       // transition_width
+        pll = gr::analog::pll_refout_cc::make(0.0002,    // loop_bw FIXME
                                 2*M_PI * 31200 / input_rate,  // max_freq
                                 2*M_PI * 31300 / input_rate); // min_freq
     }


### PR DESCRIPTION
Increase pilot FIR filter rolloff to reduce the order and taps size. This should not increase noise as pll_refout is itself a very narrow filter.
With this fix my small old laptop (Samsung NC10) is able to receive FM stereo transmissions even at 2.4Msps with almost no skipping. Without this fix 240ksps max stable.