### PR TITLE
Space freezes the plotter

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -157,6 +157,10 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     auto *rx_offset_zero_shortcut = new QShortcut(QKeySequence(Qt::Key_Z), this);
     QObject::connect(rx_offset_zero_shortcut, &QShortcut::activated, this, &MainWindow::rxOffsetZeroShortcut);
 
+    // freeze plotter on SPACE
+    auto *toggle_freeze_shortcut = new QShortcut(QKeySequence(Qt::Key_Space), this);
+    QObject::connect(toggle_freeze_shortcut, &QShortcut::activated, this, &MainWindow::toggleFreezeShortcut);
+
     setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
     setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
     setCorner(Qt::BottomLeftCorner, Qt::BottomDockWidgetArea);
@@ -2443,4 +2447,9 @@ void MainWindow::frequencyFocusShortcut()
 void MainWindow::rxOffsetZeroShortcut()
 {
     uiDockRxOpt->setFilterOffset(0);
+}
+
+void MainWindow::toggleFreezeShortcut()
+{
+    ui->plotter->toggleFreeze();
 }

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -129,6 +129,7 @@ private:
     /* key shortcuts */
     void frequencyFocusShortcut();
     void rxOffsetZeroShortcut();
+    void toggleFreezeShortcut();
 
 private slots:
     /* RecentConfig */

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -136,6 +136,7 @@ CPlotter::CPlotter(QWidget *parent) : QFrame(parent)
     m_CursorCaptured = NOCAP;
     m_Running = false;
     m_DrawOverlay = true;
+    m_Frozen = false;
     m_2DPixmap = QPixmap(0,0);
     m_OverlayPixmap = QPixmap(0,0);
     m_WaterfallPixmap = QPixmap(0,0);
@@ -578,6 +579,11 @@ bool CPlotter::saveWaterfall(const QString & filename) const
     return pixmap.save(filename, nullptr, -1);
 }
 
+void CPlotter::toggleFreeze()
+{
+    m_Frozen = !m_Frozen;
+}
+
 /** Get waterfall time resolution in milleconds / line. */
 quint64 CPlotter::getWfTimeRes() const
 {
@@ -885,6 +891,8 @@ void CPlotter::resizeEvent(QResizeEvent* )
 
     drawOverlay();
     emit newSize();
+
+    m_Frozen = false;
 }
 
 // Called by QT when screen needs to be redrawn
@@ -893,8 +901,11 @@ void CPlotter::paintEvent(QPaintEvent *)
     QPainter painter(this);
 
     painter.drawPixmap(0, 0, m_2DPixmap);
-    painter.drawPixmap(0, m_Percent2DScreen * m_Size.height() / 100,
-                       m_WaterfallPixmap);
+    if (!m_Frozen)
+    {
+        painter.drawPixmap(0, m_Percent2DScreen * m_Size.height() / 100,
+                           m_WaterfallPixmap);
+    }
 }
 
 // Called to update spectrum data for displaying on the screen

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -122,6 +122,7 @@ public:
     void    setFftRate(int rate_hz);
     void    clearWaterfall();
     bool    saveWaterfall(const QString & filename) const;
+    void    toggleFreeze();
 
 signals:
     void newDemodFreq(qint64 freq, qint64 delta); /* delta is the offset from the center */
@@ -211,6 +212,7 @@ private:
     int         m_YAxisWidth{};
 
     eCapturetype    m_CursorCaptured;
+    bool        m_Frozen;           // Waterfall is frozen - pixmap will not be rendered
     QPixmap     m_2DPixmap;
     QPixmap     m_OverlayPixmap;
     QPixmap     m_WaterfallPixmap;


### PR DESCRIPTION
The drawing routines keep running, so when Space is hit again, nothing has been lost.

Currently, various controls do not work as expected when the plotter is frozen. Area for improvement - would likely require a third drawing layer (not a bad idea if performance allows).

Two possible uses:
- Look at something for a second but don't want to miss new stuff or shut off rx
- Save bandwidth when operating VNC/RDP