### PR TITLE
User selectable max/avg/min sampling modes for fft scaling

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -65,6 +65,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     QMainWindow(parent),
     configOk(true),
     ui(new Ui::MainWindow),
+    d_display_dbm(false),
     d_lnb_lo(0),
     d_hw_freq(0),
     d_fftAvg(0.25),
@@ -250,6 +251,8 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(uiDockFft, SIGNAL(fftSizeChanged(int)), this, SLOT(setIqFftSize(int)));
     connect(uiDockFft, SIGNAL(fftRateChanged(int)), this, SLOT(setIqFftRate(int)));
     connect(uiDockFft, SIGNAL(fftWindowChanged(int)), this, SLOT(setIqFftWindow(int)));
+    connect(uiDockFft, SIGNAL(rbwChanged(int)), this, SLOT(setIqRbw(int)));
+    connect(uiDockFft, SIGNAL(displayDbmChanged(int)), this, SLOT(setDisplayDbm(int)));
     connect(uiDockFft, SIGNAL(wfSpanChanged(quint64)), this, SLOT(setWfTimeSpan(quint64)));
     connect(uiDockFft, SIGNAL(fftSplitChanged(int)), this, SLOT(setIqFftSplit(int)));
     connect(uiDockFft, SIGNAL(fftAvgChanged(float)), this, SLOT(setIqFftAvg(float)));
@@ -1377,7 +1380,11 @@ void MainWindow::iqFftTimeout()
     }
 
     // Scale for dBm into 50 ohms
-    const double pwr_scale = 1000.0 / (2.0 * (double)fftsize * quad_rate * 50.0);
+    double pwr_scale;
+    if (d_display_dbm)
+        pwr_scale = 1000.0 / (2.0 * (double)fftsize * quad_rate * 50.0);
+    else
+        pwr_scale = 1.0 / (double)fftsize / (double)fftsize;
 
     /* Normalize, calculate power and shift the FFT */
     volk_32fc_magnitude_squared_32f(d_realFftData, d_fftData + (fftsize/2), fftsize/2);
@@ -1730,6 +1737,16 @@ void MainWindow::setIqFftRate(int fps)
 void MainWindow::setIqFftWindow(int type)
 {
     rx->set_iq_fft_window(type);
+}
+
+void MainWindow::setIqRbw(int rbw)
+{
+    rx->set_iq_rbw(rbw);
+}
+
+void MainWindow::setDisplayDbm(int state)
+{
+    d_display_dbm = (state != 0);
 }
 
 /** Waterfall time span has changed. */

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -254,6 +254,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(uiDockFft, SIGNAL(fftSplitChanged(int)), this, SLOT(setIqFftSplit(int)));
     connect(uiDockFft, SIGNAL(fftAvgChanged(float)), this, SLOT(setIqFftAvg(float)));
     connect(uiDockFft, SIGNAL(fftZoomChanged(float)), ui->plotter, SLOT(zoomOnXAxis(float)));
+    connect(uiDockFft, SIGNAL(samplingModeChanged(int)), ui->plotter, SLOT(setSamplingMode(int)));
     connect(uiDockFft, SIGNAL(resetFftZoom()), ui->plotter, SLOT(resetHorizontalZoom()));
     connect(uiDockFft, SIGNAL(gotoFftCenter()), ui->plotter, SLOT(moveToCenterFreq()));
     connect(uiDockFft, SIGNAL(gotoDemodFreq()), ui->plotter, SLOT(moveToDemodFreq()));

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1365,7 +1365,7 @@ void MainWindow::iqFftTimeout()
 {
     unsigned int    fftsize;
     unsigned int    i;
-    float           pwr_scale;
+    double          quad_rate = rx->get_input_rate() / rx->get_input_decim();
 
     // FIXME: fftsize is a reference
     rx->get_iq_fft_data(d_fftData, fftsize);
@@ -1376,9 +1376,8 @@ void MainWindow::iqFftTimeout()
         return;
     }
 
-    // NB: without cast to float the multiplication will overflow at 64k
-    // and pwr_scale will be inf
-    pwr_scale = 1.0 / ((float)fftsize * (float)fftsize);
+    // Scale for dBm into 50 ohms
+    const double pwr_scale = 1000.0 / (2.0 * (double)fftsize * quad_rate * 50.0);
 
     /* Normalize, calculate power and shift the FFT */
     volk_32fc_magnitude_squared_32f(d_realFftData, d_fftData + (fftsize/2), fftsize/2);

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -76,6 +76,8 @@ private:
     QString             m_last_dir;
     RecentConfig       *m_recent_config; /* Menu File Recent config */
 
+    bool d_display_dbm;
+
     qint64 d_lnb_lo;  /* LNB LO in Hz. */
     qint64 d_hw_freq;
     qint64 d_hw_freq_start{};
@@ -189,6 +191,8 @@ private slots:
     void setIqFftSize(int size);
     void setIqFftRate(int fps);
     void setIqFftWindow(int type);
+    void setIqRbw(int rbw);
+    void setDisplayDbm(int state);
     void setIqFftSplit(int pct_wf);
     void setIqFftAvg(float avg);
     void setAudioFftRate(int fps);

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -744,6 +744,11 @@ void receiver::set_iq_fft_window(int window_type)
     iq_fft->set_window_type(window_type);
 }
 
