### PR TITLE
Scale FFT to dB/MHz

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1375,9 +1375,8 @@ void MainWindow::iqFftTimeout()
         return;
     }
 
-    // NB: without cast to float the multiplication will overflow at 64k
-    // and pwr_scale will be inf
-    pwr_scale = 1.0 / ((float)fftsize * (float)fftsize);
+    // Scale to dB/MHz
+    pwr_scale = 1.0 / 1000000.0 / (float)fftsize;
 
     /* Normalize, calculate power and shift the FFT */
     volk_32fc_magnitude_squared_32f(d_realFftData, d_fftData + (fftsize/2), fftsize/2);


### PR DESCRIPTION
FFT power was scaled using 1/(fftsize^2). This works out approximately for fftsize 1M, but was causing the power levels to shift at other sizes.

The plotter shows the maximum value of all those mapped to a pixel on the screen. This is useful, but does not represent the average power for the bins mapped to that pixel. The code was probably written to make the answer on the screen look correct in this situation, and show the noise floor averaging down at higher fftsize.

Separate modes to show the average power in a fft bin, and the minimum power, are the subjects of a separate commit.