### PR TITLE
Drop support for GNU Radio 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         image:
-          - "ubuntu:18.04"
           - "ubuntu:20.04"
           - "ubuntu:22.04"
         backend:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,10 +148,6 @@ math(EXPR GNURADIO_BCD_VERSION
 )
 add_definitions(-DGNURADIO_VERSION=${GNURADIO_BCD_VERSION})
 
-if(Gnuradio_VERSION VERSION_LESS "3.8")
-    find_package(Boost COMPONENTS system REQUIRED)
-endif()
-
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
     if(NOT LINUX_AUDIO_BACKEND)
         set(LINUX_AUDIO_BACKEND Pulseaudio CACHE STRING "Choose the audio backend, options are: Pulseaudio, Portaudio, Gr-audio" FORCE)
@@ -167,11 +163,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
         unset(PORTAUDIO_LIBRARIES CACHE)
     elseif(${LINUX_AUDIO_BACKEND} MATCHES "Portaudio")
         message(STATUS "Portaudio backend enabled")
-        if(Gnuradio_VERSION VERSION_LESS "3.8")
-            find_package(Portaudio REQUIRED)
-        else()
-            find_package(PORTAUDIO REQUIRED)
-        endif()
+        find_package(PORTAUDIO REQUIRED)
         add_definitions(-DWITH_PORTAUDIO)
         unset(PULSEAUDIO_FOUND CACHE)
         unset(PULSEAUDIO_INCLUDE_DIR CACHE)
@@ -203,11 +195,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
     if(${OSX_AUDIO_BACKEND} MATCHES "Portaudio")
         message(STATUS "Portaudio backend enabled")
-        if(Gnuradio_VERSION VERSION_LESS "3.8")
-            find_package(Portaudio REQUIRED)
-        else()
-            find_package(PORTAUDIO REQUIRED)
-        endif()
+        find_package(PORTAUDIO REQUIRED)
         add_definitions(-DWITH_PORTAUDIO)
         unset(PULSEAUDIO_FOUND CACHE)
         unset(PULSEAUDIO_INCLUDE_DIR CACHE)
@@ -255,17 +243,6 @@ link_directories(
     ${GNURADIO_RUNTIME_LIBRARY_DIRS}
     ${ICU4C_LIBRARY_DIRS}
 )
-
-if(Gnuradio_VERSION VERSION_LESS "3.8")
-    include_directories(
-        ${Boost_INCLUDE_DIRS}
-        ${GNURADIO_RUNTIME_INCLUDE_DIRS}
-    )
-
-    link_directories(
-        ${Boost_LIBRARY_DIRS}
-    )
-endif()
 
 # Install desktop
 install(FILES dk.gqrx.gqrx.desktop DESTINATION share/applications)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Installation from source
 The source code is hosted on Github: https://github.com/gqrx-sdr/gqrx
 
 To compile gqrx from source you need the following dependencies:
-- GNU Radio 3.7, 3.8, 3.9, or 3.10 with the following components:
+- GNU Radio 3.8, 3.9, or 3.10 with the following components:
     - gnuradio-runtime
     - gnuradio-analog
     - gnuradio-audio

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+      2.16: In progress...
+
+   REMOVED: Support for GNU Radio 3.7.
+
+
    2.15.10: Released April 13, 2023
 
        NEW: Restore FFT zoom level between sessions.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,7 +111,7 @@ if(NOT Gnuradio_VERSION VERSION_LESS "3.10")
         gnuradio::gnuradio-audio
         Volk::volk
     )
