### PR TITLE
Add support for RTL-SDR Blog V4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,22 @@ jobs:
             libairspyhf-dev \
             libfreesrp-dev \
             libhackrf-dev \
-            librtlsdr-dev \
+            libusb-1.0-0-dev \
             libsoapysdr-dev \
             soapysdr-module-remote \
             libuhd-dev \
             liborc-0.4-dev \
             libhidapi-dev
+
+          cd /tmp
+          git clone https://gitea.osmocom.org/sdr/rtl-sdr.git
+          cd rtl-sdr
+          mkdir build
+          cd build
+          cmake -DCMAKE_INSTALL_PREFIX=/usr -DDETACH_KERNEL_DRIVER=ON ..
+          make -j4
+          make install
+          ldconfig
 
           cd /tmp
           git clone https://github.com/Nuand/bladeRF.git
@@ -87,7 +97,7 @@ jobs:
           ldconfig
 
           cd /tmp
-          git clone https://gitea.osmocom.org/sdr/gr-osmosdr.git
+          git clone https://github.com/gqrx-sdr/gr-osmosdr.git
           cd gr-osmosdr
           git checkout origin/gr3.8
           mkdir build
@@ -123,7 +133,8 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install airspy airspyhf boost dylibbundler gnuradio hackrf libbladerf librtlsdr libserialport portaudio pybind11 uhd qt@6 || true
+          brew install --HEAD librtlsdr
+          brew install airspy airspyhf boost dylibbundler gnuradio hackrf libbladerf libserialport portaudio pybind11 uhd qt@6 || true
           brew tap pothosware/homebrew-pothos
           brew install soapyremote
 
@@ -176,7 +187,7 @@ jobs:
           make install
 
           cd /tmp
-          git clone https://gitea.osmocom.org/sdr/gr-osmosdr.git
+          git clone https://github.com/gqrx-sdr/gr-osmosdr.git
           cd gr-osmosdr
           mkdir build
           cd build

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -11,6 +11,7 @@
        NEW: Dropped frames are indicated by red background in FFT Settigns panel.
        NEW: "Avg" waterfall mode, which displays average of FFT bins.
        NEW: "Sync" waterfall mode, which mirrors averaged data from plot.
+       NEW: Support for RTL-SDR Blog V4 in AppImage and DMG releases.
   IMPROVED: Peak detection algorithm.
   IMPROVED: Peak detection uses peak hold data when available.
   IMPROVED: Maximum FFT size increased to 4M.


### PR DESCRIPTION
Closes #1272.

Here I've added support for RTL-SDR Blog V4 dongles. On Linux, the `master` branch of rtl-sdr is built from source, and on macOS the `HEAD` version is built using Homebrew. Because @rtlsdrblog's gr-osmosdr patch has not yet been accepted upstream, I've temporarily forked gr-osmosdr and applied the patch.

Pre-release binaries (AppImage and DMG) can be downloaded in the "Artifacts" section here: https://github.com/gqrx-sdr/gqrx/actions/runs/6244124081

@rtlsdrblog I'd appreciate your feedback on the pre-release versions.