### PR TITLE
Fix double promotion warnings everywhere except the plotter

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -983,7 +983,7 @@ void MainWindow::setLnbLo(double freq_mhz)
     ui->plotter->setCenterFreq(d_lnb_lo + d_hw_freq);
 
     // update LNB LO in settings
-    if (freq_mhz == 0.f)
+    if (freq_mhz == 0.)
         m_settings->remove("input/lnb_lo");
     else
         m_settings->setValue("input/lnb_lo", d_lnb_lo);
@@ -1436,7 +1436,7 @@ void MainWindow::setSqlLevel(double level_db)
  */
 double MainWindow::setSqlLevelAuto()
 {
-    double level = rx->get_signal_pwr() + 3.0;
+    double level = rx->get_signal_pwr() + 3.0f;
     if (level > -10.0)  // avoid 0 dBFS
         level = uiDockRxOpt->getSqlLevel();
 
@@ -1468,15 +1468,15 @@ void MainWindow::iqFftTimeout()
     // Track the frame rate and warn if not keeping up. Since the interval is ms, the timer can
     // not be set exactly to all rates.
     const quint64 now_ms = QDateTime::currentMSecsSinceEpoch();
-    const float expected_rate = 1000.0 / (float)iq_fft_timer->interval();
-    const float last_fft_rate = 1000.0 / (float)(now_ms - d_last_fft_ms);
-    const float alpha = std::pow(expected_rate, -0.75);
-    if (d_avg_fft_rate == 0.0)
+    const float expected_rate = 1000.0f / (float)iq_fft_timer->interval();
+    const float last_fft_rate = 1000.0f / (float)(now_ms - d_last_fft_ms);
+    const float alpha = std::pow(expected_rate, -0.75f);
+    if (d_avg_fft_rate == 0.0f)
         d_avg_fft_rate = expected_rate;
     else
-        d_avg_fft_rate = (1.0 - alpha) * d_avg_fft_rate + alpha * last_fft_rate;
+        d_avg_fft_rate = (1.0f - alpha) * d_avg_fft_rate + alpha * last_fft_rate;
 
-    const bool drop = d_avg_fft_rate < expected_rate * 0.95;
+    const bool drop = d_avg_fft_rate < expected_rate * 0.95f;
     if (drop != d_frame_drop) {
         if (drop) {
             uiDockFft->setActualFrameRate(d_avg_fft_rate, true);

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -985,7 +985,7 @@ receiver::status receiver::set_af_gain(float gain_db)
     float k;
 
     /* convert dB to factor */
-    k = pow(10.0, gain_db / 20.0);
+    k = powf(10.0f, gain_db / 20.0f);
     //std::cout << "G:" << gain_db << "dB / K:" << k << std::endl;
     audio_gain0->set_k(k);
     audio_gain1->set_k(k);

--- a/src/dsp/afsk1200/cafsk12.cpp
+++ b/src/dsp/afsk1200/cafsk12.cpp
@@ -54,12 +54,12 @@ void CAfsk12::reset()
     for (f = 0, i = 0; i < CORRLEN; i++) {
         corr_mark_i[i] = cos(f);
         corr_mark_q[i] = sin(f);
-        f += 2.0*M_PI*FREQ_MARK/FREQ_SAMP;
+        f += 2*(float)M_PI*FREQ_MARK/FREQ_SAMP;
     }
     for (f = 0, i = 0; i < CORRLEN; i++) {
         corr_space_i[i] = cos(f);
         corr_space_q[i] = sin(f);
-        f += 2.0*M_PI*FREQ_SPACE/FREQ_SAMP;
+        f += 2*(float)M_PI*FREQ_SPACE/FREQ_SAMP;
     }
 
 }
@@ -460,4 +460,3 @@ void CAfsk12::ax25_disp_packet(unsigned char *bp, unsigned int len)
         emit newMessage(message);
     }
 }
-

--- a/src/dsp/resampler_xx.cpp
+++ b/src/dsp/resampler_xx.cpp
@@ -49,8 +49,8 @@ resampler_cc::resampler_cc(float rate)
     */
 
     /* generate taps */
