### PR TITLE
Initialize d_fftWindowType to zero

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -68,6 +68,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     d_lnb_lo(0),
     d_hw_freq(0),
     d_fftAvg(0.25),
+    d_fftWindowType(0),
     d_fftNormalizeEnergy(false),
     d_have_audio(true),
     dec_afsk1200(nullptr)


### PR DESCRIPTION
This is necessary because the default index of the FFT window combo box is zero, and `DockFft::readSettings` only sets the FFT window when the combo box's index changes.

This fixes the following Valgrind errors which occur if Gqrx is started when the Hamming window is selected:
```
==357957== Conditional jump or move depends on uninitialised value(s)
==357957==    at 0x202842: rx_fft_c::set_window_type(int, bool) (rx_fft.cpp:204)
==357957==    by 0x5E0F272: ??? (in /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4)
==357957==    by 0x1AE7B2: DockFft::plotScaleChanged(int, bool) (moc_dockfft.cpp:638)
==357957==    by 0x23C430: DockFft::readSettings(QSettings*) (dockfft.cpp:445)
==357957==    by 0x1C2086: MainWindow::loadConfig(QString const&, bool, bool) (mainwindow.cpp:655)
==357957==    by 0x1C9933: MainWindow::MainWindow(QString const&, bool, QWidget*) (mainwindow.cpp:357)
==357957==    by 0x1A6A19: main (main.cpp:156)
==357957== 
==357957== Conditional jump or move depends on uninitialised value(s)
==357957==    at 0x65C20A9: gr::fft::window::build(gr::fft::window::win_type, int, double, bool) (window.cc:394)
==357957==    by 0x2025F1: rx_fft_c::update_window() (rx_fft.cpp:217)
==357957==    by 0x5E0F272: ??? (in /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4)
==357957==    by 0x1AE7B2: DockFft::plotScaleChanged(int, bool) (moc_dockfft.cpp:638)
==357957==    by 0x23C430: DockFft::readSettings(QSettings*) (dockfft.cpp:445)
==357957==    by 0x1C2086: MainWindow::loadConfig(QString const&, bool, bool) (mainwindow.cpp:655)
==357957==    by 0x1C9933: MainWindow::MainWindow(QString const&, bool, QWidget*) (mainwindow.cpp:357)
==357957==    by 0x1A6A19: main (main.cpp:156)
==357957== 
==357957== Use of uninitialised value of size 8
==357957==    at 0x65C20B8: gr::fft::window::build(gr::fft::window::win_type, int, double, bool) (window.cc:394)
==357957==    by 0x2025F1: rx_fft_c::update_window() (rx_fft.cpp:217)
==357957==    by 0x5E0F272: ??? (in /usr/lib/x86_64-linux-gnu/libQt6Core.so.6.2.4)
==357957==    by 0x1AE7B2: DockFft::plotScaleChanged(int, bool) (moc_dockfft.cpp:638)
==357957==    by 0x23C430: DockFft::readSettings(QSettings*) (dockfft.cpp:445)
==357957==    by 0x1C2086: MainWindow::loadConfig(QString const&, bool, bool) (mainwindow.cpp:655)
==357957==    by 0x1C9933: MainWindow::MainWindow(QString const&, bool, QWidget*) (mainwindow.cpp:357)
==357957==    by 0x1A6A19: main (main.cpp:156)
==357957== 
```