### PR TITLE
Avoid implicit promotion to double in AGC

### DIFF
--- a/src/dsp/agc_impl.cpp
+++ b/src/dsp/agc_impl.cpp
@@ -46,32 +46,32 @@
 
 //signal delay line time delay in seconds.
 //adjust to cover the impulse response time of filter
-#define DELAY_TIMECONST .015
+#define DELAY_TIMECONST .015f
 
 //Peak Detector window time delay in seconds.
-#define WINDOW_TIMECONST .018
+#define WINDOW_TIMECONST .018f
 
 //attack time constant in seconds
 //just small enough to let attackave charge up within the DELAY_TIMECONST time
-#define ATTACK_RISE_TIMECONST .002
-#define ATTACK_FALL_TIMECONST .005
+#define ATTACK_RISE_TIMECONST .002f
+#define ATTACK_FALL_TIMECONST .005f
 
-#define DECAY_RISEFALL_RATIO .3	//ratio between rise and fall times of Decay time constants
+#define DECAY_RISEFALL_RATIO .3f	//ratio between rise and fall times of Decay time constants
 //adjust for best action with SSB
 
 // hang timer release decay time constant in seconds
-#define RELEASE_TIMECONST .05
+#define RELEASE_TIMECONST .05f
 
 //limit output to about 3db of max
-#define AGC_OUTSCALE 0.7
+#define AGC_OUTSCALE 0.7f
 
 // keep max in and out the same
-#define MAX_AMPLITUDE 1.0 //32767.0
-#define MAX_MANUAL_AMPLITUDE 1.0 //32767.0
+#define MAX_AMPLITUDE 1.0f //32767.0
+#define MAX_MANUAL_AMPLITUDE 1.0f //32767.0
 
 #define LOG_MAX_AMPL    log10f(MAX_AMPLITUDE)
 
-#define MIN_CONSTANT 1e-8   // const for calc log() so that a value of 0 magnitude == -8
+#define MIN_CONSTANT 1e-8f  // const for calc log() so that a value of 0 magnitude == -8
                             // corresponding to -160dB.
                             // K = 10^(-8 + log(MAX_AMP))
 
