### PR TITLE
Make out-of-range values visible at the bottom of the plot

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1545,10 +1545,10 @@ void CPlotter::draw(bool newData)
             const qreal ixPlot = (qreal)ix;
             const qreal yMaxD = (qreal)std::max(std::min(
                 panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMaxBuf[ix])),
-                (float)plotHeight), 0.0f);
+                (float)plotHeight - 1.0f), 0.0f);
             const qreal yAvgD = (qreal)std::max(std::min(
                 panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftAvgBuf[ix])),
-                (float)plotHeight), 0.0f);
+                (float)plotHeight - 1.0f), 0.0f);
 
             if (m_PlotMode == PLOT_MODE_HISTOGRAM)
             {
@@ -1617,7 +1617,7 @@ void CPlotter::draw(bool newData)
                 const qreal ixPlot = (qreal)ix;
                 const qreal yMaxHoldD = (qreal)std::max(std::min(
                     panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMaxHoldBuf[ix])),
-                    (float)plotHeight), 0.0f);
+                    (float)plotHeight - 1.0f), 0.0f);
                 maxLineBuf[i] = QPointF(ixPlot, yMaxHoldD);
             }
             // NOT scaling to DPR due to performance
@@ -1637,7 +1637,7 @@ void CPlotter::draw(bool newData)
                 const qreal ixPlot = (qreal)ix;
                 const qreal yMinHoldD = (qreal)std::max(std::min(
                     panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMinHoldBuf[ix])),
-                    (float)plotHeight), 0.0f);
+                    (float)plotHeight - 1.0f), 0.0f);
                 maxLineBuf[i] = QPointF(ixPlot, yMinHoldD);
             }
             // NOT scaling to DPR due to performance
@@ -1687,7 +1687,7 @@ void CPlotter::draw(bool newData)
                     {
                         const qreal y = (qreal)std::max(std::min(
                             panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(vi)),
-                            (float)plotHeight - 0.0f), 0.0f);
+                            (float)plotHeight - 1.0f), 0.0f);
                         m_Peaks[ix] = y;
                     }
                 }
@@ -1711,7 +1711,7 @@ void CPlotter::draw(bool newData)
                     {
                         const qreal y = (qreal)std::max(std::min(
                             panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(vi)),
-                            (float)plotHeight - 0.0f), 0.0f);
+                            (float)plotHeight - 1.0f), 0.0f);
 
                         // Show the wider peak only if there is no very close narrow peak
                         bool found = false;


### PR DESCRIPTION
This is an alternative to #1296.

Instead of removing clamping, we could correct the clamping calculation so that out-of-range values are visible at the lower edge of the plot the same way as they are at the top.

Before:
![Screenshot from 2023-10-03 09-31-20](https://github.com/gqrx-sdr/gqrx/assets/583749/19d4b628-eb6c-4af9-bc33-491bb979a06d)

After:
![Screenshot from 2023-10-03 09-30-05](https://github.com/gqrx-sdr/gqrx/assets/583749/5b8d7f6c-1113-4ad4-885b-e35ff74e3cee)