### PR TITLE
performance: Improve resampler performance

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -26,6 +26,7 @@
   IMPROVED: Waterfall span setting is stored in milliseconds.
   IMPROVED: Added 6 dB attenuation to WAV file recordings to prevent clipping.
   IMPROVED: Use logarithmic scale for frequency zoom slider.
+  IMPROVED: Reduced CPU utilization of demodulators.
    CHANGED: Frequency zoom slider zooms around center of display.
    CHANGED: Disallow scrolling beyond the FFT frequency limits.
    CHANGED: Default narrow FM deviation increased to 5 kHz.

--- a/src/dsp/resampler_xx.cpp
+++ b/src/dsp/resampler_xx.cpp
@@ -57,6 +57,7 @@ resampler_cc::resampler_cc(float rate)
 
     /* create the filter */
     d_filter = gr::filter::pfb_arb_resampler_ccf::make(rate, d_taps, flt_size);
+    d_filter->set_output_multiple(4096);
 
     /* connect filter */
     connect(self(), 0, d_filter, 0);
@@ -82,6 +83,7 @@ void resampler_cc::set_rate(float rate)
     disconnect(d_filter, 0, self(), 0);
     d_filter.reset();
     d_filter = gr::filter::pfb_arb_resampler_ccf::make(rate, d_taps, flt_size);
+    d_filter->set_output_multiple(4096);
     connect(self(), 0, d_filter, 0);
     connect(d_filter, 0, self(), 0);
     unlock();

--- a/src/dsp/resampler_xx.cpp
+++ b/src/dsp/resampler_xx.cpp
@@ -25,6 +25,7 @@
 #include <gnuradio/filter/firdes.h>
 #include "dsp/resampler_xx.h"
 
+#define RESAMPLER_OUTPUT_MULTIPLE 4096
 
 /* Create a new instance of resampler_cc and return
  * a shared_ptr. This is effectively the public constructor.
@@ -57,7 +58,7 @@ resampler_cc::resampler_cc(float rate)
 
     /* create the filter */
     d_filter = gr::filter::pfb_arb_resampler_ccf::make(rate, d_taps, flt_size);
-    d_filter->set_output_multiple(4096);
+    d_filter->set_output_multiple(RESAMPLER_OUTPUT_MULTIPLE);
 
     /* connect filter */
     connect(self(), 0, d_filter, 0);
@@ -83,7 +84,7 @@ void resampler_cc::set_rate(float rate)
     disconnect(d_filter, 0, self(), 0);
     d_filter.reset();
     d_filter = gr::filter::pfb_arb_resampler_ccf::make(rate, d_taps, flt_size);
-    d_filter->set_output_multiple(4096);
+    d_filter->set_output_multiple(RESAMPLER_OUTPUT_MULTIPLE);
     connect(self(), 0, d_filter, 0);
     connect(d_filter, 0, self(), 0);
     unlock();


### PR DESCRIPTION
Set resampler_cc output_multiple to 4096. This results in slightly increased audio delay (to ~23ms) and huge CPU load reduction.

All credit to @vladisslav2011, I only cherry-picked and tested this change. I found this one small simple change provided something like a 2.5-3x reduction in DSP CPU usage, and the added delay is barely perceptible if at all. No regressions observed. With this change, I can smoothly listen to radio channels while using the full 61.44 Msps sample rate of my USRP B210. Before this change, even 30 Msps had my CPU struggling and skipping audio chunks.