### PR TITLE
Store waterfall span setting in milliseconds

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -21,6 +21,7 @@
   IMPROVED: Plot & waterfall performance.
   IMPROVED: Plot can be zoomed & resized while DSP is stopped.
   IMPROVED: FFT window setting is stored as a string.
+  IMPROVED: Waterfall span setting is stored in milliseconds.
      FIXED: Time on waterfall is calculated correctly.
      FIXED: Frequency is correctly rounded in I/Q filenames.
 

--- a/src/qtgui/dockfft.h
+++ b/src/qtgui/dockfft.h
@@ -45,6 +45,9 @@ public:
     int fftSize();
     int setFftSize(int fft_size);
 
+    quint64 wfSpan();
+    quint64 setWfSpan(quint64 fft_size);
+
     void setSampleRate(float sample_rate);
 
     void saveSettings(QSettings *settings);


### PR DESCRIPTION
Fixes #1241.

The only remaining setting that's stored as a QComboBox index is `waterfall_span`. Here I've changed it to store the value in milliseconds. There's also a fallback to read the index value stored by earlier versions of Gqrx.