+void receiver::set_iq_rbw(int rbw)
+{
+    iq_fft->set_rbw(rbw);
+}
+
 /** Get latest baseband FFT data. */
 void receiver::get_iq_fft_data(std::complex<float>* fftPoints, unsigned int &fftsize)
 {

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -165,6 +165,7 @@ public:
     float       get_signal_pwr() const;
     void        set_iq_fft_size(int newsize);
     void        set_iq_fft_window(int window_type);
+    void        set_iq_rbw(int rbw);
     void        get_iq_fft_data(std::complex<float>* fftPoints,
                                 unsigned int &fftsize);
     void        get_audio_fft_data(std::complex<float>* fftPoints,

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -218,8 +218,17 @@ void rx_fft_c::set_window_type(int wintype)
         d_wintype = gr::fft::window::WIN_HAMMING;
     }
 
+    const float min_rbw = 100000;
+    const float rbw_fft = d_quadrate / (float)d_fftsize;
+    unsigned int ntaps;
+    if (min_rbw > rbw_fft)
+        ntaps = std::max((unsigned int)lround(d_quadrate / min_rbw), 1);
+    else
+        ntaps = d_fftsize;
+
     d_window.clear();
-    d_window = gr::fft::window::build((gr::fft::window::win_type)d_wintype, d_fftsize, 6.76);
+    d_window = gr::fft::window::build((gr::fft::window::win_type)d_wintype, ntaps, 6.76);
+    d_window.resize(d_fftsize);
     volk_32f_accumulator_s32f(&tmp, d_window.data(), d_fftsize);
     volk_32f_s32f_normalize(d_window.data(), tmp / float(d_fftsize), d_fftsize);
 }

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -205,11 +205,11 @@ unsigned int rx_fft_c::get_fft_size() const
 void rx_fft_c::set_window_type(int wintype)
 {
     float tmp;
-    if (wintype == d_wintype)
-    {
-        /* nothing to do */
-        return;
-    }
+    // if (wintype == d_wintype)
+    // {
+    //     /* nothing to do */
+    //     return;
+    // }
 
     d_wintype = wintype;
 
@@ -218,11 +218,10 @@ void rx_fft_c::set_window_type(int wintype)
         d_wintype = gr::fft::window::WIN_HAMMING;
     }
 
-    const float min_rbw = 100000;
     const float rbw_fft = d_quadrate / (float)d_fftsize;
     unsigned int ntaps;
-    if (min_rbw > rbw_fft)
-        ntaps = std::max((unsigned int)lround(d_quadrate / min_rbw), 1);
+    if (d_rbw > rbw_fft)
+        ntaps = std::max((unsigned int)lround(d_quadrate / d_rbw), 1U);
     else
         ntaps = d_fftsize;
 
@@ -231,6 +230,12 @@ void rx_fft_c::set_window_type(int wintype)
     d_window.resize(d_fftsize);
     volk_32f_accumulator_s32f(&tmp, d_window.data(), d_fftsize);
     volk_32f_s32f_normalize(d_window.data(), tmp / float(d_fftsize), d_fftsize);
+}
+
+void rx_fft_c::set_rbw(int rbw)
+{
+    d_rbw = (float)rbw;
+    set_window_type(d_wintype);
 }
 
 /*! \brief Get currently used window type. */

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -90,6 +90,7 @@ public:
     void get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSize);
 
     void set_window_type(int wintype);
+    void set_rbw(int rbw);
     int  get_window_type() const;
 
     void set_fft_size(unsigned int fftsize);
@@ -100,6 +101,7 @@ private:
     unsigned int d_fftsize;   /*! Current FFT size. */
     double       d_quadrate;
     int          d_wintype;   /*! Current window type. */
+    float        d_rbw;
 
     std::mutex   d_mutex;  /*! Used to lock FFT output buffer. */
 

--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -217,6 +217,11 @@ void DockFft::saveSettings(QSettings *settings)
     else
         settings->remove("averaging");
 
+    if (ui->dbmBox->checkState())
+        settings->setValue("display_dbm_hz", true);
+    else
+        settings->remove("display_dbm_hz");
+
     if (ui->fftSplitSlider->value() != DEFAULT_FFT_SPLIT)
         settings->setValue("split", ui->fftSplitSlider->value());
     else
@@ -334,6 +339,9 @@ void DockFft::readSettings(QSettings *settings)
     intval = settings->value("averaging", DEFAULT_FFT_AVG).toInt(&conv_ok);
     if (conv_ok)
         ui->fftAvgSlider->setValue(intval);
+
+    bool_val = settings->value("display_dbm_hz", false).toBool();
+    ui->dbmBox->setChecked(bool_val);
 
     intval = settings->value("split", DEFAULT_FFT_SPLIT).toInt(&conv_ok);
     if (conv_ok)

--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -292,6 +292,12 @@ void DockFft::saveSettings(QSettings *settings)
     else
         settings->remove("fft_zoom");
 
+    intval = ui->samplingModeBox->currentIndex();
+    if (intval != 0)
+        settings->setValue("sampling_mode", intval);
+    else
+        settings->remove("sampling_mode");
+
     settings->endGroup();
 }
 
@@ -378,6 +384,10 @@ void DockFft::readSettings(QSettings *settings)
     intval = settings->value("fft_zoom", DEFAULT_FFT_ZOOM).toInt(&conv_ok);
     if (conv_ok)
         ui->fftZoomSlider->setValue(intval);
+
+    intval = settings->value("sampling_mode", 0).toInt(&conv_ok);
+    if (conv_ok && intval >=0 && intval <=2)
+        ui->samplingModeBox->setCurrentIndex(intval);
 
     settings->endGroup();
 }
@@ -491,6 +501,11 @@ void DockFft::on_fftZoomSlider_valueChanged(int level)
 {
     ui->zoomLevelLabel->setText(QString("%1x").arg(level));
     emit fftZoomChanged((float)level);
+}
+
+void DockFft::on_samplingModeBox_currentIndexChanged(int index)
+{
+    emit samplingModeChanged(index);
 }
 
 void DockFft::on_pandRangeSlider_valuesChanged(int min, int max)

--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -269,7 +269,7 @@ void DockFft::saveSettings(QSettings *settings)
         settings->setValue("bandplan", true);
     else
         settings->remove("bandplan");
-    
+
     // Peak
     if (ui->peakDetectionButton->isChecked())
         settings->setValue("peak_detect", true);
