### PR TITLE
plotter: more responsive overlay redraws

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1135,8 +1135,7 @@ void CPlotter::resizeEvent(QResizeEvent* )
         m_CursorCaptureDelta = qRound((qreal)CUR_CUT_DELTA * m_DPR);
     }
 
-    drawOverlay();
-    draw(false);
+    updateOverlay();
     emit newSize();
 }
 
@@ -2436,10 +2435,7 @@ void CPlotter::setCenterFreq(quint64 f)
 void CPlotter::updateOverlay()
 {
     m_DrawOverlay = true;
-    if (!m_Running)
-    {
-        draw(false);
-    }
+    draw(false);
 }
 
 /** Reset horizontal zoom to 100% and centered around 0. */

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -55,7 +55,7 @@ public:
     void setFilterOffset(qint64 freq_hz)
     {
         m_DemodCenterFreq = m_CenterFreq + freq_hz;
-        drawOverlay();
+        updateOverlay();
     }
     qint64 getFilterOffset() const
     {
@@ -71,7 +71,7 @@ public:
     {
         m_DemodLowCutFreq = LowCut;
         m_DemodHiCutFreq = HiCut;
-        drawOverlay();
+        updateOverlay();
     }
 
     void getHiLowCutFrequencies(int *LowCut, int *HiCut) const
@@ -89,7 +89,7 @@ public:
             m_Span = (qint32)s;
             setFftCenterFreq(m_FftCenter);
         }
-        drawOverlay();
+        updateOverlay();
     }
 
     void setVdivDelta(int delta) { m_VdivDelta = delta; }
@@ -102,7 +102,7 @@ public:
         if (rate > 0.0f)
         {
             m_SampleFreq = rate;
-            drawOverlay();
+            updateOverlay();
         }
     }
 


### PR DESCRIPTION
Do not wait for the next fft frame to redraw overlay elements

Fixes #1244 and also makes the overlay more responsive to changes in general.