### PR TITLE
Add muting to remote control

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -344,6 +344,8 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(remote, SIGNAL(gainChanged(QString, double)), uiDockInputCtl, SLOT(setGain(QString,double)));
     connect(remote, SIGNAL(dspChanged(bool)), this, SLOT(on_actionDSP_triggered(bool)));
     connect(uiDockRDS, SIGNAL(rdsPI(QString)), remote, SLOT(rdsPI(QString)));
+    connect(remote, SIGNAL(newAudioMuted(bool)), uiDockAudio, SLOT(setAudioMuted(bool)));
+    connect(uiDockAudio, SIGNAL(audioMuted(bool)), remote, SLOT(setAudioMuted(bool)));
 
     rds_timer = new QTimer(this);
     connect(rds_timer, SIGNAL(timeout()), this, SLOT(rdsTimeout()));

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -364,6 +364,12 @@ void RemoteControl::setAudioGain(float gain)
     audio_gain = gain;
 }
 
+/*! \brief Set audio muted (from mainwindow). */
+void RemoteControl::setAudioMuted(bool muted)
+{
+    is_audio_muted = muted;
+}
+
 /*! \brief Start audio recorder (from mainwindow). */
 void RemoteControl::startAudioRecorder(QString unused)
 {
@@ -633,7 +639,7 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
         QStringList names;
         for(auto &g : gains)
             names.push_back(QString("%1_GAIN").arg(QString::fromStdString(g.name)));
-        answer = QString("SQL STRENGTH AF %1\n").arg(names.join(" "));
+        answer = QString("SQL STRENGTH AF MUTE %1\n").arg(names.join(" "));
     }
     else if (lvl.compare("STRENGTH", Qt::CaseInsensitive) == 0 || lvl.isEmpty())
     {
@@ -646,6 +652,10 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
     else if (lvl.compare("AF", Qt::CaseInsensitive) == 0)
     {
         answer = QString("%1\n").arg((double)audio_gain, 0, 'f', 1);
+    }
+    else if (lvl.compare("MUTE", Qt::CaseInsensitive) == 0)
+    {
+        answer = QString("%1\n").arg(is_audio_muted ? '1' : '0');
     }
     else if (lvl.endsWith("_GAIN"))
     {
@@ -679,7 +689,7 @@ QString RemoteControl::cmd_set_level(QStringList cmdlist)
         QStringList names;
         for(auto &g : gains)
             names.push_back(QString("%1_GAIN").arg(QString::fromStdString(g.name)));
-        answer = QString("SQL AF %1\n").arg(names.join(" "));
+        answer = QString("SQL MUTE AF %1\n").arg(names.join(" "));
     }
     else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
     {
@@ -705,6 +715,20 @@ QString RemoteControl::cmd_set_level(QStringList cmdlist)
             answer = QString("RPRT 0\n");
             new_audio_gain = std::max<float>(-80.0f, std::min<float>(50.0f, new_audio_gain));
             emit newAudioGain(new_audio_gain);
+        }
+        else
+        {
+            answer = QString("RPRT 1\n");
+        }
+    }
+	else if (lvl.compare("MUTE", Qt::CaseInsensitive) == 0)
+    {
+        bool ok;
+        short muted = cmdlist.value(2, "ERR").toShort(&ok);
+        if (ok)
+        {
+            answer = QString("RPRT 0\n");
+            emit newAudioMuted(muted != 0);
         }
         else
         {

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -50,6 +50,7 @@ RemoteControl::RemoteControl(QObject *parent) :
     audio_recorder_status = false;
     receiver_running = false;
     hamlib_compatible = false;
+    is_audio_muted = false;
 
     rc_port = DEFAULT_RC_PORT;
     rc_allowed_hosts.append(DEFAULT_RC_ALLOWED_HOSTS);
@@ -639,7 +640,7 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
         QStringList names;
         for(auto &g : gains)
             names.push_back(QString("%1_GAIN").arg(QString::fromStdString(g.name)));
-        answer = QString("SQL STRENGTH AF MUTE %1\n").arg(names.join(" "));
+        answer = QString("SQL STRENGTH AF %1\n").arg(names.join(" "));
     }
     else if (lvl.compare("STRENGTH", Qt::CaseInsensitive) == 0 || lvl.isEmpty())
     {
@@ -652,10 +653,6 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
     else if (lvl.compare("AF", Qt::CaseInsensitive) == 0)
     {
         answer = QString("%1\n").arg((double)audio_gain, 0, 'f', 1);
-    }
-    else if (lvl.compare("MUTE", Qt::CaseInsensitive) == 0)
-    {
-        answer = QString("%1\n").arg(is_audio_muted ? '1' : '0');
     }
     else if (lvl.endsWith("_GAIN"))
     {
@@ -689,7 +686,7 @@ QString RemoteControl::cmd_set_level(QStringList cmdlist)
         QStringList names;
         for(auto &g : gains)
             names.push_back(QString("%1_GAIN").arg(QString::fromStdString(g.name)));
-        answer = QString("SQL MUTE AF %1\n").arg(names.join(" "));
+        answer = QString("SQL AF %1\n").arg(names.join(" "));
     }
     else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
     {
@@ -715,20 +712,6 @@ QString RemoteControl::cmd_set_level(QStringList cmdlist)
             answer = QString("RPRT 0\n");
             new_audio_gain = std::max<float>(-80.0f, std::min<float>(50.0f, new_audio_gain));
             emit newAudioGain(new_audio_gain);
-        }
-        else
-        {
-            answer = QString("RPRT 1\n");
-        }
-    }
-	else if (lvl.compare("MUTE", Qt::CaseInsensitive) == 0)
-    {
-        bool ok;
-        short muted = cmdlist.value(2, "ERR").toShort(&ok);
-        if (ok)
-        {
-            answer = QString("RPRT 0\n");
-            emit newAudioMuted(muted != 0);
         }
         else
         {
@@ -761,13 +744,15 @@ QString RemoteControl::cmd_get_func(QStringList cmdlist)
     QString func = cmdlist.value(1, "");
 
     if (func == "?")
-        answer = QString("RECORD DSP RDS\n");
+        answer = QString("RECORD DSP RDS MUTE\n");
     else if (func.compare("RECORD", Qt::CaseInsensitive) == 0)
         answer = QString("%1\n").arg(audio_recorder_status);
     else if (func.compare("DSP", Qt::CaseInsensitive) == 0)
         answer = QString("%1\n").arg(receiver_running);
     else if (func.compare("RDS", Qt::CaseInsensitive) == 0)
         answer = QString("%1\n").arg(rds_status);
+	else if (func.compare("MUTE", Qt::CaseInsensitive) == 0)
+        answer = QString("%1\n").arg(is_audio_muted ? '1' : '0');
     else
         answer = QString("RPRT 1\n");
 
@@ -784,7 +769,7 @@ QString RemoteControl::cmd_set_func(QStringList cmdlist)
 
     if (func == "?")
     {
-        answer = QString("RECORD DSP RDS\n");
+        answer = QString("RECORD DSP RDS MUTE\n");
     }
     else if ((func.compare("RECORD", Qt::CaseInsensitive) == 0) && ok)
     {
@@ -810,6 +795,15 @@ QString RemoteControl::cmd_set_func(QStringList cmdlist)
             emit dspChanged(false);
 
         answer = QString("RPRT 0\n");
+    }
+	else if (func.compare("MUTE", Qt::CaseInsensitive) == 0)
+    {
+		if (status)
+			emit newAudioMuted(true);
+		else
+			emit newAudioMuted(false);
+
+		answer = QString("RPRT 0\n");
     }
     else if ((func.compare("RDS", Qt::CaseInsensitive) == 0) && ok)
     {

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -93,6 +93,7 @@ public slots:
     void setPassband(int passband_lo, int passband_hi);
     void setSquelchLevel(double level);
     void setAudioGain(float gain);
+	void setAudioMuted(bool muted);
     void startAudioRecorder(QString unused);
     void stopAudioRecorder();
     bool setGain(QString name, double gain);
@@ -112,6 +113,7 @@ signals:
     void gainChanged(QString name, double value);
     void dspChanged(bool value);
     void newRDSmode(bool value);
+    void newAudioMuted(bool muted);
 
 private slots:
     void acceptConnection();
@@ -141,6 +143,7 @@ private:
     bool        receiver_running;  /*!< Whether the receiver is running or not */
     bool        hamlib_compatible;
     gain_list_t gains;             /*!< Possible and current gain settings */
+	bool 		is_audio_muted;
 
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -121,6 +121,15 @@ void DockAudio::setAudioGainDb(float gain)
     ui->audioGainSlider->setValue(int(std::round(gain*10.0f)));
 }
 
+/*! \brief Set audio muted
+ *  \param muted true if audio should be muted
+ */
+void DockAudio::setAudioMuted(bool muted)
+{
+    ui->audioMuteButton->setChecked(!muted);
+    ui->audioMuteButton->click();
+}
+
 
 /*! \brief Get current audio gain.
  *  \returns The current audio gain in tens of dB (0 dB = 10).
@@ -288,6 +297,7 @@ void DockAudio::on_audioMuteButton_clicked(bool checked)
         float gain = float(value) / 10.0f;
         emit audioGainChanged(gain);
     }
+	emit audioMuted(checked);
 }
 
 /*! \brief Set status of audio record button. */

--- a/src/qtgui/dockaudio.h
+++ b/src/qtgui/dockaudio.h
@@ -73,6 +73,7 @@ public slots:
     void setRxFrequency(qint64 freq);
     void setWfColormap(const QString &cmap);
     void setAudioGainDb(float gain);
+    void setAudioMuted(bool muted);
 
 signals:
     /*! \brief Signal emitted when audio gain has changed. Gain is in dB. */
@@ -98,6 +99,9 @@ signals:
 
     /*! \brief FFT rate changed. */
     void fftRateChanged(int fps);
+    
+	/*! \brief Audio mute chenged. */
+    void audioMuted(bool muted);
 
 private slots:
     void on_audioGainSlider_valueChanged(int value);


### PR DESCRIPTION
Adds "MUTE" to both L and l commands. Setting it to any value other than 0 mutes the audio, querying it results in 1 if audio is muted, else 0.