### PR TITLE
Fix a double promotion warning in setNewFftData

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1869,7 +1869,7 @@ void CPlotter::setRunningState(bool running)
 void CPlotter::setNewFftData(const float *fftData, int size)
 {
     // Make sure zeros don't get through to log calcs
-    const float fmin = std::numeric_limits<float>::min();
+    const float fmin = 1e-20;
 
     if (size != m_fftDataSize)
     {
@@ -1936,8 +1936,8 @@ void CPlotter::setNewFftData(const float *fftData, int size)
     if (needIIR) {
         for (int i = 0; i < size; ++i)
         {
-            const double v = m_fftData[i];
-            const double iir = m_fftIIR[i];
+            const float v = m_fftData[i];
+            const float iir = m_fftIIR[i];
             m_fftIIR[i] = iir * powf(v / iir, a);
         }
     }


### PR DESCRIPTION
This was split off from #1260.

Double was used to prevent `v / iir` from underflowing when `iir` was greater than 1 and the FFT bin value was zero (rounded up to `fmin` on line 1917).

To avoid this situation, we can simply increase `fmin` to 1e-20. At -400 dB this is still much lower than Gqrx's minimum limit (-160 dB), and it allows FFT bin IIR values to reach roughly 1e18 before an underflow condition could occur.

This change addresses a double promotion warning, but does not appear to improve performance. Even on a Raspberry Pi (where double calculations are slower than float) I didn't notice a performance difference, as the cost of the IIR loop is dominated by `powf`.