### PR TITLE
Reply to \get_powerstat to fix wsjtx

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.17.4: In progress...
+
+  IMPROVED: Respond to \dump_state remote command (needed by some clients).
+
+
     2.17.3: Released October 20, 2023
 
      FIXED: Delete key shortcut for bookmark removal.

--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -52,6 +52,8 @@ Supported commands:
     display. Otherwise print the current LNB LO frequency [Hz].
  \dump_state
     Dump state (only usable for hamlib compatibility)
+ \get_powerstat
+    Get power status (only usable for hamlib compatibility)
  v
     Get 'VFO' (only usable for hamlib compatibility)
  V

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -247,6 +247,8 @@ void RemoteControl::startRead()
         answer = cmd_lnb_lo(cmdlist);
     else if (cmd == "\\dump_state")
         answer = cmd_dump_state();
+    else if (cmd == "\\get_powerstat")
+        answer = QString("1\n");
     else if (cmd == "q" || cmd == "Q")
     {
         // FIXME: for now we assume 'close' command


### PR DESCRIPTION
Fixes #1277.

Maybe better to add alias to DSP ON/OFF, but this will fix wsjtx at least.