### PR TITLE
bookmarks: restore Delete key

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.17.3: In progress...
+
+     FIXED: Delete key shortcut for bookmark removal.
+
+
     2.17.2: Released October 9, 2023
 
        NEW: FORCE_QT6 and FORCE_QT5 CMake options to force Qt version.

--- a/src/qtgui/dockbookmarks.cpp
+++ b/src/qtgui/dockbookmarks.cpp
@@ -158,12 +158,20 @@ void DockBookmarks::on_tableWidgetTagList_itemChanged(QTableWidgetItem *item)
 
 bool DockBookmarks::eventFilter(QObject* object, QEvent* event)
 {
-    if (event->type() == QEvent::KeyPress)
+    // Since Key_Delete can be (is) used as a global shortcut, override the
+    // shortcut. Accepting a ShortcutOverride causes the event to be delivered
+    // again, but as a KeyPress.
+    if (event->type() == QEvent::KeyPress || event->type() == QEvent::ShortcutOverride)
     {
         QKeyEvent* pKeyEvent = static_cast<QKeyEvent *>(event);
-        if (pKeyEvent->key() == Qt::Key_Delete && ui->tableViewFrequencyList->hasFocus())
+        if (pKeyEvent->key() == Qt::Key_Delete)
         {
-            return DeleteSelectedBookmark();
+            if (event->type() == QEvent::ShortcutOverride) {
+                event->accept();
+            }
+            else {
+                return DeleteSelectedBookmark();
+            }
         }
     }
     return QWidget::eventFilter(object, event);


### PR DESCRIPTION
Delete is used as a global shortcut to clear the waterfall. It is also used to delete a bookmark when the bookmarks table has focus. Allow the bookmarks table to override the global Delete shortcut.

Delete is used by other widgets, e.g., text fields, and is handled there in a similar way by the Qt library.

Note - the bookmarks table holds focus until something else acquires it, so a second Delete will offer to delete the next bookmark. There is a confirmation step.

Fixes issue mentioned in #1298 