@@ -441,6 +441,25 @@ void DockFft::on_fftRateComboBox_currentIndexChanged(int index)
 void DockFft::on_fftWinComboBox_currentIndexChanged(int index)
 {
     emit fftWindowChanged(index);
+}
+
+void DockFft::on_rbwBox_currentIndexChanged(int index)
+{
+    if (index == 0)
+    {
+        emit rbwChanged(0);
+    }
+    else
+    {
+        QString text = ui->rbwBox->currentText();
+        int val = text.toInt();
+        emit rbwChanged(val);
+    }
+}
+
+void DockFft::on_dbmBox_stateChanged(int state)
+{
+    emit displayDbmChanged(state);
 }
 
 static const quint64 wf_span_table[] =

--- a/src/qtgui/dockfft.h
+++ b/src/qtgui/dockfft.h
@@ -57,6 +57,7 @@ signals:
     void wfSpanChanged(quint64 span_ms);           /*! Waterfall span changed. */
     void fftSplitChanged(int pct);                 /*! Split between pandapter and waterfall changed. */
     void fftZoomChanged(float level);              /*! Zoom level slider changed. */
+    void samplingModeChanged(int value);           /*! Sampling mode (max/avg/min) changed. */
     void fftAvgChanged(float gain);                /*! FFT video filter gain has changed. */
     void pandapterRangeChanged(float min, float max);
     void waterfallRangeChanged(float min, float max);
@@ -84,6 +85,7 @@ private slots:
     void on_fftSplitSlider_valueChanged(int value);
     void on_fftAvgSlider_valueChanged(int value);
     void on_fftZoomSlider_valueChanged(int level);
+    void on_samplingModeBox_currentIndexChanged(int index);
     void on_pandRangeSlider_valuesChanged(int min, int max);
     void on_wfRangeSlider_valuesChanged(int min, int max);
     void on_resetButton_clicked(void);

--- a/src/qtgui/dockfft.h
+++ b/src/qtgui/dockfft.h
@@ -54,6 +54,8 @@ signals:
     void fftSizeChanged(int size);                 /*! FFT size changed. */
     void fftRateChanged(int fps);                  /*! FFT rate changed. */
     void fftWindowChanged(int window);             /*! FFT window type changed */
+    void rbwChanged(int rbw);                      /*! Minimum RBW */
+    void displayDbmChanged(int state);             /*! Whether to show dBm/Hz.*/
     void wfSpanChanged(quint64 span_ms);           /*! Waterfall span changed. */
     void fftSplitChanged(int pct);                 /*! Split between pandapter and waterfall changed. */
     void fftZoomChanged(float level);              /*! Zoom level slider changed. */
@@ -81,6 +83,8 @@ private slots:
     void on_fftSizeComboBox_currentIndexChanged(int index);
     void on_fftRateComboBox_currentIndexChanged(int index);
     void on_fftWinComboBox_currentIndexChanged(int index);
+    void on_rbwBox_currentIndexChanged(int index);
+    void on_dbmBox_stateChanged(int state);
     void on_wfSpanComboBox_currentIndexChanged(int index);
     void on_fftSplitSlider_valueChanged(int value);
     void on_fftAvgSlider_valueChanged(int value);

--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -71,8 +71,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>350</width>
-         <height>407</height>
+         <width>345</width>
+         <height>546</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
@@ -111,17 +111,39 @@
           <property name="spacing">
            <number>5</number>
           </property>
-          <item row="0" column="2" colspan="2">
-           <widget class="QLabel" name="fftRbwLabel">
+          <item row="10" column="3" rowspan="2">
+           <widget class="QLabel" name="zoomLevelLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="toolTip">
-             <string>Resolution bandwidth</string>
+             <string>Current zoom level on the frequency axis</string>
+            </property>
+            <property name="statusTip">
+             <string>Current zoom level on the frequency axis</string>
             </property>
             <property name="text">
-             <string>RBW: 0 kHz</string>
+             <string>1x</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="14" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Colormap</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
            <widget class="QLabel" name="fftAvgLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -140,90 +162,36 @@
             </property>
            </widget>
           </item>
-          <item row="12" column="1">
-           <widget class="QtColorPicker" name="colorPicker">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>32</height>
-             </size>
-            </property>
+          <item row="9" column="0">
+           <widget class="QLabel" name="wfRangeLabel">
             <property name="toolTip">
-             <string>Click to select color for the FFT plot</string>
+             <string>Set waterfall dB range</string>
             </property>
             <property name="statusTip">
-             <string>Click to select color for the FFT plot</string>
+             <string>Set waterfall dB range</string>
             </property>
             <property name="text">
-             <string/>
-            </property>
-            <property name="flat">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="3">
-           <widget class="QLabel" name="wfLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Waterfall</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="pandLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Panadapter</string>
+             <string>Wf. dB</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="1" column="2" colspan="2">
-           <widget class="QLabel" name="fftOvrLabel">
+          <item row="13" column="0">
+           <widget class="QLabel" name="colorLabel">
             <property name="toolTip">
-             <string>FFT buffer overlap between two consecutive FFT calculations.</string>
+             <string>Color for the FFT plot</string>
             </property>
             <property name="text">
-             <string>Overlap: 0%</string>
-            </property>
-            <property name="margin">
-             <number>0</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="fftRateLabel">
-            <property name="text">
-             <string>Rate</string>
+             <string>Color</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="7" column="1" colspan="2">
+          <item row="8" column="1" colspan="2">
            <widget class="ctkRangeSlider" name="pandRangeSlider">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -254,50 +222,33 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="1" rowspan="2" colspan="2">
-           <widget class="QSlider" name="fftZoomSlider">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="0" column="0">
+           <widget class="QLabel" name="fftSizeLabel">
+            <property name="text">
+             <string>FFT size</string>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Set zoom level on the frequency axis</string>
-            </property>
-            <property name="statusTip">
-             <string>Set zoom level on the frequency axis</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>50</number>
-            </property>
-            <property name="pageStep">
-             <number>5</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="invertedAppearance">
-             <bool>false</bool>
-            </property>
-            <property name="invertedControls">
-             <bool>false</bool>
-            </property>
-            <property name="tickPosition">
-             <enum>QSlider::NoTicks</enum>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="7" column="3">
+          <item row="8" column="0">
+           <widget class="QLabel" name="pandRangeLabel">
+            <property name="toolTip">
+             <string>Set pandapter dB range</string>
+            </property>
+            <property name="statusTip">
+             <string>Set pandapter dB range</string>
+            </property>
+            <property name="text">
+             <string>Pand. dB</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="3">
            <widget class="QPushButton" name="lockButton">
             <property name="enabled">
              <bool>true</bool>
