### PR TITLE
Save FFT plotter center frequency in settings

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -12,6 +12,7 @@
        NEW: "Avg" waterfall mode, which displays average of FFT bins.
        NEW: "Sync" waterfall mode, which mirrors averaged data from plot.
        NEW: Support for RTL-SDR Blog V4 in AppImage and DMG releases.
+       NEW: Save FFT plot center frequency in settings.
   IMPROVED: Peak detection algorithm.
   IMPROVED: Peak detection uses peak hold data when available.
   IMPROVED: Maximum FFT size increased to 4M.

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -673,6 +673,15 @@ bool MainWindow::loadConfig(const QString& cfgfile, bool check_crash,
     }
 
     {
+        // Center frequency for FFT plotter
+        int64_val = m_settings->value("fft/fft_center", 0).toLongLong(&conv_ok);
+
+        if (conv_ok) {
+            ui->plotter->setFftCenterFreq(int64_val);
+        }
+    }
+
+    {
         int flo = m_settings->value("receiver/filter_low_cut", 0).toInt(&conv_ok);
         int fhi = m_settings->value("receiver/filter_high_cut", 0).toInt(&conv_ok);
 
@@ -766,6 +775,7 @@ void MainWindow::storeSession()
     if (m_settings)
     {
         m_settings->setValue("input/frequency", ui->freqCtrl->getFrequency());
+        m_settings->setValue("fft/fft_center", ui->plotter->getFftCenterFreq());
 
         uiDockInputCtl->saveSettings(m_settings);
         uiDockRxOpt->saveSettings(m_settings);

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -2352,7 +2352,10 @@ int CPlotter::xFromFreq(qint64 freq)
 // Convert from screen coordinate to frequency
 qint64 CPlotter::freqFromX(int x)
 {
-    double ratio = (double)x / (qreal)m_Size.width() / m_DPR;
+    double ratio = 0;
+    if ((m_Size.width() > 0) && (m_DPR > 0))
+        ratio = (double)x / (qreal)m_Size.width() / m_DPR;
+
     qint64 f = qRound64((double)m_CenterFreq + (double)m_FftCenter
                         - (double)m_Span / 2.0 + ratio * (double)m_Span);
     return f;

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -117,6 +117,10 @@ public:
         m_FftCenter = qBound(-limit, f, limit);
     }
 
+    qint64 getFftCenterFreq() const {
+        return m_FftCenter;
+    }
+
     int     getNearestPeak(QPoint pt);
     void    setWaterfallSpan(quint64 span_ms);
     quint64 getWfTimeRes() const;


### PR DESCRIPTION
Store the selected center frequency in the plotter as `fft/fft_center`. This will make the plotter center consistent on startup when zoomed in.