### PR TITLE
Add remote API for RDS STATION and RADIOTEXT

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -344,12 +344,15 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(remote, SIGNAL(gainChanged(QString, double)), uiDockInputCtl, SLOT(setGain(QString,double)));
     connect(remote, SIGNAL(dspChanged(bool)), this, SLOT(on_actionDSP_triggered(bool)));
     connect(uiDockRDS, SIGNAL(rdsPI(QString)), remote, SLOT(rdsPI(QString)));
+    connect(uiDockRDS, SIGNAL(stationChanged(QString)), remote, SLOT(setRdsStation(QString)));
+    connect(uiDockRDS, SIGNAL(radiotextChanged(QString)), remote, SLOT(setRdsRadiotext(QString)));
 
     rds_timer = new QTimer(this);
     connect(rds_timer, SIGNAL(timeout()), this, SLOT(rdsTimeout()));
 
     // enable frequency tooltips on FFT plot
     ui->plotter->setTooltipsEnabled(true);
+
 
     // Create list of input devices. This must be done before the configuration is
     // restored because device probing might change the device configuration

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -419,18 +419,20 @@ void RemoteControl::setRDSstatus(bool enabled)
 {
     rds_status = enabled;
     rc_program_id = "0000";
+    rds_station = "RDS OFF";
+    rds_radiotext = "RDS OFF";
 }
 
 /*! \brief Set RDS Station name. */
 void RemoteControl::setRdsStation(QString name)
 {
-    rds_station = name;
+    rds_station = name.trimmed();
 }
 
 /*! \brief Set RDS Radiotext. */
 void RemoteControl::setRdsRadiotext(QString text)
 {
-    rds_radiotext = text;
+    rds_radiotext = text.trimmed();
 }
 
 

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -50,6 +50,8 @@ RemoteControl::RemoteControl(QObject *parent) :
     audio_recorder_status = false;
     receiver_running = false;
     hamlib_compatible = false;
+    rds_station = QString("");
+    rds_radiotext = QString("");
 
     rc_port = DEFAULT_RC_PORT;
     rc_allowed_hosts.append(DEFAULT_RC_ALLOWED_HOSTS);
@@ -418,6 +420,19 @@ void RemoteControl::setRDSstatus(bool enabled)
     rds_status = enabled;
     rc_program_id = "0000";
 }
+
+/*! \brief Set RDS Station name. */
+void RemoteControl::setRdsStation(QString name)
+{
+    rds_station = name;
+}
+
+/*! \brief Set RDS Radiotext. */
+void RemoteControl::setRdsRadiotext(QString text)
+{
+    rds_radiotext = text;
+}
+
 
 /*! \brief Convert mode string to enum (DockRxOpt::rxopt_mode_idx)
  *  \param mode The Hamlib rigctld compatible mode string
@@ -811,9 +826,13 @@ QString RemoteControl::cmd_get_param(QStringList cmdlist)
     QString func = cmdlist.value(1, "");
 
     if (func == "?")
-        answer = QString("RDS_PI\n");
+        answer = QString("RDS_PI RDS_STATION RDS_RADIOTEXT\n");
     else if (func.compare("RDS_PI", Qt::CaseInsensitive) == 0)
         answer = QString("%1\n").arg(rc_program_id);
+	else if (func.compare("RDS_STATION", Qt::CaseInsensitive) == 0)
+		answer = QString("%1\n").arg(rds_station);
+	else if (func.compare("RDS_RADIOTEXT", Qt::CaseInsensitive) == 0)
+		answer = QString("%1\n").arg(rds_radiotext);
     else
         answer = QString("RPRT 1\n");
 
@@ -857,7 +876,7 @@ QString RemoteControl::cmd_set_split_vfo()
 /* Get info */
 QString RemoteControl::cmd_get_info() const
 {
-    return QString("Gqrx %1\n").arg(VERSION);
+    return QString("Gqrx %1 rdsapi\n").arg(VERSION);
 };
 
 /* Gpredict / Gqrx specific command: AOS - satellite AOS event */
@@ -901,7 +920,6 @@ QString RemoteControl::cmd_lnb_lo(QStringList cmdlist)
         return QString("%1\n").arg((qint64)(rc_lnb_lo_mhz * 1e6));
     }
 }
