### PR TITLE
Replace QTime with std::chrono in DX Cluster

### DIFF
--- a/src/qtgui/dxc_spots.cpp
+++ b/src/qtgui/dxc_spots.cpp
@@ -50,7 +50,7 @@ DXCSpots& DXCSpots::Get()
 
 void DXCSpots::add(DXCSpotInfo &info)
 {
-    info.time = QTime::currentTime();
+    info.time = std::chrono::steady_clock::now();
     // check only callsign, so if present remove and re-append
     // if check also frequency we can only change the time
     if (m_DXCSpotList.contains(info))
@@ -58,14 +58,16 @@ void DXCSpots::add(DXCSpotInfo &info)
     m_DXCSpotList.append(info);
     std::stable_sort(m_DXCSpotList.begin(),m_DXCSpotList.end());
     emit( dxcSpotsUpdated() );
-    QTimer::singleShot(m_DXCSpotTimeout * 1000, this, SLOT(checkSpotTimeout()));
+    QTimer::singleShot(m_DXCSpotTimeout, this, SLOT(checkSpotTimeout()));
 }
 
 void DXCSpots::checkSpotTimeout()
 {
+    auto now = std::chrono::steady_clock::now();
     for (int i = 0; i < m_DXCSpotList.size(); i++)
     {
-        if ( m_DXCSpotTimeout <= m_DXCSpotList[i].time.secsTo(QTime::currentTime() ))
+        auto diff = std::chrono::duration_cast<std::chrono::seconds>(now - m_DXCSpotList[i].time);
+        if ( m_DXCSpotTimeout <= diff)
         {
             m_DXCSpotList.removeAt(i);
         }

--- a/src/qtgui/dxc_spots.h
+++ b/src/qtgui/dxc_spots.h
@@ -30,19 +30,19 @@
 #include <QList>
 #include <QStringList>
 #include <QColor>
-#include <QTime>
+#include <chrono>
 
 struct DXCSpotInfo
 {
     qint64  frequency;
     QString name;
-    QTime time;
+    std::chrono::time_point<std::chrono::steady_clock> time;
     QColor color;
 
     DXCSpotInfo()
     {
         this->frequency = 0;
-        this->time = QTime::currentTime();
+        this->time = std::chrono::steady_clock::now();
         this->color = Qt::lightGray;
     }
 
@@ -70,14 +70,14 @@ public:
     static DXCSpots& Get();
 
     void add(DXCSpotInfo& info);
-    void setSpotTimeout(int i) {m_DXCSpotTimeout = i * 60;}
+    void setSpotTimeout(int i) { m_DXCSpotTimeout = std::chrono::seconds(i * 60); }
     DXCSpotInfo& getDXCSpot(int i) { return m_DXCSpotList[i]; }
     QList<DXCSpotInfo> getDXCSpotsInRange(qint64 low, qint64 high);
 
 private:
     DXCSpots(); // Singleton Constructor is private.
     QList<DXCSpotInfo> m_DXCSpotList;
-    int m_DXCSpotTimeout;
+    std::chrono::seconds m_DXCSpotTimeout;
     static DXCSpots* m_pThis;
 
 private slots:


### PR DESCRIPTION
DX Cluster spots are supposed to expire after a configurable number of minutes, but spots that occur just before midnight fail to expire. This happens because `QTime` is used to compare timestamps, and this class represents a 24-hour clock time that resets each midnight. A similar problem could occur during daylight saving time changes.

Here I've replaced `QTime` with `std::chrono::steady_clock`, which is a monotonic clock suitable for measuring intervals.