### PR TITLE
Warn on audio device failure rather than abort.

### DIFF
--- a/src/applications/gqrx/main.cpp
+++ b/src/applications/gqrx/main.cpp
@@ -98,41 +98,6 @@ int main(int argc, char *argv[])
         return 0;
     }
 
-    // check whether audio backend is functional
-#ifdef WITH_PORTAUDIO
-    PaError     err = Pa_Initialize();
-    if (err != paNoError)
-    {
-        QString message = QString("Portaudio error: %1").arg(Pa_GetErrorText(err));
-        qCritical() << message;
-        QMessageBox::critical(nullptr, "Audio Error", message,
-                              QMessageBox::Abort, QMessageBox::NoButton);
-        return 1;
-    }
-#endif
-
-#ifdef WITH_PULSEAUDIO
-    int         error = 0;
-    pa_simple  *test_sink;
-    pa_sample_spec ss;
-
-    ss.format = PA_SAMPLE_FLOAT32LE;
-    ss.rate = 48000;
-    ss.channels = 2;
-    test_sink =  pa_simple_new(NULL, "Gqrx Test", PA_STREAM_PLAYBACK, NULL,
-                               "Test stream", &ss, NULL, NULL, &error);
-    if (!test_sink)
-    {
-        QString message = QString("Pulseaudio error: %1").arg(pa_strerror(error));
-        qCritical() << message;
-        QMessageBox::critical(0, "Audio Error", message,
-                              QMessageBox::Abort, QMessageBox::NoButton);
-        return 1;
-    }
-    pa_simple_free(test_sink);
-#endif
-
-
     if (parser.isSet("conf"))
     {
         cfg_file = parser.value("conf");

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -553,7 +553,8 @@ bool MainWindow::loadConfig(const QString& cfgfile, bool check_crash,
         }
 
         // Update window title
-        setWindowTitle(QString("Gqrx %1 - %2").arg(VERSION).arg(indev));
+        const char* audio_status = rx->has_audio_device() ? "" : " - NO AUDIO";
+        setWindowTitle(QString("Gqrx %1 - %2%3").arg(VERSION).arg(indev).arg(audio_status));
 
         // Add available antenna connectors to the UI
         std::vector<std::string> antennas = rx->get_antennas();

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -206,6 +206,8 @@ public:
     status      start_udp_streaming(const std::string host, int port, bool stereo);
     status      stop_udp_streaming();
 
+    bool        has_audio_device(void) { return d_has_audio_device; }
+
     /* I/Q recording and playback */
     status      start_iq_recording(const std::string filename);
     status      stop_iq_recording();
@@ -285,13 +287,8 @@ private:
     sniffer_f_sptr    sniffer;    /*!< Sample sniffer for data decoders. */
     resampler_ff_sptr sniffer_rr; /*!< Sniffer resampler. */
 
-#ifdef WITH_PULSEAUDIO
-    pa_sink_sptr              audio_snk;  /*!< Pulse audio sink. */
-#elif WITH_PORTAUDIO
-    portaudio_sink_sptr       audio_snk;  /*!< portaudio sink */
-#else
-    gr::audio::sink::sptr     audio_snk;  /*!< gr audio sink */
-#endif
+    bool                       d_has_audio_device;
+    gr::basic_block_sptr       audio_snk;  /*!< Audio sink (pulse, portaudio, gr-audio). */
 
     //! Get a path to a file containing random bytes
     static std::string get_zero_file(void);

--- a/src/pulseaudio/pa_sink.cc
+++ b/src/pulseaudio/pa_sink.cc
@@ -69,8 +69,7 @@ pa_sink::pa_sink(const string device_name, int audio_rate,
                              &error);
 
     if (!d_pasink) {
-        /** FIXME: Throw an exception **/
-        fprintf(stderr, __FILE__": pa_simple_new() failed: %s\n", pa_strerror(error));
+        throw std::runtime_error("Unable to open pulseaudio device.");
     }
 
 }


### PR DESCRIPTION
In some cases, being able to hear the signal is not important, and a system has no usable audio device. This patch removes the error dialog and exit when no device is found. Instead, "NO AUDIO" is added to the title. Note that the PortAudio case may still need some work. Only PulseAudio has been tested.

This is an old patch I had lying around, and I haven't tried it recently on a device without audio. But is still applies cleanly and compiles :-)

Fixes #1356