### PR TITLE
Allow the Qt version to be chosen explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,10 +122,20 @@ else()
 endif()
 
 # 3rd Party Dependency Stuff
-find_package(Qt6 QUIET COMPONENTS Core Network Widgets Svg SvgWidgets)
-if(NOT Qt6_FOUND)
+option(FORCE_QT6 "Force Qt6 to be used" OFF)
+option(FORCE_QT5 "Force Qt5 to be used" OFF)
+
+if(FORCE_QT6)
+    find_package(Qt6 QUIET COMPONENTS Core Network Widgets Svg SvgWidgets)
+elseif(FORCE_QT5)
     find_package(Qt5 REQUIRED COMPONENTS Core Network Widgets Svg)
+else()
+    find_package(Qt6 QUIET COMPONENTS Core Network Widgets Svg SvgWidgets)
+    if(NOT Qt6_FOUND)
+        find_package(Qt5 REQUIRED COMPONENTS Core Network Widgets Svg)
+    endif()
 endif()
+
 include(FindPkgConfig)
 find_package(Gnuradio-osmosdr REQUIRED)
 

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.17.2: In progress...
+
+       NEW: FORCE_QT6 and FORCE_QT5 CMake options to force Qt version.
+
+
     2.17.1: Released October 9, 2023
 
        NEW: Delete key clears the waterfall.


### PR DESCRIPTION
Gentoo has requested that it be possible to choose Qt6 or Qt5 explicitly. Here I've added cmake options (`-DFORCE_QT6=ON`, `-DFORCE_QT5=ON`) to do this. If neither is specified, then the newest available version of Qt will be selected.

/cc @ZeroChaos-