### PR TITLE
bookmarks: Filter panadapter bookmark marks by tags

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
        NEW: Restore AM & AM-Sync settings between sessions.
        NEW: Set/get audio gain via remote control.
+       NEW: Only show bookmarks for active tag groups in the panadapter.
      FIXED: Loading of narrow FM tau setting.
      FIXED: Crash when adding or removing bookmark tags.
      FIXED: Redraw bookmarks immediately after changes.

--- a/src/qtgui/bookmarks.cpp
+++ b/src/qtgui/bookmarks.cpp
@@ -220,7 +220,7 @@ QList<BookmarkInfo> Bookmarks::getBookmarksInRange(qint64 low, qint64 high)
     while (lb != ub)
     {
         const BookmarkInfo& info = *lb;
-        //if(info.IsActive())
+        if(info.IsActive())
         {
           found.append(info);
         }


### PR DESCRIPTION
Update panadapter overlay in addition to the bookmarks list when the user sets/removes a tag checkmark.
Requires #1188 to work correctly.