### PR TITLE
Build AppImage based on conda packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             soapysdr-module-remote
             volk
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Configure
@@ -63,7 +63,7 @@ jobs:
           PREFIX: ${{ steps.setup-micromamba.outputs.environment-path }}
         run: ./appimage.sh
       - name: Save artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gqrx-appimage-${{ github.run_id }}
           path: Gqrx-*.AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
             pulseaudio
             qt6-gtk-platformtheme
             qt6-main
+            soapysdr-module-fcdpp
             soapysdr-module-lms7
             soapysdr-module-netsdr
             soapysdr-module-plutosdr

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
             pkg-config
             gnuradio-core
             gnuradio-osmosdr
-            libboost-headers
+            boost-cpp
             mesa-libgl-devel-cos6-x86_64
             pybind11
             pulseaudio

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,7 @@ jobs:
             pulseaudio
             qt6-gtk-platformtheme
             qt6-main
-            soapysdr-module-fcdpp
             soapysdr-module-lms7
-            soapysdr-module-netsdr
             soapysdr-module-plutosdr
             soapysdr-module-remote
             volk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,122 +6,60 @@ jobs:
   appimage:
     name: AppImage
     runs-on: ubuntu-latest
-    container:
-      image: "ubuntu:18.04"
-      env:
-        DEBIAN_FRONTEND: noninteractive
-        APPIMAGE_EXTRACT_AND_RUN: "1"
     steps:
-      - name: Install dependencies
+      - name: Install base dependencies
         run: |
-          apt-get update -qq
-          apt-get install -y --no-install-recommends software-properties-common
-          add-apt-repository -y ppa:gnuradio/gnuradio-releases
-          add-apt-repository -y ppa:git-core/ppa
-          apt-get install -y --no-install-recommends \
-            git \
-            build-essential \
-            autoconf \
-            automake \
-            cmake \
-            libtool \
-            wget \
-            qt5-default \
-            qt5-gtk-platformtheme \
-            qttranslations5-l10n \
-            libqt5svg5-dev \
-            libboost-dev \
-            libpulse-dev \
-            portaudio19-dev \
-            liblog4cpp5-dev \
-            gnuradio-dev \
-            libairspy-dev \
-            libairspyhf-dev \
-            libfreesrp-dev \
-            libhackrf-dev \
-            libusb-1.0-0-dev \
-            libsoapysdr-dev \
-            soapysdr-module-remote \
-            libuhd-dev \
-            liborc-0.4-dev \
-            libhidapi-dev
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libopengl0 \
+            libegl1
 
-          cd /tmp
-          git clone https://gitea.osmocom.org/sdr/rtl-sdr.git
-          cd rtl-sdr
-          git checkout v2.0.1
-          mkdir build
-          cd build
-          cmake -DCMAKE_INSTALL_PREFIX=/usr -DDETACH_KERNEL_DRIVER=ON ..
-          make -j4
-          make install
-          ldconfig
-
-          cd /tmp
-          git clone https://github.com/Nuand/bladeRF.git
-          cd bladeRF
-          mkdir build
-          cd build
-          cmake -DCMAKE_INSTALL_PREFIX=/usr ..
-          make -j4
-          make install
-          ldconfig
-
-          cd /tmp
-          git clone https://github.com/dl1ksv/gr-fcdproplus.git
-          cd gr-fcdproplus
-          mkdir build
-          cd build
-          cmake -DCMAKE_INSTALL_PREFIX=/usr ..
-          make -j4
-          make install
-          ldconfig
-
-          cd /tmp
-          git clone https://gitea.osmocom.org/sdr/libosmo-dsp.git
-          cd libosmo-dsp
-          autoreconf -i
-          ./configure --prefix=/usr
-          make -j4
-          make install
-          ldconfig
-
-          cd /tmp
-          git clone https://gitea.osmocom.org/sdr/gr-iqbal.git
-          cd gr-iqbal
-          git checkout gr3.8
-          mkdir build
-          cd build
-          cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_MODULES_DIR=/usr/lib/x86_64-linux-gnu/cmake ..
-          make -j4
-          make install
-          ldconfig
-
-          cd /tmp
-          git clone https://gitea.osmocom.org/sdr/gr-osmosdr.git
-          cd gr-osmosdr
-          git checkout origin/gr3.8
-          git cherry-pick -n 9c09c90d920dd4906fa8bb9d8443eef84d2565a3
-          mkdir build
-          cd build
-          cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_MODULES_DIR=/usr/lib/x86_64-linux-gnu/cmake -DENABLE_PYTHON=False ..
-          make -j4
-          make install
-          ldconfig
+      - name: Install conda dependencies
+        id: setup-micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: gqrx
+          create-args: >-
+            c-compiler
+            cxx-compiler
+            cmake
+            make
+            pkg-config
+            gnuradio-core
+            gnuradio-osmosdr
+            libboost-headers
+            mesa-libgl-devel-cos6-x86_64
+            pybind11
+            pulseaudio
+            qt6-gtk-platformtheme
+            qt6-main
+            soapysdr-module-lms7
+            soapysdr-module-netsdr
+            soapysdr-module-plutosdr
+            soapysdr-module-remote
+            volk
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Configure
+        shell: bash -el {0}
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
           mkdir build
           cd build
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
       - name: Compile