-
 /*
  * '\dump_state' used by hamlib clients, e.g. xdx, fldigi, rigctl and etc
  * More info:

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -423,7 +423,7 @@ void RemoteControl::setRDSstatus(bool enabled)
     rds_radiotext = "RDS OFF";
 }
 
-/*! \brief Set RDS Station name. */
+/*! \brief Set RDS program service (station) name. */
 void RemoteControl::setRdsStation(QString name)
 {
     rds_station = name.trimmed();
@@ -828,10 +828,10 @@ QString RemoteControl::cmd_get_param(QStringList cmdlist)
     QString func = cmdlist.value(1, "");
 
     if (func == "?")
-        answer = QString("RDS_PI RDS_STATION RDS_RADIOTEXT\n");
+        answer = QString("RDS_PI RDS_PS_NAME RDS_RADIOTEXT\n");
     else if (func.compare("RDS_PI", Qt::CaseInsensitive) == 0)
         answer = QString("%1\n").arg(rc_program_id);
-	else if (func.compare("RDS_STATION", Qt::CaseInsensitive) == 0)
+	else if (func.compare("RDS_PS_NAME", Qt::CaseInsensitive) == 0)
 		answer = QString("%1\n").arg(rds_station);
 	else if (func.compare("RDS_RADIOTEXT", Qt::CaseInsensitive) == 0)
 		answer = QString("%1\n").arg(rds_radiotext);

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -143,7 +143,7 @@ private:
     bool        receiver_running;  /*!< Whether the receiver is running or not */
     bool        hamlib_compatible;
     gain_list_t gains;             /*!< Possible and current gain settings */
-    QString     rds_station;       /*!< RDS Station Name */
+    QString     rds_station;       /*!< RDS program service (station) name */
     QString     rds_radiotext;     /*!< RDS Radiotext */
 
     void        setNewRemoteFreq(qint64 freq);

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -98,6 +98,8 @@ public slots:
     bool setGain(QString name, double gain);
     void setRDSstatus(bool enabled);
     void rdsPI(QString program_id);
+    void setRdsStation(QString name);
+    void setRdsRadiotext(QString text);
 
 signals:
     void newFrequency(qint64 freq);
@@ -112,6 +114,7 @@ signals:
     void gainChanged(QString name, double value);
     void dspChanged(bool value);
     void newRDSmode(bool value);
+    void rdsStateChanged(bool state);
 
 private slots:
     void acceptConnection();
@@ -141,6 +144,8 @@ private:
     bool        receiver_running;  /*!< Whether the receiver is running or not */
     bool        hamlib_compatible;
     gain_list_t gains;             /*!< Possible and current gain settings */
+    QString     rds_station;       /*!< RDS Station Name */
+    QString     rds_radiotext;     /*!< RDS Radiotext */
 
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);
@@ -164,6 +169,9 @@ private:
     QString     cmd_AOS();
     QString     cmd_LOS();
     QString     cmd_lnb_lo(QStringList cmdlist);
+    QString     cmd_set_rds(QStringList cmdlist);
+    QString     cmd_rds_station();
+    QString     cmd_rds_radiotext();
     QString     cmd_dump_state() const;
 };
 

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -114,7 +114,6 @@ signals:
     void gainChanged(QString name, double value);
     void dspChanged(bool value);
     void newRDSmode(bool value);
-    void rdsStateChanged(bool state);
 
 private slots:
     void acceptConnection();
@@ -169,7 +168,6 @@ private:
     QString     cmd_AOS();
     QString     cmd_LOS();
     QString     cmd_lnb_lo(QStringList cmdlist);
-    QString     cmd_set_rds(QStringList cmdlist);
     QString     cmd_rds_station();
     QString     cmd_rds_radiotext();
     QString     cmd_dump_state() const;

--- a/src/qtgui/dockrds.cpp
+++ b/src/qtgui/dockrds.cpp
@@ -103,6 +103,10 @@ void DockRDS::ClearTextFields()
     ui->radiotext->setText("");
     ui->clocktime->setText("");
     ui->alt_freq->setText("");
+    
+    emit radiotextChanged("");
+    emit stationChanged("");
+    emit rdsPI("");
 }
 
 void DockRDS::showEnabled()

--- a/src/qtgui/dockrds.cpp
+++ b/src/qtgui/dockrds.cpp
@@ -58,6 +58,7 @@ void DockRDS::updateRDS(QString text, int type)
         ui->program_information->setText(text);
         break;
     case 1:
+        emit stationChanged(text);
         ui->station_name->setText(text);
         break;
     case 2:
@@ -78,6 +79,7 @@ void DockRDS::updateRDS(QString text, int type)
         ui->flags->setText(QString::fromStdString(out));
         break;
     case 4:
+        emit radiotextChanged(text);
         ui->radiotext->setText(text);
         break;
     case 5:

--- a/src/qtgui/dockrds.h
+++ b/src/qtgui/dockrds.h
@@ -30,6 +30,8 @@ private:
 signals:
     void rdsDecoderToggled(bool);
     void rdsPI(QString text);
+    void stationChanged(QString);
+    void radiotextChanged(QString);
 
 private slots:
     void on_rdsCheckbox_toggled(bool checked);


### PR DESCRIPTION
> Note: This code is based on changes by our club members HA7CSK and HA5DNC done in 2020. I recently found them in the files, updated to the latest version and reworked the API a bit.

This PR adds 2 new queries to the "get parameter" command `p`:
- ~~`RDS_STATION`~~ `RDS_PS_NAME` reports program service name (usually station text)
- `RDS_RADIOTEXT` reports the radio text (usually name of the played song)

Example:
```
F 105300000
U RDS 1
p RDS_PI
p RDS_PS_NAME
p RDS_RADIOTEXT
```