@@ -328,152 +279,23 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QComboBox" name="wfSpanComboBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label">
             <property name="toolTip">
              <string>The vertical time span on the waterfall.</string>
             </property>
-            <item>
-             <property name="text">
-              <string>Auto</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>1 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>2 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>5 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>10 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>15 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>20 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>30 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>1 hour</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>2 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>5 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>10 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>16 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>24 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>48 hours</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QComboBox" name="fftWinComboBox">
-            <property name="toolTip">
-             <string>FFT window</string>
+            <property name="statusTip">
+             <string/>
             </property>
-            <item>
-             <property name="text">
-              <string>Hamming</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Hann</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Blackman</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Rectangular</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Kaiser</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Blackman-Harris</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Bartlett</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Flattop</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="fftSizeLabel">
             <property name="text">
-             <string>FFT size</string>
+             <string>Time span</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="5" column="1" colspan="2">
+          <item row="6" column="1" colspan="2">
            <widget class="QSlider" name="fftSplitSlider">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -504,84 +326,111 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="fftRateComboBox">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="toolTip">
+             <string>FFT window</string>
+            </property>
+            <property name="text">
+             <string>Window</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="fftRateLabel">
+            <property name="text">
+             <string>Rate</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="3">
+           <widget class="QLabel" name="wfLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
+            <property name="text">
+             <string>Waterfall</string>
             </property>
-            <property name="toolTip">
-             <string>FFT refresh rate</string>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
-            <property name="currentIndex">
-             <number>3</number>
-            </property>
-            <item>
-             <property name="text">
-              <string>60 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>50 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>30 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>25 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>20 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>17 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>15 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>10 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>5 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>1 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>0 fps</string>
-             </property>
-            </item>
            </widget>
           </item>
-          <item row="6" column="1" colspan="3">
+          <item row="9" column="1" colspan="2">
+           <widget class="ctkRangeSlider" name="wfRangeSlider">
+            <property name="toolTip">
+             <string>Set waterfall dB range</string>
+            </property>
+            <property name="statusTip">
+             <string>Set waterfall dB range</string>
+            </property>
+            <property name="minimum">
+             <number>-160</number>
+            </property>
+            <property name="maximum">
+             <number>0</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="15" column="0" colspan="4">
+           <widget class="QCheckBox" name="bandPlanCheckbox">
+            <property name="toolTip">
+             <string>Enable Band Plan on bottom of spectrum</string>
+            </property>
+            <property name="text">
+             <string>Enable Band Plan</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2" colspan="2">
+           <widget class="QLabel" name="fftOvrLabel">
+            <property name="toolTip">
+             <string>FFT buffer overlap between two consecutive FFT calculations.</string>
+            </property>
+            <property name="text">
+             <string>Overlap: 0%</string>
+            </property>
+            <property name="margin">
+             <number>0</number>
+            </property>
+           </widget>
+          </item>
+          <item row="16" column="0" colspan="4">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>253</width>
+              <height>68</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="peakLabel">
+            <property name="text">
+             <string>Peak</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1" colspan="3">
            <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
             <property name="spacing">
              <number>2</number>
@@ -659,235 +508,7 @@
             </item>
            </layout>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label">
-            <property name="toolTip">
-             <string>The vertical time span on the waterfall.</string>
-            </property>
-            <property name="statusTip">
-             <string/>
-            </property>
-            <property name="text">
-             <string>Time span</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1" colspan="2">
-           <widget class="ctkRangeSlider" name="wfRangeSlider">
-            <property name="toolTip">
-             <string>Set waterfall dB range</string>
-            </property>
-            <property name="statusTip">
-             <string>Set waterfall dB range</string>
-            </property>
-            <property name="minimum">
-             <number>-160</number>
-            </property>
-            <property name="maximum">
-             <number>0</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="0" colspan="4">
-           <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0">
-            <property name="spacing">
-             <number>2</number>
-            </property>
-            <item>
-             <widget class="QPushButton" name="resetButton">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>50</width>
-                <height>32</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Reset zoom level to 1x</string>
-              </property>
-              <property name="text">
-               <string>Reset</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="centerButton">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>50</width>
-                <height>32</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Center FFT around original center frequency</string>
-              </property>
-              <property name="text">
-               <string>Center</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="demodButton">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>50</width>
-                <height>32</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Center FFT around demodulator frequency</string>
-              </property>
-              <property name="text">
-               <string>Demod</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="wfRangeLabel">
-            <property name="toolTip">
-             <string>Set waterfall dB range</string>
-            </property>
-            <property name="statusTip">
-             <string>Set waterfall dB range</string>
-            </property>
-            <property name="text">
-             <string>Wf. dB</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0" rowspan="2">
-           <widget class="QLabel" name="zoomLAbel">
-            <property name="toolTip">
-             <string>Set zoom level on the frequency axis</string>
-            </property>
-            <property name="statusTip">
-             <string>Set zoom level on the frequency axis</string>
-            </property>
-            <property name="text">
-             <string>Freq zoom</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="12" column="2">
-           <widget class="QPushButton" name="fillButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>32</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Fill the area below the FFT plot with a gradient</string>
-            </property>
-            <property name="statusTip">
-             <string>Fill the area below the FFT plot with a gradient</string>
-            </property>
-            <property name="text">
-             <string>Fill</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="15" column="0" colspan="4">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>253</width>
-              <height>68</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="toolTip">
-             <string>FFT window</string>
-            </property>
-            <property name="text">
-             <string>Window</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="peakLabel">
-            <property name="text">
-             <string>Peak</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1" colspan="2">
+          <item row="5" column="1" colspan="2">
            <widget class="QSlider" name="fftAvgSlider">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -1025,21 +646,15 @@
             </item>
            </widget>
           </item>
