### PR TITLE
Add core:hw to SigMF metadata files

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1656,6 +1656,7 @@ void MainWindow::startIqRecording(const QString& recdir, const QString& format)
                 {"core:sample_rate", sr/dec},
                 {"core:version", "1.0.0"},
                 {"core:recorder", "Gqrx " VERSION},
+                {"core:hw", QString("OsmoSDR: ") + m_settings->value("input/device", "").toString()},
             }}, {"captures", QJsonArray {
                 QJsonObject {
                     {"core:sample_start", 0},


### PR DESCRIPTION
This is a follow-up to #1182.

As noted in https://github.com/gqrx-sdr/gqrx/pull/1182#issuecomment-1749787086, it would be useful to store input device metadata in the `core:hw` field, which the SigMF spec defines as:

> A text description of the hardware used to make the Recording.

Unfortunately, the gr-osmosdr API does not appear to provide any means to fetch metadata about the device associated with a source block. Metadata about all scanned devices can be retrieved with `osmosdr::device::find()`, but there is no guarantee that the device selected by the device string matches one of the scanned devices. So I think the best we can do for now is write out the current device string, e.g. `"core:hw": "airspyhf=0"`.

/cc @Niautanor 