### PR TITLE
Add feature to update existing bookmark

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -311,6 +311,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
 
     // Bookmarks
     connect(uiDockBookmarks, SIGNAL(newBookmarkActivated(qint64, QString, int)), this, SLOT(onBookmarkActivated(qint64, QString, int)));
+    connect(uiDockBookmarks->actionUpdateBookmark, SIGNAL(triggered()), this, SLOT(on_actionUpdateBookmark_triggered()));
     connect(uiDockBookmarks->actionAddBookmark, SIGNAL(triggered()), this, SLOT(on_actionAddBookmark_triggered()));
     connect(&Bookmarks::Get(), SIGNAL(BookmarksChanged()), ui->plotter, SLOT(updateOverlay()));
 
@@ -2448,6 +2449,30 @@ void MainWindow::on_actionAbout_triggered()
 void MainWindow::on_actionAboutQt_triggered()
 {
     QMessageBox::aboutQt(this, tr("About Qt"));
+}
+
+void MainWindow::on_actionUpdateBookmark_triggered()
+{
+    auto* action = qobject_cast<QAction *>(sender());
+    if (!action)
+    {
+        return;
+    }
+    bool ok = false;
+    auto bookmarkIndex = action->data().toInt(&ok);
+    if (!ok)
+    {
+        return;
+    }
+    BookmarkInfo info;
+    info.frequency = ui->freqCtrl->getFrequency();
+    info.bandwidth = ui->plotter->getFilterBw();
+    info.modulation = uiDockRxOpt->currentDemodAsString();
+    auto newIndex = Bookmarks::Get().update(bookmarkIndex, info);
+    if (newIndex >= 0)
+    {
+        uiDockBookmarks->selectBookmark(newIndex);
+    }
 }
 
 void MainWindow::on_actionAddBookmark_triggered()

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -242,6 +242,7 @@ private slots:
     void on_actionKbdShortcuts_triggered();
     void on_actionAbout_triggered();
     void on_actionAboutQt_triggered();
+    void on_actionUpdateBookmark_triggered();
     void on_actionAddBookmark_triggered();
     void on_actionDX_Cluster_triggered();
 

--- a/src/qtgui/bookmarks.cpp
+++ b/src/qtgui/bookmarks.cpp
@@ -56,6 +56,17 @@ void Bookmarks::setConfigDir(const QString& cfg_dir)
     std::cout << "BookmarksFile is " << m_bookmarksFile.toStdString() << std::endl;
 }
 