-    double cutoff = rate > 1.0 ? 0.4 : 0.4*rate;
-    double trans_width = rate > 1.0 ? 0.2 : 0.2*rate;
+    double cutoff = rate > 1.0f ? 0.4 : 0.4*(double)rate;
+    double trans_width = rate > 1.0f ? 0.2 : 0.2*(double)rate;
     unsigned int flt_size = 32;
 
     d_taps = gr::filter::firdes::low_pass(flt_size, flt_size, cutoff, trans_width);
@@ -71,8 +71,8 @@ resampler_cc::~resampler_cc()
 void resampler_cc::set_rate(float rate)
 {
     /* generate taps */
-    double cutoff = rate > 1.0 ? 0.4 : 0.4*rate;
-    double trans_width = rate > 1.0 ? 0.2 : 0.2*rate;
+    double cutoff = rate > 1.0f ? 0.4 : 0.4*(double)rate;
+    double trans_width = rate > 1.0f ? 0.2 : 0.2*(double)rate;
     unsigned int flt_size = 32;
     d_taps = gr::filter::firdes::low_pass(flt_size, flt_size, cutoff, trans_width);
 
@@ -110,8 +110,8 @@ resampler_ff::resampler_ff(float rate)
     */
 
     /* generate taps */
-    double cutoff = rate > 1.0 ? 0.4 : 0.4*rate;
-    double trans_width = rate > 1.0 ? 0.2 : 0.2*rate;
+    double cutoff = rate > 1.0f ? 0.4 : 0.4*(double)rate;
+    double trans_width = rate > 1.0f ? 0.2 : 0.2*(double)rate;
     unsigned int flt_size = 32;
 
     d_taps = gr::filter::firdes::low_pass(flt_size, flt_size, cutoff, trans_width);
@@ -132,8 +132,8 @@ resampler_ff::~resampler_ff()
 void resampler_ff::set_rate(float rate)
 {
     /* generate taps */
-    double cutoff = rate > 1.0 ? 0.4 : 0.4*rate;
-    double trans_width = rate > 1.0 ? 0.2 : 0.2*rate;
+    double cutoff = rate > 1.0f ? 0.4 : 0.4*(double)rate;
+    double trans_width = rate > 1.0f ? 0.2 : 0.2*(double)rate;
     unsigned int flt_size = 32;
     d_taps = gr::filter::firdes::low_pass(flt_size, flt_size, cutoff, trans_width);
 

--- a/src/dsp/rx_demod_am.cpp
+++ b/src/dsp/rx_demod_am.cpp
@@ -111,7 +111,7 @@ rx_demod_amsync_sptr make_rx_demod_amsync(float quad_rate, bool dcr, float pll_b
     return gnuradio::get_initial_sptr(new rx_demod_amsync(quad_rate, dcr, pll_bw));
 }
 
-#define PLL_FMAX 5000.0
+#define PLL_FMAX 5000.0f
 
 rx_demod_amsync::rx_demod_amsync(float quad_rate, bool dcr, float pll_bw)
     : gr::hier_block2 ("rx_demod_amsync",
@@ -121,8 +121,8 @@ rx_demod_amsync::rx_demod_amsync(float quad_rate, bool dcr, float pll_bw)
 {
     /* demodulator */
     d_demod1 = gr::analog::pll_carriertracking_cc::make(pll_bw,
-                                                        (2.0*M_PI*PLL_FMAX/quad_rate),
-                                                        (2.0*M_PI*(-PLL_FMAX)/quad_rate));
+                                                        (2*(float)M_PI*PLL_FMAX/quad_rate),
+                                                        (2*(float)M_PI*(-PLL_FMAX)/quad_rate));
     d_demod2 = gr::blocks::complex_to_real::make(1);
 
     /* connect blocks */

--- a/src/dsp/rx_demod_fm.cpp
+++ b/src/dsp/rx_demod_fm.cpp
@@ -50,7 +50,7 @@ rx_demod_fm::rx_demod_fm(float quad_rate, float max_dev, double tau)
     float gain;
 
     /* demodulator gain */
-    gain = d_quad_rate / (2.0 * M_PI * d_max_dev);
+    gain = d_quad_rate / (2 * (float)M_PI * d_max_dev);
 
     qDebug() << "FM demod gain:" << gain;
 
@@ -83,14 +83,14 @@ void rx_demod_fm::set_max_dev(float max_dev)
 {
     float gain;
 
-    if ((max_dev < 500.0) || (max_dev > d_quad_rate/2.0))
+    if ((max_dev < 500.0f) || (max_dev > d_quad_rate/2.0f))
     {
         return;
     }
 
     d_max_dev = max_dev;
 
-    gain = d_quad_rate / (2.0 * M_PI * max_dev);
+    gain = d_quad_rate / (2 * (float)M_PI * max_dev);
     d_quad->set_gain(gain);
 }
 

--- a/src/dsp/rx_meter.cpp
+++ b/src/dsp/rx_meter.cpp
@@ -92,5 +92,5 @@ float rx_meter_c::get_level_db()
     float sum = 0;
     volk_32f_x2_dot_prod_32f(&sum, (float *)d_reader->read_pointer(), (float *)d_reader->read_pointer(), d_avgsize * 2);
     float power = sum / (float)(d_avgsize);
-    return (float) 10. * log10f(power + 1.0e-20);
+    return 10.f * log10f(power + 1.0e-20f);
 }

--- a/src/dsp/stereo_demod.cpp
+++ b/src/dsp/stereo_demod.cpp
@@ -74,8 +74,8 @@ stereo_demod::stereo_demod(float input_rate, float audio_rate, bool stereo, bool
                                        19020.,       // high_cutoff_freq
                                        5000.);       // transition_width
         pll = gr::analog::pll_refout_cc::make(0.0002,    // loop_bw FIXME
-                                2*M_PI * 19020 / input_rate,  // max_freq
-                                2*M_PI * 18980 / input_rate); // min_freq
+                                2 * (float)M_PI * 19020 / input_rate,  // max_freq
+                                2 * (float)M_PI * 18980 / input_rate); // min_freq
         subtone = gr::blocks::multiply_cc::make();
     } else {
         d_tone_taps = gr::filter::firdes::complex_band_pass(
@@ -85,8 +85,8 @@ stereo_demod::stereo_demod(float input_rate, float audio_rate, bool stereo, bool
                                        31300.,       // high_cutoff_freq
                                        5000.);       // transition_width
         pll = gr::analog::pll_refout_cc::make(0.0002,    // loop_bw FIXME
-                                2*M_PI * 31200 / input_rate,  // max_freq
-                                2*M_PI * 31300 / input_rate); // min_freq
+                                2 * (float)M_PI * 31200 / input_rate,  // max_freq
+                                2 * (float)M_PI * 31300 / input_rate); // min_freq
     }
 
     tone = gr::filter::fir_filter_fcc::make(1, d_tone_taps);