-          <item row="12" column="0">
-           <widget class="QLabel" name="colorLabel">
+          <item row="14" column="1" colspan="2">
+           <widget class="QComboBox" name="cmapComboBox">
             <property name="toolTip">
-             <string>Color for the FFT plot</string>
-            </property>
-            <property name="text">
-             <string>Color</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             <string>Select waterfall color map</string>
             </property>
            </widget>
           </item>
-          <item row="9" column="3" rowspan="2">
-           <widget class="QLabel" name="zoomLevelLabel">
+          <item row="2" column="1">
+           <widget class="QComboBox" name="wfSpanComboBox">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -1047,33 +662,312 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Current zoom level on the frequency axis</string>
+             <string>The vertical time span on the waterfall.</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Auto</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>15 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>20 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>30 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1 hour</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>16 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>24 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>48 hours</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="13" column="2">
+           <widget class="QPushButton" name="fillButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>32</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Fill the area below the FFT plot with a gradient</string>
             </property>
             <property name="statusTip">
-             <string>Current zoom level on the frequency axis</string>
+             <string>Fill the area below the FFT plot with a gradient</string>
             </property>
             <property name="text">
-             <string>1x</string>
+             <string>Fill</string>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <property name="checkable">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="pandRangeLabel">
+          <item row="3" column="1" colspan="2">
+           <widget class="QComboBox" name="fftWinComboBox">
             <property name="toolTip">
-             <string>Set pandapter dB range</string>
+             <string>FFT window</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Hamming</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Hann</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Blackman</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Rectangular</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Kaiser</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Blackman-Harris</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Bartlett</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Flattop</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="10" column="1" rowspan="2" colspan="2">
+           <widget class="QSlider" name="fftZoomSlider">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Set zoom level on the frequency axis</string>
             </property>
             <property name="statusTip">
-             <string>Set pandapter dB range</string>
+             <string>Set zoom level on the frequency axis</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>50</number>
+            </property>
+            <property name="pageStep">
+             <number>5</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="invertedAppearance">
+             <bool>false</bool>
+            </property>
+            <property name="invertedControls">
+             <bool>false</bool>
+            </property>
+            <property name="tickPosition">
+             <enum>QSlider::NoTicks</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="1">
+           <widget class="QtColorPicker" name="colorPicker">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>32</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Click to select color for the FFT plot</string>
+            </property>
+            <property name="statusTip">
+             <string>Click to select color for the FFT plot</string>
             </property>
             <property name="text">
-             <string>Pand. dB</string>
+             <string/>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <property name="flat">
+             <bool>true</bool>
             </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="fftRateComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>FFT refresh rate</string>
+            </property>
+            <property name="currentIndex">
+             <number>3</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>60 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>50 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>30 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>25 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>20 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>17 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>15 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>0 fps</string>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="2" column="2" colspan="2">
@@ -1089,32 +983,167 @@
             </property>
            </widget>
           </item>
-          <item row="13" column="1" colspan="2">
-           <widget class="QComboBox" name="cmapComboBox">
+          <item row="12" column="0" colspan="4">
+           <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0">
+            <property name="spacing">
+             <number>2</number>
+            </property>
+            <item>
+             <widget class="QPushButton" name="resetButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>50</width>
+                <height>32</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Reset zoom level to 1x</string>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="centerButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>50</width>
+                <height>32</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Center FFT around original center frequency</string>
+              </property>
+              <property name="text">
+               <string>Center</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="demodButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>50</width>
+                <height>32</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Center FFT around demodulator frequency</string>
+              </property>
+              <property name="text">
+               <string>Demod</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="0" column="2" colspan="2">
+           <widget class="QLabel" name="fftRbwLabel">
             <property name="toolTip">
-             <string>Select waterfall color map</string>
+             <string>Resolution bandwidth</string>
+            </property>
+            <property name="text">
+             <string>RBW: 0 kHz</string>
             </property>
            </widget>
           </item>
-          <item row="13" column="0">
-           <widget class="QLabel" name="label_3">
+          <item row="6" column="0">
+           <widget class="QLabel" name="pandLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
-             <string>Colormap</string>
+             <string>Panadapter</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="14" column="0" colspan="4">
-            <widget class="QCheckBox" name="bandPlanCheckbox">
-              <property name="toolTip">
-                <string>Enable Band Plan on bottom of spectrum</string>
-              </property>
-              <property name="text">
-                <string>Enable Band Plan</string>
-              </property>
-            </widget>
+          <item row="10" column="0" rowspan="2">
+           <widget class="QLabel" name="zoomLAbel">
+            <property name="toolTip">
+             <string>Set zoom level on the frequency axis</string>
+            </property>
+            <property name="statusTip">
+             <string>Set zoom level on the frequency axis</string>
+            </property>
+            <property name="text">
+             <string>Freq zoom</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Sampling</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="samplingModeBox">
+            <item>
+             <property name="text">
+              <string>Maximum</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Average</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Minimum</string>
+             </property>
+            </item>
+           </widget>
           </item>
          </layout>
         </item>

--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>368</width>
+    <width>416</width>
     <height>444</height>
    </rect>
   </property>
@@ -70,9 +70,9 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>0</y>
-         <width>345</width>
-         <height>546</height>
+         <y>-113</y>
+         <width>389</width>
+         <height>618</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
@@ -111,114 +111,13 @@
           <property name="spacing">
            <number>5</number>
           </property>
-          <item row="10" column="3" rowspan="2">
-           <widget class="QLabel" name="zoomLevelLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Current zoom level on the frequency axis</string>
-            </property>
-            <property name="statusTip">
-             <string>Current zoom level on the frequency axis</string>
-            </property>
+          <item row="2" column="0">
+           <widget class="QLabel" name="fftRateLabel">
             <property name="text">
