### PR TITLE
Increase default narrow FM devation to 5 kHz

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -22,6 +22,7 @@
   IMPROVED: Plot can be zoomed & resized while DSP is stopped.
   IMPROVED: FFT window setting is stored as a string.
   IMPROVED: Waterfall span setting is stored in milliseconds.
+   CHANGED: Default narrow FM deviation increased to 5 kHz.
      FIXED: Time on waterfall is calculated correctly.
      FIXED: Frequency is correctly rounded in I/Q filenames.
      FIXED: Crash in AFSK1200 decoder.

--- a/src/qtgui/demod_options.ui
+++ b/src/qtgui/demod_options.ui
@@ -100,7 +100,7 @@ this demodulator</string>
             <string>Maximum FM deviation</string>
            </property>
            <property name="currentIndex">
-            <number>0</number>
+            <number>1</number>
            </property>
            <item>
             <property name="text">

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -411,7 +411,7 @@ void DockRxOpt::readSettings(QSettings *settings)
     if (conv_ok)
         demodOpt->setCwOffset(int_val);
 
-    int_val = settings->value("receiver/fm_maxdev", 2500).toInt(&conv_ok);
+    int_val = settings->value("receiver/fm_maxdev", 5000).toInt(&conv_ok);
     if (conv_ok)
         demodOpt->setMaxDev(int_val);
 
@@ -499,7 +499,7 @@ void DockRxOpt::saveSettings(QSettings *settings)
 
     // currently we do not need the decimal
     int_val = (int)demodOpt->getMaxDev();
-    if (int_val == 2500)
+    if (int_val == 5000)
         settings->remove("receiver/fm_maxdev");
     else
         settings->setValue("receiver/fm_maxdev", int_val);


### PR DESCRIPTION
Partially addresses #1115.

5 kHz deviation is commonly used, so I think it makes sense to increase Gqrx's default to avoid accidental clipping.

If this default is used when receiving signals with 2.5 kHz deviation, the audio level will simply be 6 dB lower.