### PR TITLE
Preserve waterfall during zooms and pans

### DIFF
--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -213,6 +213,15 @@ private:
         MARKER_B
     };
 
+    qint64 getMinFrequency() const {
+        return m_CenterFreq + m_FftCenter - m_Span / 2;
+    }
+
+    qint64 getMaxFrequency() const {
+        return m_CenterFreq + m_FftCenter + m_Span / 2;
+    }
+
+    void        moveWaterfall(qint64 old_min_freq, qint64 old_max_freq);
     void        drawOverlay();
     void        makeFrequencyStrs();
     int         xFromFreq(qint64 freq);


### PR DESCRIPTION
- I wanted to have some level of preservation when panning and zooming in the waterfall, so when I'm looking around I can see some rudimentary history of the waterfall. Currently, the waterfall data is not always aligned with the current frequency scale. I guess there is technically a bug with the hover tooltip reporting the incorrect frequency (but correct times) on the waterfall, which this PR fixes.
- I did some research to see if there was an easy or efficient way to do this, but found that the cheapest way would be to have a partial persistence. I considered storing each waterfall line as a timeseries, but it did not seem cpu or memory efficient. Also it did not work well with all of the existing features.
- The compromise I came up with here was to do "destructive" operations on the waterfall QImage. If the frequency or center frequency changes the waterfall is cropped and moved (using QImage::copy) to make sure the waterfall still lines up with the new frequency range.
- Something similar happens with zooming in and out (using QImage::scaled), and in both cases the waterfall data is always aligned with the current frequency range.
- NOTE: the zoom in is not smoothed to keep discrete bins identifiable, but the zoom out operation is smoothed to make the small version more representative of the actually source buckets.
- I added a moveWaterfall method and attached to plotter movements.
- Also `new_span_int` was calculated but never used. I use it now to ensure getMinFrequency and getMaxFrequency do arithmetic correctly.

See it in action:

https://github.com/user-attachments/assets/1fe284b8-9388-4e6a-8d99-ffe2791423ea