-             <string>1x</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Colormap</string>
+             <string>Rate</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="fftAvgLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>FFT averaging gain</string>
-            </property>
-            <property name="text">
-             <string>Averaging</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0">
-           <widget class="QLabel" name="wfRangeLabel">
-            <property name="toolTip">
-             <string>Set waterfall dB range</string>
-            </property>
-            <property name="statusTip">
-             <string>Set waterfall dB range</string>
-            </property>
-            <property name="text">
-             <string>Wf. dB</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="13" column="0">
-           <widget class="QLabel" name="colorLabel">
-            <property name="toolTip">
-             <string>Color for the FFT plot</string>
-            </property>
-            <property name="text">
-             <string>Color</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1" colspan="2">
-           <widget class="ctkRangeSlider" name="pandRangeSlider">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Set pandapter dB range</string>
-            </property>
-            <property name="statusTip">
-             <string>Set pandapter dB range</string>
-            </property>
-            <property name="minimum">
-             <number>-160</number>
-            </property>
-            <property name="maximum">
-             <number>0</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
@@ -232,159 +131,178 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="pandRangeLabel">
-            <property name="toolTip">
-             <string>Set pandapter dB range</string>
-            </property>
-            <property name="statusTip">
-             <string>Set pandapter dB range</string>
-            </property>
-            <property name="text">
-             <string>Pand. dB</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="3">
-           <widget class="QPushButton" name="lockButton">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="wfSpanComboBox">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>32</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Lock panadapter and waterfall sliders together</string>
-            </property>
-            <property name="statusTip">
-             <string>Lock panadapter and waterfall sliders together</string>
-            </property>
-            <property name="text">
-             <string>Lock</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label">
             <property name="toolTip">
              <string>The vertical time span on the waterfall.</string>
             </property>
-            <property name="statusTip">
-             <string/>
-            </property>
+            <item>
+             <property name="text">
+              <string>Auto</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>15 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>20 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>30 min</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1 hour</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>16 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>24 hours</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>48 hours</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="17" column="0">
+           <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Time span</string>
+             <string>Colormap</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="6" column="1" colspan="2">
-           <widget class="QSlider" name="fftSplitSlider">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>22</height>
-             </size>
-            </property>
+          <item row="1" column="3">
+           <widget class="QLabel" name="fftRbwLabel">
             <property name="toolTip">
-             <string>Spatial distribution between pandapter and waterfall</string>
+             <string>Resolution bandwidth</string>
             </property>
-            <property name="minimum">
-             <number>0</number>
-            </property>
-            <property name="maximum">
-             <number>100</number>
-            </property>
-            <property name="value">
-             <number>35</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+            <property name="text">
+             <string>RBW: 0 kHz</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_2">
+          <item row="13" column="0" rowspan="2">
+           <widget class="QLabel" name="zoomLAbel">
+            <property name="toolTip">
+             <string>Set zoom level on the frequency axis</string>
+            </property>
+            <property name="statusTip">
+             <string>Set zoom level on the frequency axis</string>
+            </property>
+            <property name="text">
+             <string>Freq zoom</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1" colspan="3">
+           <widget class="QComboBox" name="fftWinComboBox">
             <property name="toolTip">
              <string>FFT window</string>
             </property>
-            <property name="text">
-             <string>Window</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
+            <item>
+             <property name="text">
+              <string>Hamming</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Hann</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Blackman</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Rectangular</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Kaiser</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Blackman-Harris</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Bartlett</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Flattop</string>
+             </property>
+            </item>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="fftRateLabel">
-            <property name="text">
-             <string>Rate</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="3">
-           <widget class="QLabel" name="wfLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Waterfall</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="1" colspan="2">
-           <widget class="ctkRangeSlider" name="wfRangeSlider">
-            <property name="toolTip">
-             <string>Set waterfall dB range</string>
-            </property>
-            <property name="statusTip">
-             <string>Set waterfall dB range</string>
-            </property>
-            <property name="minimum">
-             <number>-160</number>
-            </property>
-            <property name="maximum">
-             <number>0</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="15" column="0" colspan="4">
+          <item row="18" column="0" colspan="5">
            <widget class="QCheckBox" name="bandPlanCheckbox">
             <property name="toolTip">
              <string>Enable Band Plan on bottom of spectrum</string>
@@ -394,43 +312,167 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2" colspan="2">
-           <widget class="QLabel" name="fftOvrLabel">
-            <property name="toolTip">
-             <string>FFT buffer overlap between two consecutive FFT calculations.</string>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="rbwBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <property name="text">
-             <string>Overlap: 0%</string>
-            </property>
-            <property name="margin">
-             <number>0</number>
-            </property>
+            <item>
+             <property name="text">
+              <string>Auto</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>20</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>50</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>100</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>200</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>500</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>20000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>50000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>100000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>200000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>500000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1000000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2000000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5000000</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10000000</string>
+             </property>
+            </item>
            </widget>
           </item>
-          <item row="16" column="0" colspan="4">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>253</width>
-              <height>68</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
           <item row="7" column="0">
-           <widget class="QLabel" name="peakLabel">
+           <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Peak</string>
+             <string>FFT Bin</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="7" column="1" colspan="3">
+          <item row="7" column="1">
+           <widget class="QComboBox" name="samplingModeBox">
+            <item>
+             <property name="text">
+              <string>Maximum</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Average</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Min RBW</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="pandLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Panadapter</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1" colspan="4">
            <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
             <property name="spacing">
              <number>2</number>
@@ -508,7 +550,35 @@
             </item>
            </layout>
           </item>
-          <item row="5" column="1" colspan="2">
+          <item row="16" column="1">
+           <widget class="QtColorPicker" name="colorPicker">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>32</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Click to select color for the FFT plot</string>
+            </property>
+            <property name="statusTip">
+             <string>Click to select color for the FFT plot</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1" colspan="3">
            <widget class="QSlider" name="fftAvgSlider">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -539,6 +609,319 @@
             </property>
             <property name="invertedControls">
              <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="fftRateComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>FFT refresh rate</string>
