### PR TITLE
Fix the pixels/bin calculation

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1154,9 +1154,8 @@ void CPlotter::draw(bool newData)
     const double startFreq = fftCenter - span / 2.0;
     const double binsPerHz = fftSize / sampleFreq;
 
-    // Scale factor for x -> fft bin. Note that it takes 2 pixels to have a
-    // span of 1 pixel.
-    double xScale = sampleFreq * (w - 1) / fftSize / span;
+    // Scale factor for x -> fft bin (pixels per bin).
+    double xScale = sampleFreq * w / fftSize / span;
 
     // Center of fft is the center of the DC bin. The Nyquist bin (index 0
     // after shift) is not used.


### PR DESCRIPTION
Partially addresses #1282.

At many zoom levels, there's an empty pixel at the right hand side of the plot & waterfall displays. As far as I can tell, this happens because the `xScale` variable, which represents the number of pixels per bin, uses the wrong figure (`w-1`) for the width of the display. (The display is actually `w` pixels wide.) As a result, the subsequent `xmin` and `xmax` calculations try to map the bins onto a `w-1` pixel display, and the rightmost pixel is often left empty (except when rounding error happens to push it one pixel larger). Changing the number of pixels to `w` fixes the problem.