### PR TITLE
nbrx: make extra room for history in rx filter

### DIFF
--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -43,6 +43,7 @@ nbrx::nbrx(float quad_rate, float audio_rate)
     iq_resamp = make_resampler_cc(PREF_QUAD_RATE/d_quad_rate);
 
     nb = make_rx_nb_cc(PREF_QUAD_RATE, 3.3, 2.5);
+    nb->set_min_output_buffer(64 * 1024);
     filter = make_rx_filter(PREF_QUAD_RATE, -5000.0, 5000.0, 1000.0);
     agc = make_rx_agc_cc(PREF_QUAD_RATE, true, -100, 0, 0, 500, false);
     sql = gr::analog::simple_squelch_cc::make(-150.0, 0.001);


### PR DESCRIPTION
The default output buffer allocation for the nb (noise blanker) block in nbrx could end up being smaller than the history requirement of the rx filter when filter params are adjusted at runtime. Allocate space for 64k items, which should be enough for a very tight filter.

Fixes #1233 