+        shell: bash -el {0}
         working-directory: build
-        run: make -j4
+        run: |
+          make -j4
+          make install
       - name: Build AppImage
+        shell: bash -el {0}
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+          PREFIX: ${{ steps.setup-micromamba.outputs.environment-path }}
         run: ./appimage.sh
       - name: Save artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
             pkg-config
             gnuradio-core
             gnuradio-osmosdr
-            boost-cpp
+            libboost-headers
             mesa-libgl-devel-cos6-x86_64
             pybind11
             pulseaudio

--- a/appimage.sh
+++ b/appimage.sh
@@ -76,6 +76,7 @@ done
 mkdir -p ./AppDir/apprun-hooks
 echo 'export CONDA_PREFIX="$APPDIR/usr"' >./AppDir/apprun-hooks/soapy-hook.sh
 echo 'export UHD_PKG_PATH="$APPDIR/usr"' >./AppDir/apprun-hooks/uhd-hook.sh
+echo 'export FONTCONFIG_FILE="$APPDIR/etc/fonts/fonts.conf"' >./AppDir/apprun-hooks/fontconfig-hook.sh
 
 # since libs come from prefix, little use in querying copyright files with dpkg-query
 export DISABLE_COPYRIGHT_FILES_DEPLOYMENT=1
@@ -103,6 +104,11 @@ cp "$PREFIX"/lib/libusb-1.0.so.0 ./AppDir/usr/lib/
 cp "$PREFIX"/lib/libuuid.so.1 ./AppDir/usr/lib/
 cp "$PREFIX"/lib/libxcb.so.1 ./AppDir/usr/lib/
 cp "$PREFIX"/lib/libz.so.1 ./AppDir/usr/lib/
+
+# copy fontconfig configuration files that the FONTCONFIG_FILE env var points to
+mkdir -p ./AppDir/etc/ ./AppDir/share/
+cp -R "$PREFIX"/etc/fonts ./AppDir/etc/fonts
+cp -R "$PREFIX"/share/fontconfig ./AppDir/share/fontconfig
 
 # finally make the AppImage
 ./appimagetool-x86_64.AppImage AppDir/

--- a/appimage.sh
+++ b/appimage.sh
@@ -73,6 +73,25 @@ for lib in ${soapy_module_libs[@]}; do
     linuxdeploy_lib_args+=( "-l" "$lib" )
 done
 
+# force otherwise excluded libraries that we really need because of library
+# dependence on newer versions
+linuxdeploy_lib_args+=(
+    "-l" "$PREFIX"/lib/libasound.so.2
+    "-l" "$PREFIX"/lib/libexpat.so.1
+    "-l" "$PREFIX"/lib/libfontconfig.so.1
+    "-l" "$PREFIX"/lib/libfreetype.so.6
+    "-l" "$PREFIX"/lib/libgcc_s.so.1
+    "-l" "$PREFIX"/lib/libgmp.so.10
+    "-l" "$PREFIX"/lib/libgpg-error.so.0
+    "-l" "$PREFIX"/lib/libharfbuzz.so.0
+    "-l" "$PREFIX"/lib/libjack.so.0
+    "-l" "$PREFIX"/lib/libstdc++.so.6
+    "-l" "$PREFIX"/lib/libusb-1.0.so.0
+    "-l" "$PREFIX"/lib/libuuid.so.1
+    "-l" "$PREFIX"/lib/libxcb.so.1
+    "-l" "$PREFIX"/lib/libz.so.1
+)
+
 mkdir -p ./AppDir/apprun-hooks
 echo 'export CONDA_PREFIX="$APPDIR/usr"' >./AppDir/apprun-hooks/soapy-hook.sh
 echo 'export UHD_PKG_PATH="$APPDIR/usr"' >./AppDir/apprun-hooks/uhd-hook.sh
@@ -90,21 +109,6 @@ RESULT=$?
 
 # copy Soapy modules into their expected path in the AppDir
 cp -R "$PREFIX"/lib/SoapySDR ./AppDir/usr/lib/SoapySDR
