### PR TITLE
Invalidate max, min, & hist before updateOverlay & redraw

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -870,15 +870,16 @@ void CPlotter::zoomStepX(float step, int x)
     // before frequency limits can be checked in setFftCenterFreq().
     m_Span = new_span;
     setFftCenterFreq(qRound64((f_max + f_min) / 2.0f));
+
+    m_MaxHoldValid = false;
+    m_MinHoldValid = false;
+    m_histIIRValid = false;
+
     updateOverlay();
 
     double zoom = (double)m_SampleFreq / (double)m_Span;
     emit newZoomLevel(zoom);
     qCDebug(plotter) << QString("Spectrum zoom: %1x").arg(zoom, 0, 'f', 1);
-
-    m_MaxHoldValid = false;
-    m_MinHoldValid = false;
-    m_histIIRValid = false;
 }
 
 // Zoom on X axis (absolute level)


### PR DESCRIPTION
Partially addresses #1282.

When zooming, max/min hold data are often incorrect, combining the previous & current zoom levels. This happens because the span and center frequency are changed, and then `updateOverlay` (and `draw`) are called, but max/min hold data are still marked as valid. Moving the invalidations before the `updateOverlay` call (as is the case elsewhere) solves the problem.