### PR TITLE
Fix double promotion warnings reported by Clang

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -110,7 +110,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
 
     /* create receiver object */
     rx = new receiver("", "", 1);
-    rx->set_rf_freq(144500000.0f);
+    rx->set_rf_freq(144500000.0);
 
     // remote controller
     remote = new RemoteControl();
@@ -1436,7 +1436,7 @@ void MainWindow::setSqlLevel(double level_db)
  */
 double MainWindow::setSqlLevelAuto()
 {
-    double level = rx->get_signal_pwr() + 3.0f;
+    double level = (double)rx->get_signal_pwr() + 3.0;
     if (level > -10.0)  // avoid 0 dBFS
         level = uiDockRxOpt->getSqlLevel();
 
@@ -1684,7 +1684,7 @@ void MainWindow::startIqPlayback(const QString& filename, float samprate, qint64
     updateHWFrequencyRange(false);
 
     // sample rate
-    auto actual_rate = rx->set_input_rate(samprate);
+    auto actual_rate = rx->set_input_rate((double)samprate);
     qDebug() << "Requested sample rate:" << samprate;
     qDebug() << "Actual sample rate   :" << QString("%1")
                 .arg(actual_rate, 0, 'f', 6);

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -631,15 +631,15 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
     }
     else if (lvl.compare("STRENGTH", Qt::CaseInsensitive) == 0 || lvl.isEmpty())
     {
-        answer = QString("%1\n").arg(signal_level, 0, 'f', 1);
+        answer = QString("%1\n").arg((double)signal_level, 0, 'f', 1);
     }
     else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
     {
-        answer = QString("%1\n").arg(squelch_level, 0, 'f', 1);
+        answer = QString("%1\n").arg((double)squelch_level, 0, 'f', 1);
     }
     else if (lvl.compare("AF", Qt::CaseInsensitive) == 0)
     {
-        answer = QString("%1\n").arg(audio_gain, 0, 'f', 1);
+        answer = QString("%1\n").arg((double)audio_gain, 0, 'f', 1);
     }
     else if (lvl.endsWith("_GAIN"))
     {

--- a/src/dsp/fm_deemph.cpp
+++ b/src/dsp/fm_deemph.cpp
@@ -76,7 +76,7 @@ void fm_deemph::calculate_iir_taps(double tau)
         double  w_c;    // Digital corner frequency
         double  w_ca;   // Prewarped analog corner frequency
         double  k, z1, p1, b0;
-        double  fs = d_quad_rate;
+        double  fs = (double)d_quad_rate;
 
         w_c = 1.0 / tau;
         w_ca = 2.0 * fs * tan(w_c / (2.0 * fs));

--- a/src/dsp/stereo_demod.cpp
+++ b/src/dsp/stereo_demod.cpp
@@ -55,35 +55,35 @@ stereo_demod::stereo_demod(float input_rate, float audio_rate, bool stereo, bool
     d_oirt(oirt)
 {
   double cutof_freq = d_oirt ? 15e3 : 17e3;
-  lpf0 = make_lpf_ff(d_input_rate, cutof_freq, 2e3); // FIXME
+  lpf0 = make_lpf_ff((double)d_input_rate, cutof_freq, 2e3); // FIXME
   audio_rr0 = make_resampler_ff(d_audio_rate/d_input_rate);
   deemph0 = make_fm_deemph(d_audio_rate, 50.0e-6);
 
   if (d_stereo)
   {
-    lpf1 = make_lpf_ff(d_input_rate, cutof_freq, 2e3, -2.1); // FIXME
+    lpf1 = make_lpf_ff((double)d_input_rate, cutof_freq, 2e3, -2.1); // FIXME
     audio_rr1 = make_resampler_ff(d_audio_rate/d_input_rate);
     deemph1 = make_fm_deemph(d_audio_rate, 50.0e-6);
 
     if (!d_oirt)
     {
         d_tone_taps = gr::filter::firdes::complex_band_pass(
-                                       1.0,          // gain,
-		                                   d_input_rate, // sampling_freq
-                                       18980.,       // low_cutoff_freq
-                                       19020.,       // high_cutoff_freq
-                                       5000.);       // transition_width
+                                       1.0,                  // gain,
+                                       (double)d_input_rate, // sampling_freq
+                                       18980.,               // low_cutoff_freq
+                                       19020.,               // high_cutoff_freq
+                                       5000.);               // transition_width
         pll = gr::analog::pll_refout_cc::make(0.0002,    // loop_bw FIXME
                                 2 * (float)M_PI * 19020 / input_rate,  // max_freq
                                 2 * (float)M_PI * 18980 / input_rate); // min_freq
         subtone = gr::blocks::multiply_cc::make();
     } else {
         d_tone_taps = gr::filter::firdes::complex_band_pass(
-                                       1.0,          // gain,
-                                       d_input_rate, // sampling_freq
-                                       31200.,       // low_cutoff_freq
-                                       31300.,       // high_cutoff_freq
-                                       5000.);       // transition_width
+                                       1.0,                  // gain,
+                                       (double)d_input_rate, // sampling_freq
+                                       31200.,               // low_cutoff_freq
+                                       31300.,               // high_cutoff_freq
+                                       5000.);               // transition_width
         pll = gr::analog::pll_refout_cc::make(0.0002,    // loop_bw FIXME
                                 2 * (float)M_PI * 31200 / input_rate,  // max_freq
                                 2 * (float)M_PI * 31300 / input_rate); // min_freq

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -189,7 +189,7 @@ void DockAudio::on_audioGainSlider_valueChanged(int value)
     float gain = float(value) / 10.0f;
 
     // update dB label
-    ui->audioGainDbLabel->setText(QString("%1 dB").arg(gain, 5, 'f', 1));
+    ui->audioGainDbLabel->setText(QString("%1 dB").arg((double)gain, 5, 'f', 1));
     if (!ui->audioMuteButton->isChecked())
         emit audioGainChanged(gain);
 }

--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -600,7 +600,7 @@ void DockFft::setWfResolution(quint64 msec_per_line)
 {
     float res = 1.0e-3f * (float)msec_per_line;
 
-    ui->wfResLabel->setText(QString("Res: %1 s").arg(res, 0, 'f', 2));
+    ui->wfResLabel->setText(QString("Res: %1 s").arg((double)res, 0, 'f', 2));
 }
 
 /**
@@ -777,11 +777,11 @@ void DockFft::updateInfoLabels(void)
 
     rbw = m_sample_rate / size;
     if (rbw < 1.e3f)
-        ui->fftRbwLabel->setText(QString("RBW: %1 Hz").arg(rbw, 0, 'f', 1));
+        ui->fftRbwLabel->setText(QString("RBW: %1 Hz").arg((double)rbw, 0, 'f', 1));
     else if (rbw < 1.e6f)
-        ui->fftRbwLabel->setText(QString("RBW: %1 kHz").arg(1.e-3f * rbw, 0, 'f', 1));
+        ui->fftRbwLabel->setText(QString("RBW: %1 kHz").arg(1.e-3 * (double)rbw, 0, 'f', 1));
     else
-        ui->fftRbwLabel->setText(QString("RBW: %1 MHz").arg(1.e-6f * rbw, 0, 'f', 1));
+        ui->fftRbwLabel->setText(QString("RBW: %1 MHz").arg(1.e-6 * (double)rbw, 0, 'f', 1));
 
     rate = fftRate();
     if (rate == 0)
@@ -795,5 +795,5 @@ void DockFft::updateInfoLabels(void)
         else
             ovr = 100 * (1.f - interval_samples / size);
     }
-    ui->fftOvrLabel->setText(QString("Overlap: %1%").arg(ovr, 0, 'f', 0));
+    ui->fftOvrLabel->setText(QString("Overlap: %1%").arg((double)ovr, 0, 'f', 0));
 }

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -270,7 +270,7 @@ void DockRxOpt::setFilterParam(int lo, int hi)
         float width_f;
         width_f = fabs((hi-lo)/1000.f);
         ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User (%1 k)")
-                                     .arg(width_f));
+                                     .arg((double)width_f));
     }
 }
 

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -749,10 +749,10 @@ void CIoConfig::decimationChanged(int index)
     quad_rate = (float)input_rate / (float)decim;
     if (quad_rate > 1.e6f)
         ui->sampRateLabel->setText(QString(" %1 Msps").
-                                   arg(quad_rate * 1.e-6f, 0, 'f', 3));
+                                   arg((double)quad_rate * 1.e-6, 0, 'f', 3));
     else
         ui->sampRateLabel->setText(QString(" %1 ksps").
-                                   arg(quad_rate * 1.e-3f, 0, 'f', 3));
+                                   arg((double)quad_rate * 1.e-3, 0, 'f', 3));
 }
 
 /**

--- a/src/qtgui/meter.cpp
+++ b/src/qtgui/meter.cpp
@@ -101,7 +101,7 @@ void CMeter::resizeEvent(QResizeEvent *)
         m_2DPixmap.fill(Qt::black);
 
         qreal w = (m_2DPixmap.width() / dpr) - 2 * CTRL_MARGIN * (m_2DPixmap.width() / dpr);
-        m_pixperdb = w / fabs(MAX_DB - MIN_DB);
+        m_pixperdb = w / fabs((double)(MAX_DB - MIN_DB));
         setSqlLevel(m_Sql);
     }
 
@@ -134,7 +134,7 @@ void CMeter::setSqlLevel(float dbfs)
     if (m_SqlLevel < 0.0)
         m_SqlLevel = 0.0;
 
-    m_Sql = dbfs;
+    m_Sql = (qreal)dbfs;
 }
 
 // Called by QT when screen needs to be redrawn

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -574,7 +574,7 @@ int CPlotter::getNearestPeak(QPoint pt)
         if (abs(y - py) > PEAK_CLICK_MAX_V_DISTANCE)
             continue;
 
-        qreal d = powf(y - py, 2) + powf(x - px, 2);
+        qreal d = pow(y - py, 2) + pow(x - px, 2);
         if (d < dist)
         {
             dist = d;
@@ -1223,7 +1223,7 @@ void CPlotter::draw(bool newData)
     const float wfdBGainFactor = 256.0f / fabsf(m_WfMaxdB - m_WfMindB);
 
     const double fftSize = m_fftDataSize;
-    const double sampleFreq = m_SampleFreq;
+    const double sampleFreq = (double)m_SampleFreq;
     const double fftCenter = (double)m_FftCenter;
     const double span = (double)m_Span;
     const double startFreq = fftCenter - span / 2.0;
@@ -1618,10 +1618,10 @@ void CPlotter::draw(bool newData)
         {
             const int ix = i + xmin;
             const qreal ixPlot = (qreal)ix;
-            const qreal yMaxD = std::max(std::min(
+            const qreal yMaxD = (qreal)std::max(std::min(
                 panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMaxBuf[ix])),
                 (float)plotHeight), 0.0f);
-            const qreal yAvgD = std::max(std::min(
+            const qreal yAvgD = (qreal)std::max(std::min(
                 panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftAvgBuf[ix])),
                 (float)plotHeight), 0.0f);
 
@@ -1638,7 +1638,7 @@ void CPlotter::draw(bool newData)
                         cidx = std::max(std::min(cidx, 255), 0);
                         QColor c = m_ColorTbl[cidx];
                         // Paint rectangle
-                        const qreal binY = binSizeY * j;
+                        const qreal binY = (qreal)binSizeY * j;
                         topBin = std::min(topBin, binY);
                         const qreal binH = (qreal)binSizeY * (j + 1) - binY;
                         painter2.fillRect(QRectF(ixPlot, binY, 1.0, binH), c);
@@ -1646,7 +1646,7 @@ void CPlotter::draw(bool newData)
                 }
                 // Highlight the top bin, if it isn't too crowded
                 if (topBin != plotHeight && showHistHighlights) {
-                    painter2.fillRect(QRectF(ixPlot, topBin, 1.0, binSizeY), maxLineColor);
+                    painter2.fillRect(QRectF(ixPlot, topBin, 1.0, (qreal)binSizeY), maxLineColor);
                 }
             }
 
@@ -1690,7 +1690,7 @@ void CPlotter::draw(bool newData)
             {
                 const int ix = i + xmin;
                 const qreal ixPlot = (qreal)ix;
-                const qreal yMaxHoldD = std::max(std::min(
+                const qreal yMaxHoldD = (qreal)std::max(std::min(
                     panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMaxHoldBuf[ix])),
                     (float)plotHeight), 0.0f);
                 maxLineBuf[i] = QPointF(ixPlot, yMaxHoldD);
@@ -1710,7 +1710,7 @@ void CPlotter::draw(bool newData)
             {
                 const int ix = i + xmin;
                 const qreal ixPlot = (qreal)ix;
-                const qreal yMinHoldD = std::max(std::min(
+                const qreal yMinHoldD = (qreal)std::max(std::min(
                     panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMinHoldBuf[ix])),
                     (float)plotHeight), 0.0f);
                 maxLineBuf[i] = QPointF(ixPlot, yMinHoldD);
@@ -1760,7 +1760,7 @@ void CPlotter::draw(bool newData)
                     m_peakSmoothBuf[ix] = avgV;
                     if (vi == maxV && (vi > 2.0f * avgV) && (vi > 4.0f * minV))
                     {
-                        const qreal y = std::max(std::min(
+                        const qreal y = (qreal)std::max(std::min(
                             panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(vi)),
                             (float)plotHeight - 0.0f), 0.0f);
                         m_Peaks[ix] = y;
@@ -1784,7 +1784,7 @@ void CPlotter::draw(bool newData)
                     const float avgV = sumV / (float)(pw2 * 2);
                     if (vi == maxV && (vi > 2.0f * avgV) && (vi > 4.0f * minV))
                     {
-                        const qreal y = std::max(std::min(
+                        const qreal y = (qreal)std::max(std::min(
                             panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(vi)),
                             (float)plotHeight - 0.0f), 0.0f);
 
@@ -2223,7 +2223,7 @@ void CPlotter::drawOverlay()
                 qMax(h / (m_VdivDelta * m_DPR), (qreal)VERT_DIVS_MIN),
                 mindBAdj64, dbDivSize, m_VerDivs);
 
-    dbstepsize = (float) dbDivSize;
+    dbstepsize = (qreal) dbDivSize;
     mindbadj = mindBAdj64;
 
     pixperdiv = h * (qreal) dbstepsize / (qreal) (m_PandMaxdB - m_PandMindB);

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -42,11 +42,11 @@ nbrx::nbrx(float quad_rate, float audio_rate)
 {
     iq_resamp = make_resampler_cc(PREF_QUAD_RATE/d_quad_rate);
 
-    nb = make_rx_nb_cc(PREF_QUAD_RATE, 3.3, 2.5);
-    filter = make_rx_filter(PREF_QUAD_RATE, -5000.0, 5000.0, 1000.0);
-    agc = make_rx_agc_cc(PREF_QUAD_RATE, true, -100, 0, 0, 500, false);
+    nb = make_rx_nb_cc((double)PREF_QUAD_RATE, 3.3, 2.5);
+    filter = make_rx_filter((double)PREF_QUAD_RATE, -5000.0, 5000.0, 1000.0);
+    agc = make_rx_agc_cc((double)PREF_QUAD_RATE, true, -100, 0, 0, 500, false);
     sql = gr::analog::simple_squelch_cc::make(-150.0, 0.001);
-    meter = make_rx_meter_c(PREF_QUAD_RATE);
+    meter = make_rx_meter_c((double)PREF_QUAD_RATE);
     demod_raw = gr::blocks::complex_to_float::make(1);
     demod_ssb = gr::blocks::complex_to_real::make(1);
     demod_fm = make_rx_demod_fm(PREF_QUAD_RATE, 5000.0, 75.0e-6);

--- a/src/receivers/wfmrx.cpp
+++ b/src/receivers/wfmrx.cpp
@@ -42,16 +42,16 @@ wfmrx::wfmrx(float quad_rate, float audio_rate)
 {
     iq_resamp = make_resampler_cc(PREF_QUAD_RATE/d_quad_rate);
 
-    filter = make_rx_filter(PREF_QUAD_RATE, -80000.0, 80000.0, 20000.0);
+    filter = make_rx_filter((double)PREF_QUAD_RATE, -80000.0, 80000.0, 20000.0);
     sql = gr::analog::simple_squelch_cc::make(-150.0, 0.001);
-    meter = make_rx_meter_c(PREF_QUAD_RATE);
+    meter = make_rx_meter_c((double)PREF_QUAD_RATE);
     demod_fm = make_rx_demod_fm(PREF_QUAD_RATE, 75000.0, 0.0);
     stereo = make_stereo_demod(PREF_QUAD_RATE, d_audio_rate, true);
     stereo_oirt = make_stereo_demod(PREF_QUAD_RATE, d_audio_rate, true, true);
     mono = make_stereo_demod(PREF_QUAD_RATE, d_audio_rate, false);
 
     /* create rds blocks but dont connect them */
-    rds = make_rx_rds(PREF_QUAD_RATE);
+    rds = make_rx_rds((double)PREF_QUAD_RATE);
     rds_decoder = gr::rds::decoder::make(0, 0);
     rds_parser = gr::rds::parser::make(0, 0, 0);
     rds_store = make_rx_rds_store();


### PR DESCRIPTION
This is a follow-up to the cleanup done in #1238, #1239, #1240, #1260, #1261, and #1263. The macOS builds (which compile with Clang) still had some double promotion warnings, which I've fixed here.