-elseif(NOT Gnuradio_VERSION VERSION_LESS "3.8")
+else()
     target_link_libraries(${PROJECT_NAME}
         gnuradio::gnuradio-analog
         gnuradio::gnuradio-blocks
@@ -119,12 +119,6 @@ elseif(NOT Gnuradio_VERSION VERSION_LESS "3.8")
         gnuradio::gnuradio-filter
         gnuradio::gnuradio-audio
         Volk::volk
-    )
-else()
-    target_link_libraries(${PROJECT_NAME}
-        ${Boost_LIBRARIES}
-        ${GNURADIO_ALL_LIBRARIES}
-        ${VOLK_LIBRARIES}
     )
 endif()
 

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -23,13 +23,8 @@
 #ifndef RECEIVER_H
 #define RECEIVER_H
 
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/blocks/multiply_const_ff.h>
-#else
-#include <gnuradio/blocks/multiply_const.h>
-#endif
-
 #include <gnuradio/blocks/file_sink.h>
+#include <gnuradio/blocks/multiply_const.h>
 #include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/blocks/wavfile_sink.h>
 #include <gnuradio/blocks/wavfile_source.h>

--- a/src/dsp/correct_iq_cc.h
+++ b/src/dsp/correct_iq_cc.h
@@ -26,14 +26,9 @@
 #include <gnuradio/gr_complex.h>
 #include <gnuradio/blocks/complex_to_float.h>
 #include <gnuradio/blocks/float_to_complex.h>
+#include <gnuradio/blocks/sub.h>
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/single_pole_iir_filter_cc.h>
-
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/blocks/sub_cc.h>
-#else
-#include <gnuradio/blocks/sub.h>
-#endif
 
 class dc_corr_cc;
 class iq_swap_cc;

--- a/src/dsp/downconverter.h
+++ b/src/dsp/downconverter.h
@@ -22,13 +22,8 @@
  */
 #pragma once
 
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/filter/freq_xlating_fir_filter_ccf.h>
-#else
-#include <gnuradio/filter/freq_xlating_fir_filter.h>
-#endif
-
 #include <gnuradio/blocks/rotator_cc.h>
+#include <gnuradio/filter/freq_xlating_fir_filter.h>
 #include <gnuradio/hier_block2.h>
 
 class downconverter_cc;

--- a/src/dsp/filter/fir_decim.cpp
+++ b/src/dsp/filter/fir_decim.cpp
@@ -24,10 +24,6 @@
 #include <cstdio>
 #include <vector>
 
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/filter/fir_filter_ccf.h>
-#endif
-
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/io_signature.h>
 

--- a/src/dsp/filter/fir_decim.h
+++ b/src/dsp/filter/fir_decim.h
@@ -22,12 +22,7 @@
  */
 #pragma once
 
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/filter/fir_filter_ccf.h>
-#else
 #include <gnuradio/filter/fir_filter_blk.h>
-#endif
-
 #include <gnuradio/hier_block2.h>
 
 class fir_decim_cc;

--- a/src/dsp/lpf.h
+++ b/src/dsp/lpf.h
@@ -25,12 +25,7 @@
 
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/firdes.h>
-
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/filter/fir_filter_fff.h>
-#else
 #include <gnuradio/filter/fir_filter_blk.h>
-#endif
 
 
 class lpf_ff;

--- a/src/dsp/rx_filter.h
+++ b/src/dsp/rx_filter.h
@@ -24,14 +24,8 @@
 #define RX_FILTER_H
 
 #include <gnuradio/hier_block2.h>
-
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/filter/fir_filter_ccc.h>
-#include <gnuradio/filter/freq_xlating_fir_filter_ccc.h>
-#else
 #include <gnuradio/filter/fir_filter_blk.h>
 #include <gnuradio/filter/freq_xlating_fir_filter.h>
-#endif
 
 
 #define RX_FILTER_MIN_WIDTH 100  /*! Minimum width of filter */

