### PR TITLE
dockfft: zoom slider uses log scale with max 100000x

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -23,6 +23,9 @@
   IMPROVED: FFT window setting is stored as a string.
   IMPROVED: Waterfall span setting is stored in milliseconds.
   IMPROVED: Added 6 dB attenuation to WAV file recordings to prevent clipping.
+  IMPROVED: Use logarithmic scale for frequency zoom slider.
+   CHANGED: Frequency zoom slider zooms around center of display.
+   CHANGED: Disallow scrolling beyond the FFT frequency limits.
    CHANGED: Default narrow FM deviation increased to 5 kHz.
      FIXED: Time on waterfall is calculated correctly.
      FIXED: Frequency is correctly rounded in I/Q filenames.

--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -541,7 +541,8 @@ void DockFft::setWaterfallRange(float min, float max)
 void DockFft::setZoomLevel(float level)
 {
     ui->fftZoomSlider->blockSignals(true);
-    ui->fftZoomSlider->setValue((int) level);
+    float logZoom = 100.0f / 5.0f * log10f(level);
+    ui->fftZoomSlider->setValue(qRound(logZoom));
     ui->zoomLevelLabel->setText(QString("%1x").arg((int) level));
     ui->fftZoomSlider->blockSignals(false);
 }
@@ -628,8 +629,9 @@ void DockFft::on_fftAvgSlider_valueChanged(int value)
 /** FFT zoom level changed */
 void DockFft::on_fftZoomSlider_valueChanged(int level)
 {
-    ui->zoomLevelLabel->setText(QString("%1x").arg(level));
-    emit fftZoomChanged((float)level);
+    float linearZoom = powf(10.0f, (float)level * 5.0f / 100.0f);
+    ui->zoomLevelLabel->setText(QString("%1x").arg(qRound(linearZoom)));
+    emit fftZoomChanged(linearZoom);
 }
 
 void DockFft::on_wfModeBox_currentIndexChanged(int index)

--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -298,7 +298,7 @@
                <string>Zoom level for frequency axis</string>
               </property>
               <property name="minimum">
-               <number>1</number>
+               <number>0</number>
               </property>
               <property name="maximum">
                <number>100</number>

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -113,7 +113,7 @@ public:
     }
 
     void setFftCenterFreq(qint64 f) {
-        qint64 limit = ((qint64)m_SampleFreq + m_Span) / 2 - 1;
+        qint64 limit = ((qint64)m_SampleFreq - m_Span) / 2 - 1;
         m_FftCenter = qBound(-limit, f, limit);
     }
 


### PR DESCRIPTION
A log scale is more sensible for the zoom slider, and it was difficult to make it work at all with a linear scale.

Fixes #1235 

Also:
- The slider is now log scaled so zoom per tick is consistent over the entire range
- Center frequency stays the same when zooming using the slider - it previously was centered on the demod freq which led to strange behavior when both mouse-based and slider-based zoom were used