### PR TITLE
Fix buffer overflow in sniffer block

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -24,6 +24,7 @@
   IMPROVED: Waterfall span setting is stored in milliseconds.
      FIXED: Time on waterfall is calculated correctly.
      FIXED: Frequency is correctly rounded in I/Q filenames.
+     FIXED: Crash in AFSK1200 decoder.
 
 
       2.16: Released April 28, 2023

--- a/src/dsp/sniffer_f.cpp
+++ b/src/dsp/sniffer_f.cpp
@@ -43,14 +43,15 @@ sniffer_f::sniffer_f(int buffsize)
     : gr::sync_block ("sniffer_f",
           gr::io_signature::make(1, 1, sizeof(float)),
           gr::io_signature::make(0, 0, 0)),
+      d_buffsize(buffsize),
       d_minsamp(1000)
 {
 
     /* allocate circular buffer */
 #if GNURADIO_VERSION < 0x031000
-    d_writer = gr::make_buffer(buffsize, sizeof(float));
+    d_writer = gr::make_buffer(d_buffsize, sizeof(float));
 #else
-    d_writer = gr::make_buffer(buffsize, sizeof(float), 1, 1);
+    d_writer = gr::make_buffer(d_buffsize, sizeof(float), 1, 1);
 #endif
     d_reader = gr::buffer_add_reader(d_writer, 0);
 
@@ -122,7 +123,7 @@ void sniffer_f::get_samples(float * out, unsigned int &num)
         return;
     }
 
-    num = d_reader->items_available();
+    num = std::min(d_reader->items_available(), d_buffsize);
     memcpy(out, d_reader->read_pointer(), sizeof(float)*num);
     d_reader->update_read_pointer(num);
 }

--- a/src/dsp/sniffer_f.h
+++ b/src/dsp/sniffer_f.h
@@ -90,6 +90,7 @@ private:
     std::mutex d_mutex;                     /*! Used to prevent concurrent access to buffer. */
     gr::buffer_sptr d_writer;
     gr::buffer_reader_sptr d_reader;
+    int d_buffsize;
     unsigned int d_minsamp;                 /*! smallest number of samples we want to return. */
 
 };


### PR DESCRIPTION
If the "AFSK1200 Decoder" window is open, and a long operation (such as choosing a large FFT size when `~/.gr_fftw_wisdom` doesn't already contain pre-calculated parameters) prevents the GUI from updating for more than two seconds, a segfault occurs.

Address Sanitizer provides details:

```
==1905078==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffc85f71c00 at pc 0x7f33f1c3a2c3 bp 0x7ffc85f42cf0 sp 0x7ffc85f42498
WRITE of size 192508 at 0x7ffc85f71c00 thread T0
    #0 0x7f33f1c3a2c2 in __interceptor_memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827
    #1 0x55a8673287bc in memcpy /usr/include/x86_64-linux-gnu/bits/string_fortified.h:29
    #2 0x55a8673287bc in sniffer_f::get_samples(float*, unsigned int&) /home/argilo/prefix_310/src/gqrx/src/dsp/sniffer_f.cpp:126
    #3 0x55a8671ef07e in MainWindow::decoderTimeout() /home/argilo/prefix_310/src/gqrx/src/applications/gqrx/mainwindow.cpp:2151
    #4 0x7f33f03ac272  (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x1ac272)
    #5 0x7f33f03ba4bd in QTimer::timeout(QTimer::QPrivateSignal) (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x1ba4bd)
    #6 0x7f33f03a062e in QObject::event(QEvent*) (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x1a062e)
    #7 0x7f33f117fd35 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/lib/x86_64-linux-gnu/libQt6Widgets.so.6+0x17fd35)
    #8 0x7f33f0353a57 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x153a57)
    #9 0x7f33f04bc202 in QTimerInfoList::activateTimers() (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x2bc202)
    #10 0x7f33f057bbfb  (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x37bbfb)
    #11 0x7f33edd82d3a in g_main_context_dispatch (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x55d3a)
    #12 0x7f33eddd76c7  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0xaa6c7)
    #13 0x7f33edd803e2 in g_main_context_iteration (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x533e2)
    #14 0x7f33f057bead in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x37bead)
    #15 0x7f33f0360ada in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x160ada)
    #16 0x7f33f035c0f2 in QCoreApplication::exec() (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x15c0f2)
    #17 0x55a8671b2c0a in main /home/argilo/prefix_310/src/gqrx/src/applications/gqrx/main.cpp:161
    #18 0x7f33ef029d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #19 0x7f33ef029e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #20 0x55a8671bf874 in _start (/home/argilo/prefix_310/bin/gqrx+0x13c874)
```

The problem is that `sniffer_f::get_samples` is not supposed to return any more than `buffsize` samples, but it can in fact return more because `gr::make_buffer` rounds up the requested buffer size.

The bug was introduced in #1042.

I've fixed it by storing `buffsize` in a member variable, and using it to ensure that `get_samples` returns no more than that many samples, even if the `gr::buffer` happens to have more.