@@ -122,7 +122,7 @@ CAgc::~CAgc()
 //  "SampleRate" is current sample rate of AGC data
 ////////////////////////////////////////////////////////////////////////////////
 void CAgc::SetParameters(bool AgcOn,  bool UseHang, int Threshold, int ManualGain,
-                         int SlopeFactor, int Decay, double SampleRate)
+                         int SlopeFactor, int Decay, float SampleRate)
 {
     if((AgcOn == m_AgcOn) && (UseHang == m_UseHang) &&
             (Threshold == m_Threshold) && (ManualGain == m_ManualGain) &&
@@ -162,27 +162,27 @@ void CAgc::SetParameters(bool AgcOn,  bool UseHang, int Threshold, int ManualGai
     }
 
     // convert m_ThreshGain to linear manual gain value
-    m_ManualAgcGain = MAX_MANUAL_AMPLITUDE * powf(10.0, (float)m_ManualGain / 20.0);
+    m_ManualAgcGain = MAX_MANUAL_AMPLITUDE * powf(10.0f, (float)m_ManualGain / 20.0f);
 
     // calculate parameters for AGC gain as a function of input magnitude
-    m_Knee = (float)m_Threshold / 20.0;
-    m_GainSlope = m_SlopeFactor / 100.0;
+    m_Knee = (float)m_Threshold / 20.0f;
+    m_GainSlope = m_SlopeFactor / 100.0f;
 
     // fixed gain value used below knee threshold
-    m_FixedGain = AGC_OUTSCALE * powf(10.0, m_Knee * (m_GainSlope - 1.0) );
+    m_FixedGain = AGC_OUTSCALE * powf(10.0f, m_Knee * (m_GainSlope - 1.0f) );
 
     // calculate fast and slow filter values.
-    m_AttackRiseAlpha = (1.0 - expf(-1.0 / (m_SampleRate * ATTACK_RISE_TIMECONST)));
-    m_AttackFallAlpha = (1.0 - expf(-1.0 / (m_SampleRate * ATTACK_FALL_TIMECONST)));
+    m_AttackRiseAlpha = (1.0f - expf(-1.0f / (m_SampleRate * ATTACK_RISE_TIMECONST)));
+    m_AttackFallAlpha = (1.0f - expf(-1.0f / (m_SampleRate * ATTACK_FALL_TIMECONST)));
 
     // make rise time DECAY_RISEFALL_RATIO of fall
-    m_DecayRiseAlpha = (1.0 - expf(-1.0 / (m_SampleRate * (float)m_Decay * 0.001 * DECAY_RISEFALL_RATIO)));
-    m_HangTime = (int)(m_SampleRate * (float)m_Decay * .001);
+    m_DecayRiseAlpha = (1.0f - expf(-1.0f / (m_SampleRate * (float)m_Decay * 0.001f * DECAY_RISEFALL_RATIO)));
+    m_HangTime = (int)(m_SampleRate * (float)m_Decay * .001f);
 
     if (m_UseHang)
-        m_DecayFallAlpha = (1.0 - expf(-1.0 / (m_SampleRate * RELEASE_TIMECONST)));
+        m_DecayFallAlpha = (1.0f - expf(-1.0f / (m_SampleRate * RELEASE_TIMECONST)));
     else
-        m_DecayFallAlpha = (1.0 - expf(-1.0 / (m_SampleRate * (float)m_Decay * 0.001)));
+        m_DecayFallAlpha = (1.0f - expf(-1.0f / (m_SampleRate * (float)m_Decay * 0.001f)));
 
     // clamp Delay samples within buffer limit
     if (m_DelaySamples >= MAX_DELAY_BUF - 1)
@@ -217,8 +217,8 @@ void CAgc::ProcessData(int Length, const TYPECPX * pInData, TYPECPX * pOutData)
             if (m_SigDelayPtr >= m_DelaySamples)
                 m_SigDelayPtr = 0;
 
-            mag = fabs(in.real());
-            float mim = fabs(in.imag());
+            mag = fabsf(in.real());
+            float mim = fabsf(in.imag());
             if (mim > mag)
                 mag = mim;
             mag = log10f(mag + MIN_CONSTANT) - LOG_MAX_AMPL;
@@ -243,17 +243,17 @@ void CAgc::ProcessData(int Length, const TYPECPX * pInData, TYPECPX * pOutData)
                 // using hang timer mode
                 if (m_Peak > m_AttackAve)
                     // if power is rising (use m_AttackRiseAlpha time constant)
-                    m_AttackAve = (1.0 - m_AttackRiseAlpha) * m_AttackAve +
+                    m_AttackAve = (1.0f - m_AttackRiseAlpha) * m_AttackAve +
                                   m_AttackRiseAlpha * m_Peak;
                 else
                     // else magnitude is falling (use  m_AttackFallAlpha time constant)
-                    m_AttackAve = (1.0 - m_AttackFallAlpha) * m_AttackAve +
+                    m_AttackAve = (1.0f - m_AttackFallAlpha) * m_AttackAve +
                                   m_AttackFallAlpha * m_Peak;
 
                 if (m_Peak > m_DecayAve)
                 {
                     // if magnitude is rising (use m_DecayRiseAlpha time constant)
-                    m_DecayAve = (1.0 - m_DecayRiseAlpha) * m_DecayAve +
+                    m_DecayAve = (1.0f - m_DecayRiseAlpha) * m_DecayAve +
                                   m_DecayRiseAlpha * m_Peak;
                     // reset hang timer
                     m_HangTimer = 0;
@@ -263,7 +263,7 @@ void CAgc::ProcessData(int Length, const TYPECPX * pInData, TYPECPX * pOutData)
                     if (m_HangTimer < m_HangTime)
                         m_HangTimer++;	// just inc and hold current m_DecayAve
                     else	// else decay with m_DecayFallAlpha which is RELEASE_TIMECONST
-                        m_DecayAve = (1.0 - m_DecayFallAlpha) * m_DecayAve +
+                        m_DecayAve = (1.0f - m_DecayFallAlpha) * m_DecayAve +
                                      m_DecayFallAlpha * m_Peak;
                 }
             }
@@ -272,20 +272,20 @@ void CAgc::ProcessData(int Length, const TYPECPX * pInData, TYPECPX * pOutData)
                 // using exponential decay mode
                 // perform average of magnitude using 2 averagers each with separate rise and fall time constants
                 if (m_Peak > m_AttackAve)	//if magnitude is rising (use m_AttackRiseAlpha time constant)
-                    m_AttackAve = (1.0 - m_AttackRiseAlpha) * m_AttackAve +
+                    m_AttackAve = (1.0f - m_AttackRiseAlpha) * m_AttackAve +
                                   m_AttackRiseAlpha * m_Peak;
                 else
                     // else magnitude is falling (use  m_AttackFallAlpha time constant)
-                    m_AttackAve = (1.0 - m_AttackFallAlpha) * m_AttackAve +
+                    m_AttackAve = (1.0f - m_AttackFallAlpha) * m_AttackAve +
                                   m_AttackFallAlpha * m_Peak;
 
                 if (m_Peak > m_DecayAve)
                     // if magnitude is rising (use m_DecayRiseAlpha time constant)
-                    m_DecayAve = (1.0 - m_DecayRiseAlpha) * m_DecayAve +
+                    m_DecayAve = (1.0f - m_DecayRiseAlpha) * m_DecayAve +
                                  m_DecayRiseAlpha * m_Peak;
                 else
                     // else magnitude is falling (use m_DecayFallAlpha time constant)
-                    m_DecayAve = (1.0 - m_DecayFallAlpha) * m_DecayAve +
+                    m_DecayAve = (1.0f - m_DecayFallAlpha) * m_DecayAve +
                                  m_DecayFallAlpha * m_Peak;
             }
 
@@ -301,7 +301,7 @@ void CAgc::ProcessData(int Length, const TYPECPX * pInData, TYPECPX * pOutData)
                 gain = m_FixedGain;
             else
                 // use variable gain if above knee
-                gain = AGC_OUTSCALE * powf(10.0, mag * (m_GainSlope - 1.0));
+                gain = AGC_OUTSCALE * powf(10.0f, mag * (m_GainSlope - 1.0f));
 
             pOutData[i] = delayedin * gain;
         }

--- a/src/dsp/agc_impl.h
+++ b/src/dsp/agc_impl.h
@@ -34,7 +34,7 @@ class CAgc
 public:
     CAgc();
     virtual ~CAgc();
-    void SetParameters(bool AgcOn, bool UseHang, int Threshold, int ManualGain, int Slope, int Decay, double SampleRate);
+    void SetParameters(bool AgcOn, bool UseHang, int Threshold, int ManualGain, int Slope, int Decay, float SampleRate);
     void ProcessData(int Length, const TYPECPX * pInData, TYPECPX * pOutData);
 
 private:


### PR DESCRIPTION
Partially fixes #1232.

As noted there, removing implicit promotions to double from `CAgc::ProcessData` reduces the AGC block's CPU utilization by about 6% on Raspberry Pi. I've removed implicit promotions from `CAgc::SetParameters` as well, so that compiling with `-Wdouble-promotion` produces no warnings.