### PR TITLE
Remove unnecessary clamping checks

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -2129,11 +2129,8 @@ void CPlotter::drawOverlay()
     if (m_CenterLineEnabled)
     {
         x = xFromFreq(m_CenterFreq);
-        if (x > 0 && x < w)
-        {
-            painter.setPen(QPen(QColor(PLOTTER_CENTER_LINE_COLOR), m_DPR));
-            painter.drawLine(QPointF(x, 0), QPointF(x, xAxisTop));
-        }
+        painter.setPen(QPen(QColor(PLOTTER_CENTER_LINE_COLOR), m_DPR));
+        painter.drawLine(QPointF(x, 0), QPointF(x, xAxisTop));
     }
 
     if (m_MarkersEnabled)
@@ -2148,35 +2145,31 @@ void CPlotter::drawOverlay()
         if (m_MarkerFreqA != MARKER_OFF) {
             x = xFromFreq(m_MarkerFreqA);
             m_MarkerAX = x;
-            if (x > 0 && x < w) {
-                QPolygon poly;
-                QPainterPath path;
-                poly << QPoint(x - markerSize/2, 0)
-                     << QPoint(x + markerSize/2, 0)
-                     << QPoint(x, markerSize);
-                path.addPolygon(poly);
-                painter.drawPolygon(poly);
-                painter.fillPath(path, brush);
-                painter.drawLine(x, markerSize, x, xAxisTop);
-                painter.drawStaticText(QPointF(x + markerSize/2, 0), QStaticText("A"));
-            }
+            QPolygon poly;
+            QPainterPath path;
+            poly << QPoint(x - markerSize/2, 0)
+                    << QPoint(x + markerSize/2, 0)
+                    << QPoint(x, markerSize);
+            path.addPolygon(poly);
+            painter.drawPolygon(poly);
+            painter.fillPath(path, brush);
+            painter.drawLine(x, markerSize, x, xAxisTop);
+            painter.drawStaticText(QPointF(x + markerSize/2, 0), QStaticText("A"));
         }
 
         if (m_MarkerFreqB != MARKER_OFF) {
             x = xFromFreq(m_MarkerFreqB);
             m_MarkerBX = x;
-            if (x > 0 && x < w) {
-                QPolygon poly;
-                QPainterPath path;
-                poly << QPoint(x - markerSize/2, 0)
-                     << QPoint(x + markerSize/2, 0)
-                     << QPoint(x, markerSize);
-                path.addPolygon(poly);
-                painter.drawPolygon(poly);
-                painter.fillPath(path, brush);
-                painter.drawLine(x, markerSize, x, xAxisTop);
-                painter.drawStaticText(QPointF(x + markerSize/2, 0), QStaticText("B"));
-            }
+            QPolygon poly;
+            QPainterPath path;
+            poly << QPoint(x - markerSize/2, 0)
+                    << QPoint(x + markerSize/2, 0)
+                    << QPoint(x, markerSize);
+            path.addPolygon(poly);
+            painter.drawPolygon(poly);
+            painter.fillPath(path, brush);
+            painter.drawLine(x, markerSize, x, xAxisTop);
+            painter.drawStaticText(QPointF(x + markerSize/2, 0), QStaticText("B"));
         }
     }
 


### PR DESCRIPTION
Clamping was removed from `xFromFreq` in #1248. There are a few places in the plotter that explicitly checked for clamping to avoid drawing elements against the edge of the window when `xFromFreq` clamped their X coordinate. These checks are no longer necessary, since the clamping is no longer present.

In cases where the drawn elements are completely outside the visible area, Qt will simply not draw them.