### PR TITLE
Use a QImage for the waterfall

### DIFF
--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -259,7 +259,7 @@ private:
     eCapturetype    m_CursorCaptured;
     QPixmap     m_2DPixmap;         // Composite of everything displayed in the 2D plotter area
     QPixmap     m_OverlayPixmap;    // Grid, axes ... things that need to be drawn infrequently
-    QPixmap     m_WaterfallPixmap;
+    QImage      m_WaterfallImage;
     QColor      m_ColorTbl[256];
     QSize       m_Size;
     qreal       m_DPR{};


### PR DESCRIPTION
`QImage` is similar to `QPixmap` but allows direct access to pixel data. This is ideal for the waterfall, which consists entirely of pixels, allowing the `QPainter` to be removed.

This change results in a significant performance increase. CPU utilization for a full-screen waterfall-only display at 333 fps and 2048-point FFT drops from about 92% to 70% on my machine. I'm also able to achieve 500 fps at full-screen.