### PR TITLE
Add back clamping in band plan coordinate calculation

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -2109,8 +2109,8 @@ void CPlotter::drawOverlay()
         m_BandPlanHeight = metrics.height() + VER_MARGIN;
         for (auto & band : bands)
         {
-            int band_left = xFromFreq(band.minFrequency);
-            int band_right = xFromFreq(band.maxFrequency);
+            int band_left = std::max(xFromFreq(band.minFrequency), 0);
+            int band_right = std::min(xFromFreq(band.maxFrequency), (int)w);
             int band_width = band_right - band_left;
             QRectF rect(band_left, xAxisTop - m_BandPlanHeight, band_width, m_BandPlanHeight);
             painter.fillRect(rect, band.color);


### PR DESCRIPTION
Partially addresses #1282.

Clamping was removed from `xFromFreq` in #1248, and this inadvertently caused a bug where band plan labels would be drawn off-screen in cases where the band is much wider than the screen.

Here I've added back clamping to this specific case, which seems to be the only place where it's needed.

Before:
![Screenshot from 2023-09-28 23-03-02](https://github.com/gqrx-sdr/gqrx/assets/583749/4e808ba8-cd0c-4ca5-bfd6-0f5a48bcf616)

After:
![Screenshot from 2023-09-28 23-02-50](https://github.com/gqrx-sdr/gqrx/assets/583749/3610ab2e-f298-45e3-820d-7933ebe83bc2)
