### PR TITLE
nbrx: set minimum buffer size for input to rx_filter

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -28,6 +28,7 @@
      FIXED: Frequency is correctly rounded in I/Q filenames.
      FIXED: Crash in AFSK1200 decoder.
      FIXED: Y axis in saved waterfall is too narrow.
+     FIXED: Hang when setting a very narrow filter width.
 
 
       2.16: Released April 28, 2023

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -57,7 +57,7 @@ nbrx::nbrx(float quad_rate, float audio_rate)
     // output buffer of nb) needs to be large enough for the longest history
     // required by the filter (Narrow/Sharp). This setting may not be reliable
     // for GR prior to v3.10.7.0.
-    nb->set_min_output_buffer(64 * 1024 * sizeof(gr_complex));
+    nb->set_min_output_buffer(32768);
 
     audio_rr0.reset();
     audio_rr1.reset();

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -53,6 +53,12 @@ nbrx::nbrx(float quad_rate, float audio_rate)
     demod_am = make_rx_demod_am(PREF_QUAD_RATE, true);
     demod_amsync = make_rx_demod_amsync(PREF_QUAD_RATE, true, 0.001);
 
+    // Width of rx_filter can be adjusted at run time, so the input buffer (the
+    // output buffer of nb) needs to be large enough for the longest history
+    // required by the filter (Narrow/Sharp). This setting may not be reliable
+    // for GR prior to v3.10.7.0.
+    nb->set_min_output_buffer(64 * 1024 * sizeof(gr_complex));
+
     audio_rr0.reset();
     audio_rr1.reset();
     if (d_audio_rate != PREF_QUAD_RATE)


### PR DESCRIPTION
Width of rx_filter can be adjusted at run time, so the input buffer (the output buffer of nb) needs to be large enough for the longest history required by the filter (Narrow/Sharp). This setting may not be reliable for GR prior to v3.10.7.0.

Fixes #1233 