### PR TITLE
Calculate AGC parameters based on the correct sample rate

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -8,6 +8,7 @@
      FIXED: Crash when adding or removing bookmark tags.
      FIXED: Redraw bookmarks immediately after changes.
      FIXED: DX cluster spots fail to expire around midnight.
+     FIXED: AGC sensitivity bug introduced in version 2.15.10.
   IMPROVED: Rendering of frequency control and S-meter on some high-DPI screens.
    REMOVED: Support for GNU Radio 3.7.
 

--- a/src/dsp/agc_impl.cpp
+++ b/src/dsp/agc_impl.cpp
@@ -139,13 +139,12 @@ void CAgc::SetParameters(bool AgcOn,  bool UseHang, int Threshold, int ManualGai
     m_SlopeFactor = SlopeFactor;
     m_Decay = Decay;
 
-    m_DelaySamples = (int)(m_SampleRate * DELAY_TIMECONST);
-    m_WindowSamples = (int)(m_SampleRate * WINDOW_TIMECONST);
-
     if (m_SampleRate != SampleRate)
     {
         //clear out delay buffer and init some things if sample rate changes
         m_SampleRate = SampleRate;
+        m_DelaySamples = (int)(m_SampleRate * DELAY_TIMECONST);
+        m_WindowSamples = (int)(m_SampleRate * WINDOW_TIMECONST);
         for (int i = 0; i < MAX_DELAY_BUF; i++)
         {
             m_SigDelayBuf[i] = 0.0;


### PR DESCRIPTION
Fixes #1229.

The AGC change in #1151 introduced a bug because `m_DelaySamples` and `m_WindowSamples` were calculated prior to `m_SampleRate` being updated. This meant that the old sample rate was incorrectly used when calculating these parameters. Here I've put the calculations in the correct order.