### PR TITLE
Power scaling for dBm/Hz into 50 ohms

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1364,7 +1364,7 @@ void MainWindow::iqFftTimeout()
 {
     unsigned int    fftsize;
     unsigned int    i;
-    float           pwr_scale;
+    double          quad_rate = rx->get_input_rate() / rx->get_input_decim();
 
     // FIXME: fftsize is a reference
     rx->get_iq_fft_data(d_fftData, fftsize);
@@ -1375,9 +1375,8 @@ void MainWindow::iqFftTimeout()
         return;
     }
 
-    // NB: without cast to float the multiplication will overflow at 64k
-    // and pwr_scale will be inf
-    pwr_scale = 1.0 / ((float)fftsize * (float)fftsize);
+    // Scale for dBm into 50 ohms
+    const double pwr_scale = 1000.0 / (2.0 * (double)fftsize * quad_rate * 50.0);
 
     /* Normalize, calculate power and shift the FFT */
     volk_32fc_magnitude_squared_32f(d_realFftData, d_fftData + (fftsize/2), fftsize/2);


### PR DESCRIPTION
Scale PSD as dBm/Hz into a 50 ohm load. The current code assumes that bandwidth is same as FFT size, which is not usually the case. Also, most work with spectrum analyzers in radio is done using units of dBm rather than dBW. A spectrum analyzer compensates for load, typically 50 ohms in radio.

Playing white noise at 1MS/s, a level of -60 dBW is expected. Compensating for dBm into 50 ohms (+13dB), levels are seen to be -37dB on Gqrx at higher at higher FFT sizes. At lower sizes, max hold shows -37dB with averaging turned all the way down.

Experiments with a DC "tone" looked "about right". A tone always manages to be spread over bins or averaged in a bin, so the best test I could find was a 262144 bin FFT with a DC file played at 262144 S/s. A level of -10dB was shown. I was hoping for -7dB. The tone may have been split between bins, even though I thought DC was a single bin.

We don't really have a concept of RBW, other than rate/fftsize, which is different than a spectrum analyzer.

![scale-factor-dbm-50](https://user-images.githubusercontent.com/1258295/228268933-2ec6cbb4-6a0b-4217-b14a-bce387457bba.png)