+            </property>
+            <property name="currentIndex">
+             <number>3</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>60 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>50 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>30 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>25 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>20 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>17 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>15 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>0 fps</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="11" column="1" colspan="3">
+           <widget class="ctkRangeSlider" name="pandRangeSlider">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Set pandapter dB range</string>
+            </property>
+            <property name="statusTip">
+             <string>Set pandapter dB range</string>
+            </property>
+            <property name="minimum">
+             <number>-160</number>
+            </property>
+            <property name="maximum">
+             <number>0</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="0">
+           <widget class="QLabel" name="wfRangeLabel">
+            <property name="toolTip">
+             <string>Set waterfall dB range</string>
+            </property>
+            <property name="statusTip">
+             <string>Set waterfall dB range</string>
+            </property>
+            <property name="text">
+             <string>Wf. dB</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="16" column="0">
+           <widget class="QLabel" name="colorLabel">
+            <property name="toolTip">
+             <string>Color for the FFT plot</string>
+            </property>
+            <property name="text">
+             <string>Color</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="toolTip">
+             <string>FFT window</string>
+            </property>
+            <property name="text">
+             <string>Window</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label">
+            <property name="toolTip">
+             <string>The vertical time span on the waterfall.</string>
+            </property>
+            <property name="statusTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Time span</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="4">
+           <widget class="QPushButton" name="lockButton">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>32</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Lock panadapter and waterfall sliders together</string>
+            </property>
+            <property name="statusTip">
+             <string>Lock panadapter and waterfall sliders together</string>
+            </property>
+            <property name="text">
+             <string>Lock</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="fftAvgLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>FFT averaging gain</string>
+            </property>
+            <property name="text">
+             <string>Averaging</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1" colspan="3">
+           <widget class="QSlider" name="fftSplitSlider">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Spatial distribution between pandapter and waterfall</string>
+            </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>35</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1" colspan="3">
+           <widget class="ctkRangeSlider" name="wfRangeSlider">
+            <property name="toolTip">
+             <string>Set waterfall dB range</string>
+            </property>
+            <property name="statusTip">
+             <string>Set waterfall dB range</string>
+            </property>
+            <property name="minimum">
+             <number>-160</number>
+            </property>
+            <property name="maximum">
+             <number>0</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="16" column="3">
+           <widget class="QPushButton" name="fillButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>32</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Fill the area below the FFT plot with a gradient</string>
+            </property>
+            <property name="statusTip">
+             <string>Fill the area below the FFT plot with a gradient</string>
+            </property>
+            <property name="text">
+             <string>Fill</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3" colspan="2">
+           <widget class="QLabel" name="fftOvrLabel">
+            <property name="toolTip">
+             <string>FFT buffer overlap between two consecutive FFT calculations.</string>
+            </property>
+            <property name="text">
+             <string>Overlap: 0%</string>
+            </property>
+            <property name="margin">
+             <number>0</number>
             </property>
            </widget>
           </item>
@@ -646,15 +1029,21 @@
             </item>
            </widget>
           </item>
-          <item row="14" column="1" colspan="2">
-           <widget class="QComboBox" name="cmapComboBox">
+          <item row="3" column="3">
+           <widget class="QLabel" name="wfResLabel">
             <property name="toolTip">
-             <string>Select waterfall color map</string>
+             <string>Waterfall time resolution.</string>
+            </property>
+            <property name="statusTip">
+             <string/>
+            </property>
+            <property name="text">
+             <string>Res: - s</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QComboBox" name="wfSpanComboBox">
+          <item row="13" column="4" rowspan="2">
+           <widget class="QLabel" name="zoomLevelLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -662,167 +1051,20 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>The vertical time span on the waterfall.</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>Auto</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>1 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>2 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>5 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>10 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>15 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>20 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>30 min</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>1 hour</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>2 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>5 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>10 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>16 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>24 hours</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>48 hours</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="13" column="2">
-           <widget class="QPushButton" name="fillButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>32</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Fill the area below the FFT plot with a gradient</string>
+             <string>Current zoom level on the frequency axis</string>
             </property>
             <property name="statusTip">
-             <string>Fill the area below the FFT plot with a gradient</string>
+             <string>Current zoom level on the frequency axis</string>
             </property>
             <property name="text">
-             <string>Fill</string>
+             <string>1x</string>
             </property>
-            <property name="checkable">
-             <bool>true</bool>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QComboBox" name="fftWinComboBox">
-            <property name="toolTip">
-             <string>FFT window</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>Hamming</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Hann</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Blackman</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Rectangular</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Kaiser</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Blackman-Harris</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Bartlett</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Flattop</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="10" column="1" rowspan="2" colspan="2">
+          <item row="13" column="1" rowspan="2" colspan="3">
            <widget class="QSlider" name="fftZoomSlider">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -865,125 +1107,40 @@
             </property>
            </widget>
           </item>
-          <item row="13" column="1">
-           <widget class="QtColorPicker" name="colorPicker">
+          <item row="10" column="0">
+           <widget class="QLabel" name="peakLabel">
+            <property name="text">
+             <string>Peak</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="17" column="1" colspan="3">
+           <widget class="QComboBox" name="cmapComboBox">
+            <property name="toolTip">
+             <string>Select waterfall color map</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="4">
+           <widget class="QLabel" name="wfLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>32</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Click to select color for the FFT plot</string>
-            </property>
-            <property name="statusTip">
-             <string>Click to select color for the FFT plot</string>
-            </property>
             <property name="text">
-             <string/>
+             <string>Waterfall</string>
             </property>
-            <property name="flat">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="fftRateComboBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>FFT refresh rate</string>
-            </property>
-            <property name="currentIndex">
-             <number>3</number>
-            </property>
-            <item>
-             <property name="text">
-              <string>60 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>50 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>30 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>25 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>20 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>17 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>15 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>10 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>5 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>1 fps</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>0 fps</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="2" column="2" colspan="2">
-           <widget class="QLabel" name="wfResLabel">
-            <property name="toolTip">
-             <string>Waterfall time resolution.</string>
-            </property>
-            <property name="statusTip">
-             <string/>
-            </property>
-            <property name="text">
-             <string>Res: - s</string>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="12" column="0" colspan="4">
+          <item row="15" column="0" colspan="5">
            <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0">
             <property name="spacing">
              <number>2</number>
