### PR TITLE
Remove clamping from Y-coordinate calculations

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1543,12 +1543,8 @@ void CPlotter::draw(bool newData)
         {
             const int ix = i + xmin;
             const qreal ixPlot = (qreal)ix;
-            const qreal yMaxD = (qreal)std::max(std::min(
-                panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMaxBuf[ix])),
-                (float)plotHeight), 0.0f);
-            const qreal yAvgD = (qreal)std::max(std::min(
-                panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftAvgBuf[ix])),
-                (float)plotHeight), 0.0f);
+            const qreal yMaxD = (qreal)(panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMaxBuf[ix])));
+            const qreal yAvgD = (qreal)(panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftAvgBuf[ix])));
 
             if (m_PlotMode == PLOT_MODE_HISTOGRAM)
             {
@@ -1615,9 +1611,7 @@ void CPlotter::draw(bool newData)
             {
                 const int ix = i + xmin;
                 const qreal ixPlot = (qreal)ix;
-                const qreal yMaxHoldD = (qreal)std::max(std::min(
-                    panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMaxHoldBuf[ix])),
-                    (float)plotHeight), 0.0f);
+                const qreal yMaxHoldD = (qreal)(panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMaxHoldBuf[ix])));
                 maxLineBuf[i] = QPointF(ixPlot, yMaxHoldD);
             }
             // NOT scaling to DPR due to performance
@@ -1635,9 +1629,7 @@ void CPlotter::draw(bool newData)
             {
                 const int ix = i + xmin;
                 const qreal ixPlot = (qreal)ix;
-                const qreal yMinHoldD = (qreal)std::max(std::min(
-                    panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMinHoldBuf[ix])),
-                    (float)plotHeight), 0.0f);
+                const qreal yMinHoldD = (qreal)(panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMinHoldBuf[ix])));
                 maxLineBuf[i] = QPointF(ixPlot, yMinHoldD);
             }
             // NOT scaling to DPR due to performance
@@ -1685,9 +1677,7 @@ void CPlotter::draw(bool newData)
                     m_peakSmoothBuf[ix] = avgV;
                     if (vi == maxV && (vi > 2.0f * avgV) && (vi > 4.0f * minV))
                     {
-                        const qreal y = (qreal)std::max(std::min(
-                            panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(vi)),
-                            (float)plotHeight - 0.0f), 0.0f);
+                        const qreal y = (qreal)(panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(vi)));
                         m_Peaks[ix] = y;
                     }
                 }
@@ -1709,9 +1699,7 @@ void CPlotter::draw(bool newData)
                     const float avgV = sumV / (float)(pw2 * 2);
                     if (vi == maxV && (vi > 2.0f * avgV) && (vi > 4.0f * minV))
                     {
-                        const qreal y = (qreal)std::max(std::min(
-                            panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(vi)),
-                            (float)plotHeight - 0.0f), 0.0f);
+                        const qreal y = (qreal)(panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(vi)));
 
                         // Show the wider peak only if there is no very close narrow peak
                         bool found = false;


### PR DESCRIPTION
The plotter clamps the Y coordinate of many things:

* max line
* average line
* max hold line
* min hold line
* peaks

This is not visible at the bottom of the plot, but at the top of the plot, lines and peaks are drawn across the top of the window:

![Screenshot from 2023-10-02 16-26-18](https://github.com/gqrx-sdr/gqrx/assets/583749/0001b32e-922d-49a3-8cc6-c65e9742dae1)

This seems undesirable and wastes CPU time. I think the clamping can be safely removed. After:

![Screenshot from 2023-10-02 16-28-09](https://github.com/gqrx-sdr/gqrx/assets/583749/9b693686-dbf1-43bf-9ee2-d2bdc57b6157)

The top-bin highlighting in the histogram plot suffers from a similar problem, but it's not so easy to fix so I'll leave that for later.