+int Bookmarks::update(int index, BookmarkInfo& info)
+{
+    m_BookmarkList[index].frequency = info.frequency;
+    m_BookmarkList[index].bandwidth = info.bandwidth;
+    m_BookmarkList[index].modulation = info.modulation;
+    auto newInfo = m_BookmarkList[index];
+    std::stable_sort(m_BookmarkList.begin(),m_BookmarkList.end());
+    save();
+    return m_BookmarkList.indexOf(newInfo);
+}
+
 void Bookmarks::add(BookmarkInfo &info)
 {
     m_BookmarkList.append(info);

--- a/src/qtgui/bookmarks.h
+++ b/src/qtgui/bookmarks.h
@@ -84,6 +84,15 @@ struct BookmarkInfo
     {
         return frequency < other.frequency;
     }
+
+    bool operator==(const BookmarkInfo &other) const
+    {
+        return frequency == other.frequency
+            and name == other.name
+            and modulation == other.modulation
+            and bandwidth == other.bandwidth
+            and tags == other.tags;
+    }
 /*
     void setTags(QString tagString);
     QString getTagString();
@@ -104,6 +113,7 @@ public:
     static Bookmarks& Get();
 
     void add(BookmarkInfo& info);
+    int update(int index, BookmarkInfo& info);
     void remove(int index);
     bool load();
     bool save();

--- a/src/qtgui/bookmarkstablemodel.cpp
+++ b/src/qtgui/bookmarkstablemodel.cpp
@@ -223,3 +223,8 @@ int BookmarksTableModel::GetBookmarksIndexForRow(int iRow)
 {
   return m_mapRowToBookmarksIndex[iRow];
 }
+
+int BookmarksTableModel::GetRowForBookmarksIndex(int bookmarkIndex)
+{
+    return m_mapRowToBookmarksIndex.key(bookmarkIndex, -1);
+}

--- a/src/qtgui/bookmarkstablemodel.h
+++ b/src/qtgui/bookmarkstablemodel.h
@@ -54,6 +54,7 @@ public:
 
     BookmarkInfo* getBookmarkAtRow(int row);
     int GetBookmarksIndexForRow(int iRow);
+    int GetRowForBookmarksIndex(int bookmarkIndex);
 
 private:
     QList<BookmarkInfo*> m_Bookmarks;

--- a/src/qtgui/dockbookmarks.cpp
+++ b/src/qtgui/dockbookmarks.cpp
@@ -58,16 +58,19 @@ DockBookmarks::DockBookmarks(QWidget *parent) :
 
     // Bookmarks Context menu
     contextmenu = new QMenu(this);
+
+    //MenuItem Update
+    {
+        actionUpdateBookmark = new QAction("Update bookmark", this);
+    }
     // MenuItem Delete
     {
-        QAction* action = new QAction("Delete Bookmark", this);
-        contextmenu->addAction(action);
-        connect(action, SIGNAL(triggered()), this, SLOT(DeleteSelectedBookmark()));
+        actionDeleteBookmark = new QAction("Delete bookmark", this);
+        connect(actionDeleteBookmark, SIGNAL(triggered()), this, SLOT(DeleteSelectedBookmark()));
     }
     // MenuItem Add
     {
-        actionAddBookmark = new QAction("Add Bookmark", this);
-        contextmenu->addAction(actionAddBookmark);
+        actionAddBookmark = new QAction("Add new bookmark", this);
     }
     ui->tableViewFrequencyList->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->tableViewFrequencyList, SIGNAL(customContextMenuRequested(const QPoint&)),
@@ -189,6 +192,17 @@ bool DockBookmarks::DeleteSelectedBookmark()
 
 void DockBookmarks::ShowContextMenu(const QPoint& pos)
 {
+    contextmenu->clear();
+    auto bookmark = ui->tableViewFrequencyList->indexAt(pos);
+    if (bookmark != QModelIndex())
+    {
+        auto bookmarkIndex = bookmarksTableModel->GetBookmarksIndexForRow(bookmark.row());
+        actionUpdateBookmark->setData(QVariant::fromValue(bookmarkIndex));
+        contextmenu->addAction(actionUpdateBookmark);
+        contextmenu->addAction(actionDeleteBookmark);
+        contextmenu->addSeparator();
+    }
+    contextmenu->addAction(actionAddBookmark);
     contextmenu->popup(ui->tableViewFrequencyList->viewport()->mapToGlobal(pos));
 }
 
@@ -228,6 +242,15 @@ void ComboBoxDelegateModulation::setModelData(QWidget *editor, QAbstractItemMode
 {
     QComboBox *comboBox = static_cast<QComboBox*>(editor);
     model->setData(index, comboBox->currentText(), Qt::EditRole);
+}
+
+void DockBookmarks::selectBookmark(int bookmarkIndex)
+{
+    auto row = bookmarksTableModel->GetRowForBookmarksIndex(bookmarkIndex);
+    if (row >= 0)
+    {
+        ui->tableViewFrequencyList->selectRow(row);;
+    }
 }
 
 void DockBookmarks::changeBookmarkTags(int row, int /*column*/)

--- a/src/qtgui/dockbookmarks.h
+++ b/src/qtgui/dockbookmarks.h
@@ -60,11 +60,14 @@ public:
 
     // ui->tableViewFrequencyList
     // ui->tableWidgetTagList
+    QAction* actionUpdateBookmark;
+    QAction* actionDeleteBookmark;
     QAction* actionAddBookmark;
 
     void updateTags();
     void updateBookmarks();
     void changeBookmarkTags(int row, int /*column*/);
+    void selectBookmark(int bookmarkIndex);
 
 signals:
     void newBookmarkActivated(qint64, QString, int);


### PR DESCRIPTION
This PR mainly adds a feature that an existing can be updated using contextual menu:
![image](https://github.com/gqrx-sdr/gqrx/assets/48731257/8610ca52-3218-423c-a45b-66c50e5ad8c8)

When updating, frequency + bandwidth + modulation are updated.
Bookmarks are re-sorted and selected bookmark is kept selected at its new location.

Also this PR changes that "Delete bookmark" (and "Update bookmark" as well) is only shown if contextual menu is called when hovering a bookmark. It's not more displayed when right-clicking on an empty area of the QTableView. Only "Add new bookmark" is available in this case.