### PR TITLE
Fix inconsistent 1-2-5 scaling of amplitude axis

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -36,6 +36,7 @@
      FIXED: Crash in AFSK1200 decoder.
      FIXED: Y axis in saved waterfall is too narrow.
      FIXED: Hang when setting a very narrow filter width.
+     FIXED: Inconsistent 1-2-5 scaling of amplitude axis.
 
 
       2.16: Released April 28, 2023

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -2223,8 +2223,9 @@ void CPlotter::drawOverlay()
     // Level grid
     qint64 mindBAdj64 = 0;
     qint64 dbDivSize = 0;
+    qint64 dbSpan = (qint64) (m_PandMaxdB - m_PandMindB);
 
-    calcDivSize((qint64) m_PandMindB, (qint64) m_PandMaxdB,
+    calcDivSize((qint64) m_PandMindB, ((qint64) m_PandMindB) + dbSpan,
                 qMax(h / (m_VdivDelta * m_DPR), (qreal)VERT_DIVS_MIN),
                 mindBAdj64, dbDivSize, m_VerDivs);
 


### PR DESCRIPTION
If the amplitude axis is zoomed to a level that is close to a 1-2-5 threshold (for instance, between 2 dB steps and 5 dB steps), then dragging the axis vertically will result in the axis flickering randomly between 2 dB and 5 dB steps. This happens because the floating-point `m_PandMindB` and `m_PandMaxdB` are converted independently to integers (by rounding down) when passed to the `calcDivSize` function. As the axis is dragged, `m_PandMindB` and `m_PandMaxdB` cross integer thresholds at different times, so the difference varies by 1 dB.

To fix this problem, I've changed the code to convert the difference `m_PandMaxdB - m_PandMindB` to an integer, then add that to the integer version of `m_PandMindB`. That way, the difference between the endpoints to `calcDivSize` remains consistent.