### PR TITLE
Calculate width of Y axis in saved waterfall

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -27,6 +27,7 @@
      FIXED: Time on waterfall is calculated correctly.
      FIXED: Frequency is correctly rounded in I/Q filenames.
      FIXED: Crash in AFSK1200 decoder.
+     FIXED: Y axis in saved waterfall is too narrow.
 
 
       2.16: Released April 28, 2023

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -621,12 +621,13 @@ bool CPlotter::saveWaterfall(const QString & filename) const
     QFontMetricsF   font_metrics(font);
     float           pixperdiv;
     int             x, y, w, h;
-    int             hxa, wya = 85;
+    int             hxa, wya;
     int             i;
 
     w = pixmap.width();
     h = pixmap.height();
     hxa = font_metrics.height() + 5;    // height of X axis
+    wya = font_metrics.boundingRect("2008.08.08").width() + 5; // width of Y axis
     y = h - hxa;
     pixperdiv = (float) w / (float) m_HorDivs;
 


### PR DESCRIPTION
Fixes #1256.

Before:

![gqrx_wf_20230618_045300](https://github.com/gqrx-sdr/gqrx/assets/583749/8fbc7c8b-7527-4330-904b-86ce1f1c1ba0)

After:

![gqrx_wf_20230618_130918](https://github.com/gqrx-sdr/gqrx/assets/583749/f5588486-30af-40e3-906b-95f899456292)
