### PR TITLE
Fix high-DPI rendering of frequency control and S-meter

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -8,6 +8,7 @@
      FIXED: Crash when adding or removing bookmark tags.
      FIXED: Redraw bookmarks immediately after changes.
      FIXED: DX cluster spots fail to expire around midnight.
+  IMPROVED: Rendering of frequency control and S-meter on some high-DPI screens.
    REMOVED: Support for GNU Radio 3.7.
 
 

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -376,7 +376,7 @@ void CFreqCtrl::updateCtrl(bool all)
 void CFreqCtrl::resizeEvent(QResizeEvent *)
 {
 // qDebug() <<rect.width() << rect.height();
-    int dpr = devicePixelRatio();
+    qreal dpr = devicePixelRatioF();
     m_Pixmap = QPixmap(width() * dpr, height() * dpr); // resize pixmap to current control size
     m_Pixmap.setDevicePixelRatio(dpr);
     m_Pixmap.fill(m_BkColor);

--- a/src/qtgui/meter.cpp
+++ b/src/qtgui/meter.cpp
@@ -92,7 +92,7 @@ void CMeter::resizeEvent(QResizeEvent *)
     {
         // if size changed, resize pixmaps to new screensize
         m_Size = size();
-        int dpr = devicePixelRatio();
+        qreal dpr = devicePixelRatioF();
         m_OverlayPixmap = QPixmap(m_Size.width() * dpr, m_Size.height() * dpr);
         m_OverlayPixmap.setDevicePixelRatio(dpr);
         m_OverlayPixmap.fill(Qt::black);
@@ -156,8 +156,8 @@ void CMeter::draw()
         return;
 
     // get/draw the 2D spectrum
-    w = m_2DPixmap.width() / m_2DPixmap.devicePixelRatio();
-    h = m_2DPixmap.height() / m_2DPixmap.devicePixelRatio();
+    w = m_2DPixmap.width() / m_2DPixmap.devicePixelRatioF();
+    h = m_2DPixmap.height() / m_2DPixmap.devicePixelRatioF();
 
     // first copy into 2Dbitmap the overlay bitmap.
     m_2DPixmap = m_OverlayPixmap.copy(0, 0, m_OverlayPixmap.width(), m_OverlayPixmap.height());
@@ -207,8 +207,8 @@ void CMeter::DrawOverlay()
     if (m_OverlayPixmap.isNull())
         return;
 
-    int w = m_OverlayPixmap.width() / m_OverlayPixmap.devicePixelRatio();
-    int h = m_OverlayPixmap.height() / m_OverlayPixmap.devicePixelRatio();
+    int w = m_OverlayPixmap.width() / m_OverlayPixmap.devicePixelRatioF();
+    int h = m_OverlayPixmap.height() / m_OverlayPixmap.devicePixelRatioF();
     int x,y;
     QRect rect;
     QPainter painter(&m_OverlayPixmap);


### PR DESCRIPTION
The frequency control and S-meter look pixelated on high-DPI screens where the device pixel ratio is fractional. This can be observed by running, for instance, `QT_SCALE_FACTOR=1.5 gqrx`:

![Screenshot from 2023-04-19 18-15-20](https://user-images.githubusercontent.com/583749/233212096-a23d33fe-5965-4995-beec-ffb79810155e.png)

After storing the device pixel ratio in a `qreal` instead of `int`, all is well:

![Screenshot from 2023-04-19 18-16-10](https://user-images.githubusercontent.com/583749/233212111-756b93f2-b98f-4b4e-bbb4-69e138b28831.png)