### PR TITLE
plotter: draw on pixel center for cleaner picture

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1525,6 +1525,7 @@ void CPlotter::draw(bool newData)
     {
         m_2DPixmap.fill(PLOTTER_BGD_COLOR);
         QPainter painter2(&m_2DPixmap);
+        painter2.translate(QPointF(0.5, 0.5));
 
         // Update histogram IIR
         const double frameTime = 1.0 / (double)fft_rate;
@@ -1996,6 +1997,7 @@ void CPlotter::drawOverlay()
 
     m_OverlayPixmap.fill(Qt::transparent);
     QPainter painter(&m_OverlayPixmap);
+    painter.translate(QPointF(-0.5, -0.5));
     // painter.setRenderHint(QPainter::Antialiasing);
     painter.setFont(m_Font);
 


### PR DESCRIPTION
In the Qt coordinate system, a shift of 0.5 is required to draw on pixel centers. Without this shift, lines come out more than one pixel wide.

In the main drawing routine, shift by (0.5, 0.5). In the overlay drawing routine, shift by (-0.5, -0.5) since the result is copied by the main drawing routine (the shifts cancel out).