### PR TITLE
Improve automatic bookmark selection

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -909,7 +909,7 @@ void MainWindow::setNewFrequency(qint64 rx_freq)
     ui->plotter->setCenterFreq(center_freq);
     uiDockRxOpt->setHwFreq(d_hw_freq);
     ui->freqCtrl->setFrequency(rx_freq);
-    uiDockBookmarks->setNewFrequency(rx_freq);
+    uiDockBookmarks->newFrequencyOrModSet(rx_freq, uiDockRxOpt->currentDemod());
 }
 
 // Update delta and center (of marker span) when markers are updated
@@ -1311,6 +1311,7 @@ void MainWindow::selectDemod(int mode_idx)
     d_have_audio = (mode_idx != DockRxOpt::MODE_OFF);
 
     uiDockRxOpt->setCurrentDemod(mode_idx);
+    uiDockBookmarks->newFrequencyOrModSet(ui->freqCtrl->getFrequency(), mode_idx);
 }
 
 

--- a/src/qtgui/dockbookmarks.h
+++ b/src/qtgui/dockbookmarks.h
@@ -70,7 +70,7 @@ signals:
     void newBookmarkActivated(qint64, QString, int);
 
 public slots:
-    void setNewFrequency(qint64 rx_freq);
+    void newFrequencyOrModSet(qint64 rx_freq, int modulation = 0);
 
 private slots:
     void activated(const QModelIndex & index );


### PR DESCRIPTION
 Currently only frequency is used for comparison, and mechanism selects the first
 bookmark whose bandwidth includes selected frequency.

 The new mechanism takes into account the chosen modulation by auto-selecting
 matching bookmark with higher priority, and will then select bookmark whose
 central frequency is the closest from currently selected frequency.