### PR TITLE
Properly handle smooth scrolling

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -27,6 +27,7 @@
   IMPROVED: Added 6 dB attenuation to WAV file recordings to prevent clipping.
   IMPROVED: Use logarithmic scale for frequency zoom slider.
   IMPROVED: Reduced CPU utilization of demodulators.
+  IMPROVED: Properly handle smooth scrolling.
    CHANGED: Frequency zoom slider zooms around center of display.
    CHANGED: Disallow scrolling beyond the FFT frequency limits.
    CHANGED: Default narrow FM deviation increased to 5 kHz.

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -68,6 +68,7 @@ CFreqCtrl::CFreqCtrl(QWidget *parent) :
     m_InvertScrolling = false;
     m_UnitsFont = QFont("Arial", 12, QFont::Normal);
     m_DigitFont = QFont("Arial", 12, QFont::Normal);
+    m_CumWheelDelta = 0;
 
     setStatusTip(tr(STATUS_TIP));
 }
@@ -492,8 +493,13 @@ void CFreqCtrl::wheelEvent(QWheelEvent *event)
     QPointF   pt = event->position();
 #endif
     int       delta = m_InvertScrolling ? -event->angleDelta().y() : event->angleDelta().y();
-    int       numDegrees = delta / 8;
+    m_CumWheelDelta += delta;
+    int       numDegrees = m_CumWheelDelta / 8;
     int       numSteps = numDegrees / 15;
+
+    // accumulate enough wheel deltas to reach at least one step
+    if (abs(numSteps) == 0)
+        return;
 
     for (int i = m_DigStart; i < m_NumDigits; i++)
     {
@@ -505,6 +511,8 @@ void CFreqCtrl::wheelEvent(QWheelEvent *event)
                 decFreq();
         }
     }
+
+    m_CumWheelDelta = 0;
 }
 
 void CFreqCtrl::keyPressEvent(QKeyEvent *event)

--- a/src/qtgui/freqctrl.h
+++ b/src/qtgui/freqctrl.h
@@ -106,6 +106,7 @@ private:
     int         m_LastEditDigit;
     int         m_DecPos;
     int         m_NumSeps;
+    int         m_CumWheelDelta;
 
     qint64      m_MinStep;
     qint64      m_freq;

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1025,6 +1025,9 @@ void CPlotter::wheelEvent(QWheelEvent * event)
             m_PandMaxdB = FFT_MAX_DB;
 
         m_PandMindB = m_PandMaxdB - db_range;
+        if (m_PandMindB < FFT_MIN_DB)
+            m_PandMindB = FFT_MIN_DB;
+
         m_MaxHoldValid = false;
         m_MinHoldValid = false;
         m_histIIRValid = false;

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -142,6 +142,7 @@ CPlotter::CPlotter(QWidget *parent) : QFrame(parent)
     m_PandMaxdB = m_WfMaxdB = 0.f;
     m_PandMindB = m_WfMindB = FFT_MAX_DB;
 
+    m_CumWheelDelta = 0;
     m_FreqUnits = 1000000;
     m_CursorCaptured = NOCAP;
     m_Running = false;
@@ -1053,6 +1054,12 @@ void CPlotter::wheelEvent(QWheelEvent * event)
     }
     else
     {
+        // small steps will be lost by roundFreq, let them accumulate
+        m_CumWheelDelta += delta;
+        if (abs(m_CumWheelDelta) < 8*15)
+            return;
+        numSteps = m_CumWheelDelta / (8.0 * 15.0);
+
         // inc/dec demod frequency
         m_DemodCenterFreq += (numSteps * m_ClickResolution);
         m_DemodCenterFreq = roundFreq(m_DemodCenterFreq, m_ClickResolution );
@@ -1060,6 +1067,7 @@ void CPlotter::wheelEvent(QWheelEvent * event)
     }
 
     updateOverlay();
+    m_CumWheelDelta = 0;
 }
 
 // Called when screen size changes so must recalculate bitmaps

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1003,16 +1003,15 @@ void CPlotter::wheelEvent(QWheelEvent * event)
     int px = qRound((qreal)pt.x() * m_DPR);
     int py = qRound((qreal)pt.y() * m_DPR);
 
+    // delta is in eigths of a degree, 15 degrees is one step
     int delta = m_InvertScrolling? -event->angleDelta().y() : event->angleDelta().y();
-    int numDegrees = delta / 8;
-    int numSteps = numDegrees / 15;  /** FIXME: Only used for direction **/
+    double numSteps = delta / (8.0 * 15.0);
 
-    /** FIXME: zooming could use some optimisation **/
     if (m_CursorCaptured == YAXIS)
     {
         // Vertical zoom. Wheel down: zoom out, wheel up: zoom in
         // During zoom we try to keep the point (dB or kHz) under the cursor fixed
-        float zoom_fac = delta < 0 ? 1.1 : 0.9;
+        float zoom_fac = pow(0.9, numSteps);
         float ratio = (float) py / (float) h;
         float db_range = m_PandMaxdB - m_PandMindB;
         float y_range = (float) h;
@@ -1033,7 +1032,7 @@ void CPlotter::wheelEvent(QWheelEvent * event)
     }
     else if (m_CursorCaptured == XAXIS)
     {
-        zoomStepX(delta < 0 ? 1.1 : 0.9, px);
+        zoomStepX(pow(0.9, numSteps), px);
     }
     else if (event->modifiers() & Qt::ControlModifier)
     {

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -2248,12 +2248,12 @@ void CPlotter::drawOverlay()
     }
 
     // draw amplitude values (y axis)
-    for (int i = 0; i < m_VerDivs; i++)
+    for (int i = 0; i <= m_VerDivs; i++)
     {
         qreal y = h - ((double)i * pixperdiv + adjoffset);
         qreal th = metrics.height();
         qreal shadowOffset = th / 20.0;
-        if (y < h -xAxisHeight)
+        if ((y < h - xAxisHeight) && (y > th / 2))
         {
             int dB = mindbadj + dbstepsize * i;
             // Shadow

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -310,6 +310,7 @@ private:
     qint64      m_Span;
     float       m_SampleFreq;    /*!< Sample rate. */
     qint32      m_FreqUnits;
+    qint32      m_CumWheelDelta;
     qreal       m_ClickResolution;
     qreal       m_FilterClickResolution;
     ePlotMode   m_PlotMode;


### PR DESCRIPTION
On computers with smooth scrolling that issue frequent scroll events with small deltas (such as Mac laptops), the current scrolling logic behaves very poorly, as each event zooms the same amount regardless of its size (delta), resulting in overly fast and jittery zoom, and the cumulative effects of non-zooming small scroll events are lost due to rounding and integer discretization. This new logic handles smooth scrolling trackpads/mice properly for zooming, filter adjustment, and frequency adjustment, while also handling old fashioned mice with infrequent large scroll events correctly too.