### PR TITLE
use Blackman-Harris window in ddc to reduce aliasing

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -7,6 +7,7 @@
      FIXED: Remove empty frame from bottom of I/Q tool window.
      FIXED: Sudden scrolling of file list in I/Q tool window.
      FIXED: Reset zoom slider after right click on panadapter / waterfall.
+     FIXED: Aliasing when input rate is higher than 2 Msps.
   IMPROVED: AGC performance.
   IMPROVED: WFM stereo & OIRT performance.
   IMPROVED: Apply amplitude normalization to FFT window functions.

--- a/src/dsp/downconverter.cpp
+++ b/src/dsp/downconverter.cpp
@@ -94,7 +94,12 @@ void downconverter_cc::update_proto_taps()
     {
         double out_rate = d_samp_rate / d_decim;
         filt->set_taps(gr::filter::firdes::low_pass(1.0, d_samp_rate, LPF_CUTOFF, out_rate - 2*LPF_CUTOFF,
-            gr::fft::window::WIN_BLACKMAN_HARRIS));
+#if GNURADIO_VERSION < 0x030900
+            gr::filter::firdes::WIN_BLACKMAN_HARRIS
+#else
+            gr::fft::window::WIN_BLACKMAN_HARRIS
+#endif
+        ));
     }
 }
 

--- a/src/dsp/downconverter.cpp
+++ b/src/dsp/downconverter.cpp
@@ -93,7 +93,8 @@ void downconverter_cc::update_proto_taps()
     if (d_decim > 1)
     {
         double out_rate = d_samp_rate / d_decim;
-        filt->set_taps(gr::filter::firdes::low_pass(1.0, d_samp_rate, LPF_CUTOFF, out_rate - 2*LPF_CUTOFF));
+        filt->set_taps(gr::filter::firdes::low_pass(1.0, d_samp_rate, LPF_CUTOFF, out_rate - 2*LPF_CUTOFF,
+            gr::fft::window::WIN_BLACKMAN_HARRIS));
     }
 }
 


### PR DESCRIPTION
At input sampling frequencies of 2 MHz and above, GQRX uses a downconverter to decimate the sampling frequency before demodulation is performed. However, the aliasing filter used has poor stopband attenuation. This results in ghost signals that can be heard clearly at frequencies where the spectrum only shows a flat baseline, typically 1 MHz above or below a strong signal.
To reproduce the problem, set the input sampling frequency to 2 MHz or a higher integer multiple of 1 MHz. Then search a strong signal where the spectrum is quiet 1 MHz above or below that signal. Compare the S-meter readings when tuning to the strong signal and when tuning to the clear frequency 1 MHz below or above the signal. Tune in such a way that the strong signal itself remains in the range of the main spectrum. At 2 MHz input sample rate, the difference of S-meter readings is only about 33 dB, and the strong signal is clearly demodulated at the frequency that is clear in the spectrum. The S-meter reading when tuned to that frequency is also much higher than at other frequencies that show the same noise level in the main spectrum.
A simple fix is to use the Blackman-Harris window instead of the default Hamming window when creating the filter taps. This drastically increases stopband attenuation at a moderate increase of the number of filter taps, without significant impact on overall CPU load.