-
-# copy blacklisted libraries that we really need because of library dependence
-# on newer versions
-cp "$PREFIX"/lib/libexpat.so.1 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libfontconfig.so.1 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libfreetype.so.6 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libgcc_s.so.1 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libgmp.so.10 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libgpg-error.so.0 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libharfbuzz.so.0 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libstdc++.so.6 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libusb-1.0.so.0 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libuuid.so.1 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libxcb.so.1 ./AppDir/usr/lib/
-cp "$PREFIX"/lib/libz.so.1 ./AppDir/usr/lib/
 
 # copy fontconfig configuration files that the FONTCONFIG_FILE env var points to
 mkdir -p ./AppDir/etc/

--- a/appimage.sh
+++ b/appimage.sh
@@ -9,9 +9,8 @@
 # Requirements:
 #   * VERSION as an ENV var, if not detected will use actual github
 #     version + commit info
-#   * This must be run after a successfully build, and need to set the
-#     APP var below to the path of the executable (default is the current
-#     travis build place: build/src/gqrx)
+#   * This must be run after a successfully build and installation into a
+#     prefix passed as the PREFIX variable
 #   * Must be run on a Linux version as old as the far distro you need to
 #     support, tested successfully on Ubuntu 14.04 Trusty Tar
 #   * If you plan to use the "-u" option you need to configure some things
@@ -19,9 +18,11 @@
 #
 # On any troubles invoke stdevPavelmc in github
 
-# Tweak this please: this is the path of the gqrx executable relative to
-#the project root will reside after build
-APP="build/src/gqrx"
+# PREFIX variable must be set before calling this script. It points to the
+# prefix in which gqrx is installed and from which dependency libraries will be
+# gathered.
+#PREFIX="micromamba/envs/gqrx"
+APP="$PREFIX/bin/gqrx"
 
 # No need to tweak below unless you move files on the actual project
 DESKTOP="dk.gqrx.gqrx.desktop"
@@ -41,12 +42,12 @@ echo ""
 
 # basic tests
 if [ ! -f "$APP" ] ; then
-    echo "Error: the app file is no in the path we need it, update the APP var on this script"
+    echo "Error: the app file is no in the path we need it, set the PREFIX var before running this script"
     exit 1
 fi
 
 if [ ! -f "$DESKTOP" ] ; then
-    echo "Error: can't find the desktop file, please update the DESKTOP var on the scriot"
+    echo "Error: can't find the desktop file, please update the DESKTOP var on the script"
     exit 1
 fi
 
@@ -62,18 +63,34 @@ rm -rdf Gqrx-*.AppImage 2>/dev/null
 # download & set all needed tools
 wget -c -nv "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
 wget -c -nv "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
-wget -c -nv "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
+wget -c -nv "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
 chmod a+x *.AppImage
 
