### PR TITLE
Allow dock buttons to be smaller

### DIFF
--- a/src/qtgui/dockaudio.ui
+++ b/src/qtgui/dockaudio.ui
@@ -163,6 +163,12 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="toolTip">
          <string>Mute audio output</string>
         </property>
@@ -185,6 +191,12 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="toolTip">
          <string>Stream raw audio over UDP</string>
         </property>
@@ -206,6 +218,12 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="toolTip">
          <string>Record audio</string>
@@ -238,6 +256,12 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="toolTip">
          <string>Playback previously recorded audio</string>
         </property>
@@ -268,6 +292,12 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="toolTip">
          <string>Audio settings</string>

--- a/src/qtgui/dockrxopt.ui
+++ b/src/qtgui/dockrxopt.ui
@@ -146,6 +146,12 @@ This is an offset from the hardware RF frequency.&lt;/p&gt;&lt;/body&gt;&lt;/htm
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="toolTip">
          <string>AGC options</string>
         </property>
@@ -198,6 +204,12 @@ This is an offset from the hardware RF frequency.&lt;/p&gt;&lt;/body&gt;&lt;/htm
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="toolTip">
          <string>Noise blanker options</string>
@@ -319,6 +331,12 @@ This is an offset from the hardware RF frequency.&lt;/p&gt;&lt;/body&gt;&lt;/htm
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
         </property>
         <property name="toolTip">
          <string>Demodulator options</string>
@@ -469,6 +487,12 @@ This is an offset from the hardware RF frequency.&lt;/p&gt;&lt;/body&gt;&lt;/htm
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>Noise blanker for static type noise</string>
           </property>
@@ -496,6 +520,12 @@ This is an offset from the hardware RF frequency.&lt;/p&gt;&lt;/body&gt;&lt;/htm
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
           </property>
           <property name="toolTip">
            <string>Noise blanker for pulse type noise</string>
@@ -566,6 +596,12 @@ This is an offset from the hardware RF frequency.&lt;/p&gt;&lt;/body&gt;&lt;/htm
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="toolTip">
          <string>Reset squelch to its default value</string>
         </property>
@@ -632,6 +668,12 @@ This is an offset from the hardware RF frequency.&lt;/p&gt;&lt;/body&gt;&lt;/htm
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
           </property>
           <property name="toolTip">
            <string>Set squelch to the current signal or noise level</string>


### PR DESCRIPTION
In #1225 I removed code that explicitly changed the minimum size of buttons in the "Audio" and "Receiver Options" panels. Because Qt has a fairly wide default minimum width for buttons, this made the panels noticeably wider, reducing usability on small screens.

Here I've added back a minimum width (of 40, a bit narrower than before). I left out the Linux-specific tweaks, which I hope are unnecessary.

Here's how the panels now look (on Ubuntu 22.04) at their minimum widths:

![Screenshot from 2023-04-22 12-23-54](https://user-images.githubusercontent.com/583749/233795845-b0c71829-12fc-42ef-ae66-496a037e8233.png)

![Screenshot from 2023-04-22 12-23-59](https://user-images.githubusercontent.com/583749/233795847-128d7703-e6eb-4515-8cbb-995c2628710a.png)