--- a/src/dsp/rx_rds.h
+++ b/src/dsp/rx_rds.h
@@ -26,30 +26,21 @@
 #include <mutex>
 #include <gnuradio/hier_block2.h>
 
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/filter/fir_filter_ccf.h>
-#include <gnuradio/filter/freq_xlating_fir_filter_fcf.h>
-#include <gnuradio/digital/clock_recovery_mm_cc.h>
-#else
-#include <gnuradio/filter/fir_filter_blk.h>
-#include <gnuradio/filter/freq_xlating_fir_filter.h>
-#include <gnuradio/digital/symbol_sync_cc.h>
-#endif
-
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/filter/rational_resampler_base_ccf.h>
-#elif GNURADIO_VERSION < 0x030900
+#if GNURADIO_VERSION < 0x030900
 #include <gnuradio/filter/rational_resampler_base.h>
 #else
 #include <gnuradio/filter/rational_resampler.h>
 #endif
 
 #include <gnuradio/analog/agc_cc.h>
-#include <gnuradio/digital/constellation_receiver_cb.h>
 #include <gnuradio/blocks/keep_one_in_n.h>
-#include <gnuradio/digital/diff_decoder_bb.h>
 #include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/blocks/message_debug.h>
+#include <gnuradio/digital/constellation_receiver_cb.h>
+#include <gnuradio/digital/diff_decoder_bb.h>
+#include <gnuradio/digital/symbol_sync_cc.h>
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/filter/freq_xlating_fir_filter.h>
 #include <queue>
 #include "dsp/rds/decoder.h"
 #include "dsp/rds/parser.h"
@@ -110,12 +101,7 @@ private:
     std::vector<float> d_rrcf;
     std::vector<float> d_rrcf_manchester;
     gr::analog::agc_cc::sptr d_agc;
-#if GNURADIO_VERSION < 0x030800
-    gr::digital::clock_recovery_mm_cc::sptr d_sync;
-    gr::blocks::keep_one_in_n::sptr d_koin;
-#else
     gr::digital::symbol_sync_cc::sptr d_sync;
-#endif
     gr::digital::constellation_receiver_cb::sptr d_mpsk;
     gr::digital::diff_decoder_bb::sptr d_ddbb;
 

--- a/src/dsp/stereo_demod.h
+++ b/src/dsp/stereo_demod.h
@@ -25,27 +25,15 @@
 #define STEREO_DEMOD_H
 
 #include <gnuradio/hier_block2.h>
-#include <gnuradio/filter/firdes.h>
-
-#if GNURADIO_VERSION < 0x030800
-#include <gnuradio/filter/fir_filter_fcc.h>
-#include <gnuradio/filter/fir_filter_fff.h>
-#include <gnuradio/blocks/multiply_cc.h>
-#include <gnuradio/blocks/multiply_ff.h>
-#include <gnuradio/blocks/multiply_const_ff.h>
-#include <gnuradio/blocks/add_ff.h>
-#include <gnuradio/blocks/sub_ff.h>
-#else
-#include <gnuradio/filter/fir_filter_blk.h>
-#include <gnuradio/blocks/multiply.h>
-#include <gnuradio/blocks/multiply_const.h>
-#include <gnuradio/blocks/add_blk.h>
-#include <gnuradio/blocks/sub.h>
-#endif
-
 #include <gnuradio/analog/pll_refout_cc.h>
+#include <gnuradio/blocks/add_blk.h>
 #include <gnuradio/blocks/complex_to_imag.h>
 #include <gnuradio/blocks/delay.h>
+#include <gnuradio/blocks/multiply.h>
+#include <gnuradio/blocks/multiply_const.h>
+#include <gnuradio/blocks/sub.h>
+#include <gnuradio/filter/firdes.h>
+#include <gnuradio/filter/fir_filter_blk.h>
 #include <vector>
 #include "dsp/fm_deemph.h"
 #include "dsp/lpf.h"


### PR DESCRIPTION
GNU Radio 3.7 had its final release in February 2020, and has been fully unsupported since November 2021. Ubuntu 18.04, which ships with GNU Radio 3.7, goes out of support at the end of this month. So as we begin work on the upcoming Gqrx 2.16 feature release, I think it's time to say goodbye to GNU Radio 3.7 and remove all the conditionally-compiled code that was needed to support it.