### PR TITLE
Fix loading of narrow FM tau setting

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,6 +1,7 @@
 
       2.16: In progress...
 
+     FIXED: Loading of narrow FM tau setting.
    REMOVED: Support for GNU Radio 3.7.
 
 

--- a/src/qtgui/demod_options.cpp
+++ b/src/qtgui/demod_options.cpp
@@ -44,10 +44,10 @@ int tau_to_index(double tau)
     int i;
     for (i = 0; i < tau_tbl_maxidx; i++)
     {
-        if (tau < (tau_tbl[i] + 0.5 * (tau_tbl[i+1] - tau_tbl[i])))
+        if (tau < (tau_tbl[i] + tau_tbl[i+1]) / 2)
             return i;
     }
-    return 0;
+    return tau_tbl_maxidx;
 }
 
 /* convert betweenFM max dev and combo index */


### PR DESCRIPTION
While reviewing #1043 I noticed that the narrow FM "tau" setting is not loaded correctly when set to 1 ms. (It instead sets itself to "Off".) This happens because `tau_to_index` incorrectly returns 0 when the input value is greater than 765 μs. It should instead return `tau_tbl_maxidx`.

I also simplified the midpoint calculation in `tau_to_index`.