--- a/src/qtgui/ctk/ctkRangeSlider.cpp
+++ b/src/qtgui/ctk/ctkRangeSlider.cpp
@@ -756,7 +756,7 @@ void ctkRangeSlider::mouseMoveEvent(QMouseEvent* mouseEvent)
   else if (this->isMinimumSliderDown() && this->isMaximumSliderDown())
     {
     this->setPositions(newPosition - static_cast<int>(d->m_SubclassWidth),
-                       newPosition + static_cast<int>(d->m_SubclassWidth + .5));
+                       newPosition + static_cast<int>(d->m_SubclassWidth + .5f));
     }
   mouseEvent->accept();
 }

--- a/src/qtgui/demod_options.cpp
+++ b/src/qtgui/demod_options.cpp
@@ -76,13 +76,13 @@ float maxdev_from_index(int index)
 
 int maxdev_to_index(float max_dev)
 {
-    if (max_dev < 3000.0)
+    if (max_dev < 3000.0f)
         /* Voice 2.5k */
         return 0;
-    else if (max_dev < 10000.0)
+    else if (max_dev < 10000.0f)
         /* Voice 5k */
         return 1;
-    else if (max_dev < 20000.0)
+    else if (max_dev < 20000.0f)
         /* APT 17k */
         return 2;
     else
@@ -112,13 +112,13 @@ static float pll_bw_from_index(int index)
 
 static int pll_bw_to_index(float pll_bw)
 {
-    if (pll_bw < 0.00015)
+    if (pll_bw < 0.00015f)
         /* Slow */
         return 2;
-    else if (pll_bw < 0.0015)
+    else if (pll_bw < 0.0015f)
         /* Medium */
         return 1;
-    else if (pll_bw < 0.015)
+    else if (pll_bw < 0.015f)
         /* Fast */
         return 0;
     else

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -118,7 +118,7 @@ void DockAudio::setAudioGain(int gain)
  */
 void DockAudio::setAudioGainDb(float gain)
 {
-    ui->audioGainSlider->setValue(int(std::round(gain*10.0)));
+    ui->audioGainSlider->setValue(int(std::round(gain*10.0f)));
 }
 
 
@@ -186,7 +186,7 @@ void DockAudio::setWfColormap(const QString &cmap)
  */
 void DockAudio::on_audioGainSlider_valueChanged(int value)
 {
-    float gain = float(value) / 10.0;
+    float gain = float(value) / 10.0f;
 
     // update dB label
     ui->audioGainDbLabel->setText(QString("%1 dB").arg(gain, 5, 'f', 1));
@@ -285,7 +285,7 @@ void DockAudio::on_audioMuteButton_clicked(bool checked)
     else
     {
         int value = ui->audioGainSlider->value();
-        float gain = float(value) / 10.0;
+        float gain = float(value) / 10.0f;
         emit audioGainChanged(gain);
     }
 }

--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -548,7 +548,7 @@ void DockFft::on_wfSpanComboBox_currentIndexChanged(int index)
 /** Set waterfall time resolution. */
 void DockFft::setWfResolution(quint64 msec_per_line)
 {
-    float res = 1.0e-3 * (float)msec_per_line;
+    float res = 1.0e-3f * (float)msec_per_line;
 
     ui->wfResLabel->setText(QString("Res: %1 s").arg(res, 0, 'f', 2));
 }
@@ -569,8 +569,8 @@ void DockFft::on_fftAvgSlider_valueChanged(int value)
     // slider.
     const float v = value;
     const float x = ui->fftAvgSlider->maximum();
-    const float limit = 1.0 - 1.0/x;
-    const float avg = 1.0 - limit * v / x;
+    const float limit = 1.0f - 1.0f/x;
+    const float avg = 1.0f - limit * v / x;
 
     emit fftAvgChanged(avg);
 }
@@ -729,9 +729,9 @@ void DockFft::updateInfoLabels(void)
     if (rbw < 1.e3f)
         ui->fftRbwLabel->setText(QString("RBW: %1 Hz").arg(rbw, 0, 'f', 1));
     else if (rbw < 1.e6f)
-        ui->fftRbwLabel->setText(QString("RBW: %1 kHz").arg(1.e-3 * rbw, 0, 'f', 1));
+        ui->fftRbwLabel->setText(QString("RBW: %1 kHz").arg(1.e-3f * rbw, 0, 'f', 1));
     else
-        ui->fftRbwLabel->setText(QString("RBW: %1 MHz").arg(1.e-6 * rbw, 0, 'f', 1));
+        ui->fftRbwLabel->setText(QString("RBW: %1 MHz").arg(1.e-6f * rbw, 0, 'f', 1));
 
     rate = fftRate();
     if (rate == 0)
@@ -739,7 +739,7 @@ void DockFft::updateInfoLabels(void)
     else
     {
         interval_ms = 1000 / rate;
-        interval_samples = m_sample_rate * (interval_ms / 1000.0);
+        interval_samples = m_sample_rate * (interval_ms / 1000.0f);
         if (interval_samples >= size)
             ovr = 0;
         else

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -571,7 +571,7 @@ void DockRxOpt::saveSettings(QSettings *settings)
     else
         settings->remove("receiver/amsync_dcr");
 
-    int_val = qRound(currentAmsyncPll() * 1.0e6);
+    int_val = qRound(currentAmsyncPll() * 1.0e6f);
     if (int_val != 1000)
         settings->setValue("receiver/amsync_pllbw", int_val);
     else

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -749,10 +749,10 @@ void CIoConfig::decimationChanged(int index)
     quad_rate = (float)input_rate / (float)decim;
     if (quad_rate > 1.e6f)
         ui->sampRateLabel->setText(QString(" %1 Msps").
-                                   arg(quad_rate * 1.e-6, 0, 'f', 3));
+                                   arg(quad_rate * 1.e-6f, 0, 'f', 3));
     else
         ui->sampRateLabel->setText(QString(" %1 ksps").
-                                   arg(quad_rate * 1.e-3, 0, 'f', 3));
+                                   arg(quad_rate * 1.e-3f, 0, 'f', 3));
 }
 
 /**

--- a/src/qtgui/meter.cpp
+++ b/src/qtgui/meter.cpp
@@ -62,11 +62,11 @@ CMeter::CMeter(QWidget *parent) : QFrame(parent)
     m_2DPixmap = QPixmap(0,0);
     m_OverlayPixmap = QPixmap(0,0);
     m_Size = QSize(0,0);
-    m_pixperdb = 0.0f;
+    m_pixperdb = 0.0;
     m_Siglevel = 0;
     m_dBFS = MIN_DB;
-    m_Sql = -150.0f;
-    m_SqlLevel = 0.0f;
+    m_Sql = -150.0;
+    m_SqlLevel = 0.0;
 }
 
 CMeter::~CMeter()
@@ -119,7 +119,7 @@ void CMeter::setLevel(float dbfs)
     float level = m_dBFS;
     float alpha  = dbfs < level ? ALPHA_DECAY : ALPHA_RISE;
     m_dBFS -= alpha * (level - dbfs);
-    m_Siglevel = (level - MIN_DB) * m_pixperdb;
+    m_Siglevel = (qreal)(level - MIN_DB) * m_pixperdb;
 
     draw();
 }
@@ -127,12 +127,12 @@ void CMeter::setLevel(float dbfs)
 void CMeter::setSqlLevel(float dbfs)
 {
     if (dbfs >= 0.f)
-        m_SqlLevel = 0.0f;
+        m_SqlLevel = 0.0;
     else
-        m_SqlLevel = (dbfs - MIN_DB) * m_pixperdb;
+        m_SqlLevel = (qreal)(dbfs - MIN_DB) * m_pixperdb;
 
-    if (m_SqlLevel < 0.0f)
-        m_SqlLevel = 0.0f;
+    if (m_SqlLevel < 0.0)
+        m_SqlLevel = 0.0;
 
     m_Sql = dbfs;
 }
@@ -169,7 +169,7 @@ void CMeter::draw()
     qreal ht = (qreal) h * CTRL_NEEDLE_TOP;
     qreal x = marg + m_Siglevel;
 
-    if (m_Siglevel > 0.0f)
+    if (m_Siglevel > 0.0)
     {
         QColor color(0, 190, 0, 255);
         QPen pen(color);
@@ -181,7 +181,7 @@ void CMeter::draw()
         painter.drawRect(QRectF(marg, ht + 2, x - marg, 4));
     }
 
-    if (m_SqlLevel > 0.0f)
+    if (m_SqlLevel > 0.0)
     {
         x = marg + m_SqlLevel;
         painter.setPen(QPen(Qt::yellow, 1, Qt::SolidLine));

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -99,7 +99,7 @@ public:
     /* Determines full bandwidth. */
     void setSampleRate(float rate)
     {
-        if (rate > 0.0)
+        if (rate > 0.0f)
         {
             m_SampleFreq = rate;
             drawOverlay();

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -102,7 +102,7 @@ bool nbrx::stop()
 
 void nbrx::set_quad_rate(float quad_rate)
 {
-    if (std::abs(d_quad_rate-quad_rate) > 0.5)
+    if (std::abs(d_quad_rate-quad_rate) > 0.5f)
     {
         qDebug() << "Changing NB_RX quad rate:"  << d_quad_rate << "->" << quad_rate;
         d_quad_rate = quad_rate;

--- a/src/receivers/wfmrx.cpp
+++ b/src/receivers/wfmrx.cpp
@@ -26,7 +26,7 @@
 #include <QDebug>
 #include "receivers/wfmrx.h"
 
-#define PREF_QUAD_RATE   240e3 // Nominal channel spacing is 200 kHz
+#define PREF_QUAD_RATE   240e3f // Nominal channel spacing is 200 kHz
 
 wfmrx_sptr make_wfmrx(float quad_rate, float audio_rate)
 {
@@ -88,7 +88,7 @@ bool wfmrx::stop()
 
 void wfmrx::set_quad_rate(float quad_rate)
 {
-    if (std::abs(d_quad_rate-quad_rate) > 0.5)
+    if (std::abs(d_quad_rate-quad_rate) > 0.5f)
     {
         qDebug() << "Changing WFM RX quad rate:"  << d_quad_rate << "->" << quad_rate;
         d_quad_rate = quad_rate;


### PR DESCRIPTION
Partially fixes #1232.

Here I've fixed all remaining double promotion warnings except for the ones in `plotter.cpp`.

I don't believe any of these changes are on hot paths that will impact performance.