### PR TITLE
plotter: clear waterfall using Delete key

### DIFF
--- a/resources/kbd-shortcuts.txt
+++ b/resources/kbd-shortcuts.txt
@@ -12,6 +12,7 @@ Main window actions:
  F11            Toggle full screen mode
  F              Set focus to the frequency controller
  Z              Zero frequency offset
+ Delete         Clear waterfall
  Ctrl+Q         Quit the program
 
 Receiver modes:

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.17.1: In progress...
+
+       NEW: Delete key clears the waterfall.
+
+
       2.17: Released October 1, 2023
 
        NEW: "Avg" plot mode, which displays average of FFT bins.

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -172,6 +172,9 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     // toggle markers on/off
     auto *toggle_markers_shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_K), this);
     QObject::connect(toggle_markers_shortcut, &QShortcut::activated, this, &MainWindow::toggleMarkers);
+    // clear waterfall
+    auto *clear_waterfall_shortcut = new QShortcut(Qt::Key_Delete, this);
+    QObject::connect(clear_waterfall_shortcut, SIGNAL(activated()), ui->plotter, SLOT(clearWaterfall()));
 
     setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
     setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -2455,6 +2455,13 @@ void CPlotter::setMarkers(qint64 a, qint64 b)
     updateOverlay();
 }
 
+void CPlotter::clearWaterfall()
+{
+    if (!m_WaterfallPixmap.isNull()) {
+        m_WaterfallPixmap.fill(Qt::black);
+    }
+}
+
 void CPlotter::calcDivSize (qint64 low, qint64 high, int divswanted, qint64 &adjlow, qint64 &step, int& divs)
 {
     qCDebug(plotter) << "low:" << low;

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -181,6 +181,7 @@ public slots:
     void enableBandPlan(bool enable);
     void enableMarkers(bool enabled);
     void setMarkers(qint64 a, qint64 b);
+    void clearWaterfall();
     void updateOverlay();
 
     void setPercent2DScreen(int percent)


### PR DESCRIPTION
The waterfall is not automatically cleared after changes to the many settings that could cause it to be distorted or invalid. An explicit clear allows users who do not want to see outdated data to get rid of it.

I did not add a button, as the FFT dock is already pretty full. We can add one if the shortcut is not sufficient.

Resolves #1297 