@@ -1074,75 +1231,50 @@
             </item>
            </layout>
           </item>
-          <item row="0" column="2" colspan="2">
-           <widget class="QLabel" name="fftRbwLabel">
+          <item row="11" column="0">
+           <widget class="QLabel" name="pandRangeLabel">
             <property name="toolTip">
-             <string>Resolution bandwidth</string>
-            </property>
-            <property name="text">
-             <string>RBW: 0 kHz</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="pandLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Panadapter</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="0" rowspan="2">
-           <widget class="QLabel" name="zoomLAbel">
-            <property name="toolTip">
-             <string>Set zoom level on the frequency axis</string>
+             <string>Set pandapter dB range</string>
             </property>
             <property name="statusTip">
-             <string>Set zoom level on the frequency axis</string>
+             <string>Set pandapter dB range</string>
             </property>
             <property name="text">
-             <string>Freq zoom</string>
+             <string>Pand. dB</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_4">
+          <item row="19" column="0" colspan="5">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>253</width>
+              <height>68</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Sampling</string>
+             <string>Display</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QComboBox" name="samplingModeBox">
-            <item>
-             <property name="text">
-              <string>Maximum</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Average</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Minimum</string>
-             </property>
-            </item>
+          <item row="6" column="1">
+           <widget class="QCheckBox" name="dbmBox">
+            <property name="text">
+             <string>dBm/Hz 50Ω</string>
+            </property>
            </widget>
           </item>
          </layout>

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1264,37 +1264,6 @@ void CPlotter::getScreenIntegerFFTData(qint32 plotHeight, qint32 plotWidth,
             if (xprev >= 0)
                 outBuf[xprev] = lround((double)binsum / (double)bincount);
         }
-        else if (mode == SAMPLING_MODE_MIN)
-        {
-            qint32 ymin = 10000;
-            for (i = minbin; i < maxbin; i++ )
-            {
-                y = (qint32)(dBGainFactor*(maxdB-m_pFFTAveBuf[i]));
-
-                if (y > plotHeight)
-                    y = plotHeight;
-                else if (y < 0)
-                    y = 0;
-
-                x = m_pTranslateTbl[i];	//get fft bin to plot x coordinate transform
-
-                if (x == xprev)   // still mappped to same fft bin coordinate
-                {
-                    if (y > ymin) // store only the min value
-                    {
-                        outBuf[x] = y;
-                        ymin = y;
-                    }
-
-                }
-                else
-                {
-                    outBuf[x] = y;
-                    xprev = x;
-                    ymin = y;
-                }
-            }
-        }
     }
 
     // more plot points than FFT points

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -123,6 +123,12 @@ public:
     void    clearWaterfall();
     bool    saveWaterfall(const QString & filename) const;
 
+    enum eSamplingMode {
+        SAMPLING_MODE_MAX = 0,
+        SAMPLING_MODE_AVG = 1,
+        SAMPLING_MODE_MIN = 2
+    };
+
 signals:
     void newDemodFreq(qint64 freq, qint64 delta); /* delta is the offset from the center */
     void newLowCutFreq(int f);
@@ -138,6 +144,7 @@ public slots:
     void moveToCenterFreq();
     void moveToDemodFreq();
     void zoomOnXAxis(float level);
+    void setSamplingMode(int mode);
 
     // other FFT slots
     void setFftPlotColor(const QColor& color);
@@ -194,7 +201,8 @@ private:
                                  float maxdB, float mindB,
                                  qint64 startFreq, qint64 stopFreq,
                                  float *inBuf, qint32 *outBuf,
-                                 qint32 *maxbin, qint32 *minbin) const;
+                                 qint32 *maxbin, qint32 *minbin,
+                                 enum eSamplingMode mode = SAMPLING_MODE_MAX) const;
     static void calcDivSize (qint64 low, qint64 high, int divswanted, qint64 &adjlow, qint64 &step, int& divs);
     void        showToolTip(QMouseEvent* event, QString toolTipText);
 
@@ -260,6 +268,7 @@ private:
     qint32      m_FreqUnits;
     int         m_ClickResolution;
     int         m_FilterClickResolution;
+    eSamplingMode m_SamplingMode;
 
     int         m_Xzero{};
     int         m_Yzero{};  /*!< Used to measure mouse drag direction. */

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -125,9 +125,7 @@ public:
 
     enum eSamplingMode {
         SAMPLING_MODE_MAX = 0,
-        SAMPLING_MODE_AVG = 1,
-        SAMPLING_MODE_MIN = 2
-    };
+        SAMPLING_MODE_AVG = 1    };
 
 signals:
     void newDemodFreq(qint64 freq, qint64 delta); /* delta is the offset from the center */

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -197,10 +197,10 @@ private:
     }
     void getScreenIntegerFFTData(qint32 plotHeight, qint32 plotWidth,
                                  float maxdB, float mindB,
-                                 qint64 startFreq, qint64 stopFreq,
-                                 float *inBuf, qint32 *outBuf,
-                                 qint32 *maxbin, qint32 *minbin,
-                                 enum eSamplingMode mode = SAMPLING_MODE_MAX) const;
+                                 qint64 startFreq, qint64 endFreq,
+                                 const float *fftAvgBuf, qint32 *outBuf,
+                                 int *xmin, int *xmax,
+                                 eSamplingMode mode = SAMPLING_MODE_MAX) const;
     static void calcDivSize (qint64 low, qint64 high, int divswanted, qint64 &adjlow, qint64 &step, int& divs);
     void        showToolTip(QMouseEvent* event, QString toolTipText);
 


### PR DESCRIPTION
When the fftsize is greater than the width of the plotter (pixels) the contents of the fft are resampled. Currently, the maximum of all the fft bins mapped to a pixel is shown. This commit adds user-controllable max/avg/min.