-# abra-cadabra
-mkdir -p ./AppDir/usr/lib
-cp -R /usr/lib/x86_64-linux-gnu/SoapySDR/modules* ./AppDir/usr/soapy-modules
+# build library arguments so soapy module dependencies are included
+soapy_module_libs=("$PREFIX"/lib/SoapySDR/modules*/*)
+linuxdeploy_lib_args=()
+for lib in ${soapy_module_libs[@]}; do
+    linuxdeploy_lib_args+=( "-l" "$lib" )
+done
 
 mkdir -p ./AppDir/apprun-hooks
+echo 'export CONDA_PREFIX="$APPDIR/usr"' >./AppDir/apprun-hooks/soapy-hook.sh
 echo 'export UHD_PKG_PATH="$APPDIR/usr"' >./AppDir/apprun-hooks/uhd-hook.sh
 
-./linuxdeploy-x86_64.AppImage -e "$APP" -d "$DESKTOP" -i "$ICON" -p qt --output appimage --appdir=./AppDir
+# since libs come from prefix, little use in querying copyright files with dpkg-query
+export DISABLE_COPYRIGHT_FILES_DEPLOYMENT=1
+
+# need to set QMAKE variable for linuxdeploy-plugin-qt so it uses PREFIX's Qt
+export QMAKE="$PREFIX/bin/qmake6"
+
+./linuxdeploy-x86_64.AppImage -e "$APP" -d "$DESKTOP" -i "$ICON" "${linuxdeploy_lib_args[@]}" -p qt --appdir=./AppDir
 RESULT=$?
+
+# copy Soapy modules into their expected path in the AppDir
+cp -R "$PREFIX"/lib/SoapySDR ./AppDir/usr/lib/SoapySDR
+
+# finally make the AppImage
+./appimagetool-x86_64.AppImage AppDir/
 
 # check build success
 if [ $RESULT -ne 0 ] ; then

--- a/appimage.sh
+++ b/appimage.sh
@@ -76,7 +76,8 @@ done
 mkdir -p ./AppDir/apprun-hooks
 echo 'export CONDA_PREFIX="$APPDIR/usr"' >./AppDir/apprun-hooks/soapy-hook.sh
 echo 'export UHD_PKG_PATH="$APPDIR/usr"' >./AppDir/apprun-hooks/uhd-hook.sh
-echo 'export FONTCONFIG_FILE="$APPDIR/etc/fonts/fonts.conf"' >./AppDir/apprun-hooks/fontconfig-hook.sh
+echo 'export FONTCONFIG_FILE="$APPDIR/etc/fonts/fonts.conf"
+export FONTCONFIG_PATH="$APPDIR/etc/fonts"' >./AppDir/apprun-hooks/fontconfig-hook.sh
 
 # since libs come from prefix, little use in querying copyright files with dpkg-query
 export DISABLE_COPYRIGHT_FILES_DEPLOYMENT=1
@@ -106,9 +107,12 @@ cp "$PREFIX"/lib/libxcb.so.1 ./AppDir/usr/lib/
 cp "$PREFIX"/lib/libz.so.1 ./AppDir/usr/lib/
 
 # copy fontconfig configuration files that the FONTCONFIG_FILE env var points to
-mkdir -p ./AppDir/etc/ ./AppDir/share/
-cp -R "$PREFIX"/etc/fonts ./AppDir/etc/fonts
-cp -R "$PREFIX"/share/fontconfig ./AppDir/share/fontconfig
+mkdir -p ./AppDir/etc/
+cp -RL "$PREFIX"/etc/fonts ./AppDir/etc/fonts
+# remove any config file lines that refer to the old prefix if it's not /usr
+if [ "${PREFIX:0:4}" != "/usr" ] ; then
+    sed -i "\|$PREFIX|d" ./AppDir/etc/fonts/fonts.conf
+fi
 
 # finally make the AppImage
 ./appimagetool-x86_64.AppImage AppDir/

--- a/appimage.sh
+++ b/appimage.sh
@@ -89,6 +89,21 @@ RESULT=$?
 # copy Soapy modules into their expected path in the AppDir
 cp -R "$PREFIX"/lib/SoapySDR ./AppDir/usr/lib/SoapySDR
 
+# copy blacklisted libraries that we really need because of library dependence
+# on newer versions
+cp "$PREFIX"/lib/libexpat.so.1 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libfontconfig.so.1 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libfreetype.so.6 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libgcc_s.so.1 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libgmp.so.10 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libgpg-error.so.0 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libharfbuzz.so.0 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libstdc++.so.6 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libusb-1.0.so.0 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libuuid.so.1 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libxcb.so.1 ./AppDir/usr/lib/
+cp "$PREFIX"/lib/libz.so.1 ./AppDir/usr/lib/
+
 # finally make the AppImage
 ./appimagetool-x86_64.AppImage AppDir/
 


### PR DESCRIPTION
After discussing this on the Matrix chat, here is my attempt at updating the Github Action to build the Linux AppImage based on conda-forge packages instead of Ubuntu 18.04. Conda-forge packages are built on a CentOS 6 base (with some packages potentially opting for a CentOS 7 base), so compatibility with older distributions should be maintained. The main benefit of this would be the inclusion of recent versions of Gqrx's dependencies, e.g. GNU Radio 3.10.7, UHD 4.5, etc.

As of now, there are some non-version differences in what is included with this AppImage compared to the existing one. Missing:
- [x] FUNcube Dongle support through `soapysdr-module-fcdpp`  and `gnuradio-funcube`
- ~[ ] FreeSRP support (will require a `libfreesrp` package for conda-forge's `gnuradio-osmosdr` to be built against)~
- [x] Automatic IQ balance (will require a `gr-iqbal` package for conda-forge's `gnuradio-osmosdr` to be built against)

Now including:
- [x] PlutoSDR support through `soapysdr-module-plutosdr`
- [x] LimeSDR support through `soapysdr-module-lms7`
- [x] NETSDR support through `soapysdr-module-netsdr`
- [x] MiriSDR support with `libmirisdr` through `gnuradio-osmosdr`

The missing things just need a little more packaging work to enable.

I'm very interested in feedback from anyone who is able to test the [resulting AppImage](https://github.com/ryanvolz/gqrx/suites/16841242385/artifacts/961898081) to make sure everything works as expected, particularly on older distributions.

One thing that is left to determine is if it's necessary to distribute the licenses of the included libraries and if there is a good way to do that from the conda-forge packages. The current method relies on running `dpkg-query` and that of course doesn't work when the library source is not a Debian/Ubuntu package.