### PR TITLE
Refactor the signal meter

### DIFF
--- a/src/qtgui/meter.h
+++ b/src/qtgui/meter.h
@@ -33,7 +33,6 @@
 
 #include <QtGui>
 #include <QFrame>
-#include <QImage>
 
 class CMeter : public QFrame
 {
@@ -41,19 +40,10 @@ class CMeter : public QFrame
 
 public:
     explicit CMeter(QWidget *parent = 0);
-    explicit CMeter(float min_level = -100.0, float max_level = 10.0,
-                    QWidget *parent = 0);
     ~CMeter();
 
     QSize minimumSizeHint() const;
     QSize sizeHint() const;
-
-    void setMin(float min_level);
-    void setMax(float max_level);
-    void setRange(float min_level, float max_level);
-
-    void draw();
-    void UpdateOverlay(){DrawOverlay();}
 
 public slots:
     void setLevel(float dbfs);
@@ -61,19 +51,11 @@ public slots:
 
 protected:
     void paintEvent(QPaintEvent *event);
-    void resizeEvent(QResizeEvent* event);
 
 private:
-    void DrawOverlay();
+    void draw(QPainter &painter);
+    void drawOverlay(QPainter &painter);
 
-    QFont   m_Font;
-    QPixmap m_2DPixmap;
-    QPixmap m_OverlayPixmap;
-    QSize   m_Size;
-    QString m_Str;
-    qreal   m_pixperdb;     // pixels / dB
-    qreal   m_Siglevel;
     float   m_dBFS;
-    qreal   m_Sql;
-    qreal   m_SqlLevel;
+    float   m_Sql;
 };


### PR DESCRIPTION
The signal meter draws into an off-screen `QPixmap`, which has become unwieldy now that high-DPI screens must be supported. I've changed the code do directly draw the widget. Also, I removed a bunch of dead code and removed a lot of state variables which made the code unnecessarily complicated.

I made one visual change: there was code to draw shorter tick marks in between the numbers, but the length was set to the same value for both types of ticks. I've now made the minor ticks slightly shorter:

![Screenshot from 2023-10-03 16-10-55](https://github.com/gqrx-sdr/gqrx/assets/583749/7d4d9a21-45ed-4571-8d99-c8c11e95cdaf)
