### PR TITLE
Add 6 dB attentuation to WAV file recordings

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -22,6 +22,7 @@
   IMPROVED: Plot can be zoomed & resized while DSP is stopped.
   IMPROVED: FFT window setting is stored as a string.
   IMPROVED: Waterfall span setting is stored in milliseconds.
+  IMPROVED: Added 6 dB attenuation to WAV file recordings to prevent clipping.
    CHANGED: Default narrow FM deviation increased to 5 kHz.
      FIXED: Time on waterfall is calculated correctly.
      FIXED: Frequency is correctly rounded in I/Q filenames.

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -271,6 +271,8 @@ private:
 
     gr::blocks::multiply_const_ff::sptr audio_gain0; /*!< Audio gain block. */
     gr::blocks::multiply_const_ff::sptr audio_gain1; /*!< Audio gain block. */
+    gr::blocks::multiply_const_ff::sptr wav_gain0; /*!< WAV file gain block. */
+    gr::blocks::multiply_const_ff::sptr wav_gain1; /*!< WAV file gain block. */
 
     gr::blocks::file_sink::sptr         iq_sink;     /*!< I/Q file sink. */
 


### PR DESCRIPTION
Partially addresses #1115.

I think it makes sense to include some attenuation in the WAV file recording path, to add some headroom to account for things like tuning offset when recording FM signals. The audio output defaults to -6 dB, so I think that's a sensible choice for WAV file output.