### PR TITLE
Fix drawing of black areas in waterfall

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1421,8 +1421,8 @@ void CPlotter::draw(bool newData)
             // draw new line of fft data at top of waterfall bitmap
             // draw black areas where data will not be draw
             painter1.setPen(QPen(Qt::black));
-            painter1.drawRect(QRectF(0.0, 0.0, xmin, 1.0));
-            painter1.drawRect(QRectF(xmax, 0.0, w - xmax, 1.0));
+            painter1.drawLine(0.0, 0.0, xmin - 1, 0.0);
+            painter1.drawLine(xmax, 0.0, w - 1, 0.0);
 
             const bool useWfBuf = msec_per_wfline > 0;
             float _lineFactor;


### PR DESCRIPTION
Partially addresses #1282.

An extra black pixel is drawn along the left edge of the waterfall because the code that draws the black areas to the left and right of the waterfall uses `drawRect` which draws the outline of a rectangle, which extends down and to the right by one pixel beyond the rectangle's dimensions.

I've changed the code to use `drawLine` instead, which draws a single line of pixels.