### PR TITLE
Don't run FFTs until enough samples have arrived

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -29,6 +29,7 @@
   IMPROVED: Reduced CPU utilization of demodulators.
   IMPROVED: Properly handle smooth scrolling.
   IMPROVED: Shorten band names to fit in narrow spaces.
+  IMPROVED: Delay plot & waterfall drawing until samples arrive from hardware.
    CHANGED: Frequency zoom slider zooms around center of display.
    CHANGED: Disallow scrolling beyond the FFT frequency limits.
    CHANGED: Default narrow FM deviation increased to 5 kHz.

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1499,9 +1499,8 @@ void MainWindow::iqFftTimeout()
     }
     d_last_fft_ms = now_ms;
 
-    rx->get_iq_fft_data(d_iqFftData.data());
-
-    ui->plotter->setNewFftData(d_iqFftData.data(), fftsize);
+    if (rx->get_iq_fft_data(d_iqFftData.data()) >= 0)
+        ui->plotter->setNewFftData(d_iqFftData.data(), fftsize);
 }
 
 /** Audio FFT plot timeout. */
@@ -1519,9 +1518,8 @@ void MainWindow::audioFftTimeout()
     if (!d_have_audio || !uiDockAudio->isVisible())
         return;
 
-    rx->get_audio_fft_data(d_audioFftData.data());
-
-    uiDockAudio->setNewFftData(d_audioFftData.data(), fftsize);
+    if (rx->get_audio_fft_data(d_audioFftData.data()) >= 0)
+        uiDockAudio->setNewFftData(d_audioFftData.data(), fftsize);
 }
 
 /** RDS message display timeout. */

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -751,9 +751,9 @@ void receiver::set_iq_fft_window(int window_type, bool normalize_energy)
 }
 
 /** Get latest baseband FFT data. */
-void receiver::get_iq_fft_data(float* fftPoints)
+int receiver::get_iq_fft_data(float* fftPoints)
 {
-    iq_fft->get_fft_data(fftPoints);
+    return iq_fft->get_fft_data(fftPoints);
 }
 
 unsigned int receiver::audio_fft_size() const
@@ -762,9 +762,9 @@ unsigned int receiver::audio_fft_size() const
 }
 
 /** Get latest audio FFT data. */
-void receiver::get_audio_fft_data(float* fftPoints)
+int receiver::get_audio_fft_data(float* fftPoints)
 {
-    audio_fft->get_fft_data(fftPoints);
+    return audio_fft->get_fft_data(fftPoints);
 }
 
 receiver::status receiver::set_nb_on(int nbid, bool on)

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -163,8 +163,8 @@ public:
     void        set_iq_fft_size(int newsize);
     unsigned int iq_fft_size(void) const;
     void        set_iq_fft_window(int window_type, bool normalize_energy);
-    void        get_iq_fft_data(float* fftPoints);
-    void        get_audio_fft_data(float* fftPoints);
+    int         get_iq_fft_data(float* fftPoints);
+    int         get_audio_fft_data(float* fftPoints);
     unsigned int audio_fft_size(void) const;
 
     /* Noise blanker */

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -94,7 +94,7 @@ public:
              gr_vector_const_void_star &input_items,
              gr_vector_void_star &output_items);
 
-    void get_fft_data(float* fftPoints);
+    int get_fft_data(float* fftPoints);
 
     void set_window_type(int wintype, bool normalize_energy);
     int  get_window_type() const { return d_wintype; }
@@ -105,6 +105,7 @@ public:
 
 private:
     unsigned int d_fftsize;   /*! Current FFT size. */
+    unsigned int d_startup_samples;
     double       d_quadrate;
     int          d_wintype;   /*! Current window type. */
     bool         d_normalize_energy;
@@ -172,7 +173,7 @@ public:
              gr_vector_const_void_star &input_items,
              gr_vector_void_star &output_items);
 
-    void get_fft_data(float* fftPoints);
+    int get_fft_data(float* fftPoints);
 
     void set_window_type(int wintype, bool normalize_energy);
     int  get_window_type() const { return d_wintype; }
@@ -182,6 +183,7 @@ public:
 
 private:
     unsigned int d_fftsize;   /*! Current FFT size. */
+    unsigned int d_startup_samples;
     double       d_audiorate;
     int          d_wintype;   /*! Current window type. */
     bool         d_normalize_energy;


### PR DESCRIPTION
Partially addresses #1282.

The new "Min hold" feature sometimes fails if it's enabled when DSP is started for the first time. This happens because the `rx_fft` block is initially filled with zeroes, and will return them through `get_fft_data` if the plot is updated before any samples have arrived from the hardware.

To fix this, I've added sample counting to the `rx_fft` block. If not enough samples have arrived yet, the `get_fft_data` method returns -1, and the plot is not updated.

After the change, the "Min hold" feature works properly on startup, even with RTL-SDR.