### PR TITLE
Plotter and waterfall performance enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ The following people and organisations have contributed to gqrx:
 * Grigory Shipunov
 * Gwenhael Goavec-Merou
 * Herman Semenov
+* James Yuzawa
 * Jaroslav Škarvada
 * Jeff Long
 * Jiawei Chen

--- a/src/applications/gqrx/mainwindow.ui
+++ b/src/applications/gqrx/mainwindow.ui
@@ -21,7 +21,7 @@
    <set>QMainWindow::AllowNestedDocks|QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks</set>
   </property>
   <property name="unifiedTitleAndToolBarOnMac">
-   <bool>true</bool>
+   <bool>false</bool>
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/applications/gqrx/mainwindow.ui
+++ b/src/applications/gqrx/mainwindow.ui
@@ -349,9 +349,6 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <property name="autoFillBackground">
-       <bool>true</bool>
-      </property>
       <property name="frameShape">
        <enum>QFrame::StyledPanel</enum>
       </property>

--- a/src/qtgui/meter.cpp
+++ b/src/qtgui/meter.cpp
@@ -72,9 +72,14 @@ QSize CMeter::sizeHint() const
 
 void CMeter::setLevel(float dbfs)
 {
+    const float old = m_dBFS;
     float alpha = dbfs < m_dBFS ? ALPHA_DECAY : ALPHA_RISE;
     m_dBFS -= alpha * (m_dBFS - dbfs);
-    update();
+    // only redraw when the label needs to change
+    if (qRound(m_dBFS * 10) != qRound(old * 10))
+    {
+        update();
+    }
 }
 
 void CMeter::setSqlLevel(float dbfs)

--- a/src/qtgui/meter.cpp
+++ b/src/qtgui/meter.cpp
@@ -53,6 +53,7 @@ CMeter::CMeter(QWidget *parent) : QFrame(parent)
 
     m_dBFS = MIN_DB;
     m_Sql = -150.0;
+    m_font = QFont("Arial");
 }
 
 CMeter::~CMeter()
@@ -116,9 +117,8 @@ void CMeter::draw(QPainter &painter)
         painter.drawLine(QLineF(x, hline, x, hline + 8));
     }
 
-    QFont font("Arial");
-    font.setPixelSize(height() / 4);
-    painter.setFont(font);
+    m_font.setPixelSize(height() / 4);
+    painter.setFont(m_font);
 
     painter.setPen(QColor(0xDA, 0xDA, 0xDA, 0xFF));
     painter.drawText(marg, height() - 2, QString::number((double)m_dBFS, 'f', 1) + " dBFS" );
@@ -148,9 +148,8 @@ void CMeter::drawOverlay(QPainter &painter)
     }
 
     // draw scale text
-    QFont font("Arial");
-    font.setPixelSize(height() / 4);
-    painter.setFont(font);
+    m_font.setPixelSize(height() / 4);
+    painter.setFont(m_font);
     qreal rwidth = (hstop - marg) / 5.0;
     QRectF rect(marg - rwidth / 2, 0, rwidth, majstart);
 

--- a/src/qtgui/meter.h
+++ b/src/qtgui/meter.h
@@ -58,4 +58,5 @@ private:
 
     float   m_dBFS;
     float   m_Sql;
+    QFont   m_font;
 };

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1582,11 +1582,11 @@ void CPlotter::draw(bool newData)
             // Fill area between markers, even if they are off screen
             qreal yFill = m_PlotMode == PLOT_MODE_MAX ? yMaxD : yAvgD;
             if (fillMarkers && (ix) > minMarker && (ix) < maxMarker) {
-                abPolygon << QPointF(ixPlot, yFill + 1.0);
+                abPolygon << QPointF(ixPlot, yFill);
             }
             if (m_FftFill && m_PlotMode != PLOT_MODE_HISTOGRAM)
             {
-                underPolygon << QPointF(ixPlot, yFill + 1.0);
+                underPolygon << QPointF(ixPlot, yFill);
             }
             if (m_PlotMode == PLOT_MODE_FILLED)
             {

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1500,11 +1500,10 @@ void CPlotter::draw(bool newData)
 
 
         // draw the pandapter
-        QBrush fillBrush = QBrush(blend(bgColor, m_FftFillCol, 26));
+        QBrush fillBrush = QBrush(m_FftFillCol);
 
         // Fill between max and avg
-        QColor maxFillCol = blend(bgColor, m_FftFillCol, 80);
-        QBrush maxFillBrush = QBrush(maxFillCol);
+        QBrush maxFillBrush = QBrush(m_FilledModeFillCol);
 
         // Diagonal fill for area between markers. Scale the pattern to DPR.
         QColor abFillColor = QColor::fromRgba(PLOTTER_MARKER_COLOR);
@@ -1513,9 +1512,9 @@ void CPlotter::draw(bool newData)
 
         QColor maxLineColor;
         if (m_PlotMode == PLOT_MODE_FILLED)
-            maxLineColor = blend(bgColor, m_FftFillCol, 128);
+            maxLineColor = m_FilledModeMaxLineCol;
         else
-            maxLineColor = blend(bgColor, m_FftFillCol, 255);
+            maxLineColor = m_MainLineCol;
 
         QPen maxLinePen = QPen(maxLineColor);
 
@@ -1523,12 +1522,10 @@ void CPlotter::draw(bool newData)
         QPen avgLinePen;
         if (m_PlotMode == PLOT_MODE_AVG || m_PlotMode == PLOT_MODE_HISTOGRAM)
         {
-            QColor avgLineCol = blend(bgColor, m_FftFillCol, 255);
-            avgLinePen = QPen(avgLineCol);
+            avgLinePen = QPen(m_MainLineCol);
         }
         else {
-            QColor avgLineCol = blend(bgColor, QColor(Qt::cyan), 192);
-            avgLinePen = QPen(avgLineCol);
+            avgLinePen = QPen(m_FilledModeAvgLineCol);
         }
 
         // The m_Marker{AB}X values are one cycle old, which makes for a laggy
@@ -1630,7 +1627,7 @@ void CPlotter::draw(bool newData)
                 holdLineBuf[i] = QPointF(ixPlot, yMaxHoldD);
             }
             // NOT scaling to DPR due to performance
-            painter2.setPen(m_MaxHoldColor);
+            painter2.setPen(m_HoldLineCol);
             painter2.drawPolyline(holdLineBuf, npts);
 
             m_MaxHoldValid = true;
@@ -1650,7 +1647,7 @@ void CPlotter::draw(bool newData)
                 holdLineBuf[i] = QPointF(ixPlot, yMinHoldD);
             }
             // NOT scaling to DPR due to performance
-            painter2.setPen(m_MinHoldColor);
+            painter2.setPen(m_HoldLineCol);
             painter2.drawPolyline(holdLineBuf, npts);
 
             m_MinHoldValid = true;
@@ -1766,7 +1763,7 @@ void CPlotter::draw(bool newData)
                 m_PeakPixmap.fill(Qt::transparent);
                 QPainter peakPainter(&m_PeakPixmap);
                 peakPainter.translate(QPointF(0.5, 0.5));
-                QPen peakPen(m_maxFftColor, m_DPR);
+                QPen peakPen(m_MainLineCol, m_DPR);
                 QPen peakShadowPen(Qt::black, m_DPR);
                 peakPen.setWidthF(m_DPR);
                 peakPainter.setPen(peakShadowPen);
@@ -2430,14 +2427,14 @@ void CPlotter::moveToDemodFreq()
 /** Set FFT plot color. */
 void CPlotter::setFftPlotColor(const QColor& color)
 {
-    m_avgFftColor = color;
-    m_maxFftColor = color;
-    // m_maxFftColor.setAlpha(192);
     m_PeakPixmap = QPixmap();
     QColor bgColor = QColor::fromRgba(PLOTTER_BGD_COLOR);
-    m_FftFillCol = color;
-    m_MaxHoldColor = blend(bgColor, color, 80);
-    m_MinHoldColor = blend(bgColor, color, 80);
+    m_FftFillCol = blend(bgColor, color, 26);
+    m_MainLineCol = color;
+    m_HoldLineCol = blend(bgColor, color, 80);
+    m_FilledModeFillCol = blend(bgColor, color, 80);
+    m_FilledModeMaxLineCol = blend(bgColor, color, 128);
+    m_FilledModeAvgLineCol = blend(bgColor, QColor(Qt::cyan), 192);
 }
 
 /** Enable/disable filling the area below the FFT plot. */

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1016,8 +1016,11 @@ void CPlotter::resizeEvent(QResizeEvent* )
         // Higher resolution pixmaps are used with higher DPR. They are
         // rescaled in paintEvent().
         const int w = qRound((qreal)s.width() * m_DPR);
-        const int plotHeight = qRound((qreal)m_Percent2DScreen * (qreal)s.height() / 100.0 * m_DPR);
-        const int wfHeight = qRound((qreal)s.height() * m_DPR) - plotHeight;
+        const int rawHeight = s.height();
+        const int rawPlotHeight = qRound((qreal)m_Percent2DScreen / 100.0 * (qreal)rawHeight);
+        const int rawWfHeight = rawHeight - rawPlotHeight;
+        const int plotHeight = qRound((qreal)rawPlotHeight * m_DPR);
+        const int wfHeight = qRound((qreal)rawWfHeight * m_DPR);
 
         m_OverlayPixmap = QPixmap(w, plotHeight);
         m_OverlayPixmap.fill(Qt::transparent);
@@ -1086,19 +1089,19 @@ void CPlotter::paintEvent(QPaintEvent *)
     {
         const int plotWidthS = m_2DPixmap.width();
         const int plotHeightS = m_2DPixmap.height();
-        const QRectF plotRectS(0.0, 0.0, plotWidthS, plotHeightS);
+        const QRect plotRectS(0, 0, plotWidthS, plotHeightS);
 
         const int plotWidthT = qRound((qreal)plotWidthS / m_DPR);
         plotHeightT = qRound((qreal)plotHeightS / m_DPR);
-        const QRectF plotRectT(0.0, 0.0, plotWidthT, plotHeightT);
+        const QRect plotRectT(0, 0, plotWidthT, plotHeightT);
 
         painter.drawPixmap(plotRectT, m_2DPixmap, plotRectS);
     }
 
     if (!m_WaterfallImage.isNull())
     {
-        painter.drawImage(QPointF(0.0, plotHeightT), m_WaterfallImage,
-            QRectF(0, m_WaterfallOffset, m_WaterfallImage.width(), m_WaterfallHeight));
+        painter.drawImage(QPoint(0, plotHeightT), m_WaterfallImage,
+            QRect(0, m_WaterfallOffset, m_WaterfallImage.width(), m_WaterfallHeight));
     }
 }
 

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1088,7 +1088,6 @@ void CPlotter::paintEvent(QPaintEvent *)
 
     QPainter painter(this);
 
-    int plotWidthT = 0;
     int plotHeightT = 0;
     if (!m_2DPixmap.isNull())
     {
@@ -1096,7 +1095,7 @@ void CPlotter::paintEvent(QPaintEvent *)
         const int plotHeightS = m_2DPixmap.height();
         const QRectF plotRectS(0.0, 0.0, plotWidthS, plotHeightS);
 
-        plotWidthT = qRound((qreal)plotWidthS / m_DPR);
+        const int plotWidthT = qRound((qreal)plotWidthS / m_DPR);
         plotHeightT = qRound((qreal)plotHeightS / m_DPR);
         const QRectF plotRectT(0.0, 0.0, plotWidthT, plotHeightT);
 
@@ -1106,16 +1105,17 @@ void CPlotter::paintEvent(QPaintEvent *)
     if (!m_WaterfallImage.isNull())
     {
         const int wfWidth = m_WaterfallImage.width();
+        const int wfWidthT = qRound((qreal)wfWidth / m_DPR);
         const int wfHeight = m_WaterfallImage.height();
         const int firstHeightS = wfHeight - m_WaterfallOffset;
         const qreal firstHeightT = firstHeightS / m_DPR;
         const qreal secondHeightT = m_WaterfallOffset / m_DPR;
         // draw the waterfall in two parts based on the location of the offset:
         // the first draw is the section below the offset to be drawm at top
-        painter.drawImage(QRectF(0.0, plotHeightT, plotWidthT, firstHeightT), m_WaterfallImage,
+        painter.drawImage(QRectF(0.0, plotHeightT, wfWidthT, firstHeightT), m_WaterfallImage,
             QRectF(0.0, m_WaterfallOffset, wfWidth, firstHeightS));
         // the second draw is the section above the offset to be drawn below
-        painter.drawImage(QRectF(0.0, plotHeightT + firstHeightT, plotWidthT, secondHeightT), m_WaterfallImage,
+        painter.drawImage(QRectF(0.0, plotHeightT + firstHeightT, wfWidthT, secondHeightT), m_WaterfallImage,
             QRectF(0.0, 0.0, wfWidth, m_WaterfallOffset));
     }
 }
@@ -1775,7 +1775,10 @@ void CPlotter::draw(bool newData)
                 const int half = qRound(radius + m_DPR + shadowOffset);
                 const int full = half * 2;
                 m_PeakPixmap = QPixmap(full, full);
-                m_PeakPixmap.fill(Qt::transparent);
+                QColor bg = QColor(m_MainLineCol);
+                bg.setAlpha(128);
+                m_PeakPixmap.fill(bg);
+                //m_PeakPixmap.fill(Qt::transparent);
                 QPainter peakPainter(&m_PeakPixmap);
                 peakPainter.translate(half, half);
                 QPen peakPen(m_MainLineCol, m_DPR);

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -89,7 +89,7 @@ CPlotter::CPlotter(QWidget *parent) : QFrame(parent)
     setFocusPolicy(Qt::StrongFocus);
     setAttribute(Qt::WA_PaintOnScreen,false);
     setAutoFillBackground(false);
-    setAttribute(Qt::WA_OpaquePaintEvent, false);
+    setAttribute(Qt::WA_OpaquePaintEvent, true);
     setAttribute(Qt::WA_NoSystemBackground, true);
     setMouseTracking(true);
 

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1134,10 +1134,6 @@ void CPlotter::draw(bool newData)
         return;
     }
 
-    QPointF avgLineBuf[MAX_SCREENSIZE];
-    QPointF maxLineBuf[MAX_SCREENSIZE];
-    QPointF holdLineBuf[MAX_SCREENSIZE];
-
     const quint64 tnow_ms = QDateTime::currentMSecsSinceEpoch();
 
     // Pixmaps might be null, so scale up m_Size to get width.
@@ -1579,9 +1575,9 @@ void CPlotter::draw(bool newData)
 
             // Add max, average points if they will be drawn
             if (doMaxLine)
-                maxLineBuf[i] = QPointF(ixPlot, yMaxD);
+                m_maxLineBuf[i] = QPointF(ixPlot, yMaxD);
             if (doAvgLine)
-                avgLineBuf[i] = QPointF(ixPlot, yAvgD);
+                m_avgLineBuf[i] = QPointF(ixPlot, yAvgD);
 
             // Fill area between markers, even if they are off screen
             qreal yFill = m_PlotMode == PLOT_MODE_MAX ? yMaxD : yAvgD;
@@ -1594,7 +1590,7 @@ void CPlotter::draw(bool newData)
             }
             if (m_PlotMode == PLOT_MODE_FILLED)
             {
-                avgMaxPolygon << maxLineBuf[i];
+                avgMaxPolygon << m_maxLineBuf[i];
             }
         }
 
@@ -1606,7 +1602,8 @@ void CPlotter::draw(bool newData)
             painter2.drawPolygon(underPolygon);
         }
 
-        if (!abPolygon.isEmpty()) {
+        if (!abPolygon.isEmpty())
+        {
             abPolygon << QPointF(abPolygon.last().x(), plotHeight);
             abPolygon << QPointF(abPolygon.first().x(), plotHeight);
             painter2.setBrush(abFillBrush);
@@ -1624,11 +1621,11 @@ void CPlotter::draw(bool newData)
                 const qreal yMaxHoldD = (qreal)std::max(std::min(
                     panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMaxHoldBuf[ix])),
                     (float)plotHeight), 0.0f);
-                holdLineBuf[i] = QPointF(ixPlot, yMaxHoldD);
+                m_holdLineBuf[i] = QPointF(ixPlot, yMaxHoldD);
             }
             // NOT scaling to DPR due to performance
             painter2.setPen(m_HoldLineCol);
-            painter2.drawPolyline(holdLineBuf, npts);
+            painter2.drawPolyline(m_holdLineBuf, npts);
 
             m_MaxHoldValid = true;
         }
@@ -1644,11 +1641,11 @@ void CPlotter::draw(bool newData)
                 const qreal yMinHoldD = (qreal)std::max(std::min(
                     panddBGainFactor * (m_PandMaxdB - 10.0f * log10f(m_fftMinHoldBuf[ix])),
                     (float)plotHeight), 0.0f);
-                holdLineBuf[i] = QPointF(ixPlot, yMinHoldD);
+                m_holdLineBuf[i] = QPointF(ixPlot, yMinHoldD);
             }
             // NOT scaling to DPR due to performance
             painter2.setPen(m_HoldLineCol);
-            painter2.drawPolyline(holdLineBuf, npts);
+            painter2.drawPolyline(m_holdLineBuf, npts);
 
             m_MinHoldValid = true;
         }
@@ -1657,21 +1654,23 @@ void CPlotter::draw(bool newData)
         {
             for (i = npts - 1; i >= 0; i--)
             {
-                avgMaxPolygon << avgLineBuf[i];
+                avgMaxPolygon << m_avgLineBuf[i];
             }
             painter2.setBrush(maxFillBrush);
             painter2.drawPolygon(avgMaxPolygon);
         }
 
-        if (doMaxLine) {
+        if (doMaxLine)
+        {
             // NOT scaling to DPR due to performance
             painter2.setPen(maxLinePen);
-            painter2.drawPolyline(maxLineBuf, npts);
+            painter2.drawPolyline(m_maxLineBuf, npts);
         }
-        if (doAvgLine) {
+        if (doAvgLine)
+        {
             // NOT scaling to DPR due to performance
             painter2.setPen(avgLinePen);
-            painter2.drawPolyline(avgLineBuf, npts);
+            painter2.drawPolyline(m_avgLineBuf, npts);
         }
 
         // Peak detection

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1758,23 +1758,26 @@ void CPlotter::draw(bool newData)
             // Paint peaks with shadow
             if (m_PeakPixmap.isNull())
             {
-                m_PeakPixmap = QPixmap(qRound((10.0 + shadowOffset) * m_DPR), qRound((10.0 + shadowOffset) * m_DPR));
+                const qreal radius = 5.0 * m_DPR;
+                const qreal diameter = radius * 2;
+                const int half = qRound(radius + m_DPR + shadowOffset);
+                const int full = half * 2;
+                m_PeakPixmap = QPixmap(full, full);
                 m_PeakPixmap.fill(Qt::transparent);
                 QPainter peakPainter(&m_PeakPixmap);
-                peakPainter.translate(QPointF(0.5, 0.5));
+                peakPainter.translate(half, half);
                 QPen peakPen(m_MainLineCol, m_DPR);
                 QPen peakShadowPen(Qt::black, m_DPR);
-                peakPen.setWidthF(m_DPR);
                 peakPainter.setPen(peakShadowPen);
                 peakPainter.drawEllipse(
-                    QRectF(shadowOffset,
-                           shadowOffset,
-                           10.0 * m_DPR, 10.0 * m_DPR));
+                    QRectF(shadowOffset - radius,
+                           shadowOffset - radius,
+                           diameter, diameter));
                 peakPainter.setPen(peakPen);
                 peakPainter.drawEllipse(
-                    QRectF(0,
-                           0,
-                           10.0 * m_DPR, 10.0 * m_DPR));
+                    QRectF(-radius,
+                           -radius,
+                           diameter, diameter));
             }
             const int peakPixmapOffset = m_PeakPixmap.width() / 2;
             for(auto peakx : m_Peaks.keys()) {

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1772,13 +1772,10 @@ void CPlotter::draw(bool newData)
             {
                 const qreal radius = 5.0 * m_DPR;
                 const qreal diameter = radius * 2;
-                const int half = qRound(radius + m_DPR + shadowOffset);
+                const int half = qRound(radius + m_DPR * 2);
                 const int full = half * 2;
                 m_PeakPixmap = QPixmap(full, full);
-                QColor bg = QColor(m_MainLineCol);
-                bg.setAlpha(128);
-                m_PeakPixmap.fill(bg);
-                //m_PeakPixmap.fill(Qt::transparent);
+                m_PeakPixmap.fill(Qt::transparent);
                 QPainter peakPainter(&m_PeakPixmap);
                 peakPainter.translate(half, half);
                 QPen peakPen(m_MainLineCol, m_DPR);
@@ -1794,7 +1791,7 @@ void CPlotter::draw(bool newData)
                            -radius,
                            diameter, diameter));
             }
-            const int peakPixmapOffset = m_PeakPixmap.width() / 2;
+            const int peakPixmapOffset = m_PeakPixmap.width() / 2 + 1;
             for(auto peakx : m_Peaks.keys()) {
                 const qreal peakxPlot = (qreal)peakx;
                 const qreal peakv = m_Peaks.value(peakx);

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -259,6 +259,7 @@ private:
     eCapturetype    m_CursorCaptured;
     QPixmap     m_2DPixmap;         // Composite of everything displayed in the 2D plotter area
     QPixmap     m_OverlayPixmap;    // Grid, axes ... things that need to be drawn infrequently
+    QPixmap     m_PeakPixmap;
     QImage      m_WaterfallImage;
     QColor      m_ColorTbl[256];
     QSize       m_Size;

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -261,6 +261,8 @@ private:
     QPixmap     m_OverlayPixmap;    // Grid, axes ... things that need to be drawn infrequently
     QPixmap     m_PeakPixmap;
     QImage      m_WaterfallImage;
+    int         m_WaterfallHeight;
+    int         m_WaterfallOffset;
     QColor      m_ColorTbl[256];
     QSize       m_Size;
     qreal       m_DPR{};

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -339,7 +339,7 @@ private:
 
     quint32     m_LastSampleRate{};
 
-    QColor      m_avgFftColor, m_maxFftColor, m_FftFillCol, m_MaxHoldColor, m_MinHoldColor;
+    QColor      m_FftFillCol, m_FilledModeFillCol, m_FilledModeMaxLineCol, m_FilledModeAvgLineCol, m_MainLineCol, m_HoldLineCol;
     bool        m_FftFill{};
 
     QMap<int,qreal>   m_Peaks;

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -250,6 +250,9 @@ private:
     float       m_wfAvgBuf[MAX_SCREENSIZE]{};
     float       m_histogram[MAX_SCREENSIZE][MAX_HISTOGRAM_SIZE]{};
     float       m_histIIR[MAX_SCREENSIZE][MAX_HISTOGRAM_SIZE]{};
+    QPointF     m_avgLineBuf[MAX_SCREENSIZE]{};
+    QPointF     m_maxLineBuf[MAX_SCREENSIZE]{};
+    QPointF     m_holdLineBuf[MAX_SCREENSIZE]{};
     float       m_histMaxIIR;
     std::vector<float> m_fftIIR;
     std::vector<float> m_fftData;

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -272,7 +272,6 @@ private:
     QPixmap     m_OverlayPixmap;    // Grid, axes ... things that need to be drawn infrequently
     QPixmap     m_PeakPixmap;
     QImage      m_WaterfallImage;
-    int         m_WaterfallHeight;
     int         m_WaterfallOffset;
     QColor      m_ColorTbl[256];
     QSize       m_Size;

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -221,6 +221,14 @@ private:
     static qint64      roundFreq(qint64 freq, int resolution);
     quint64     msecFromY(int y);
     void        clampDemodParameters();
+    static QColor      blend(QColor base, QColor over, int alpha255)
+    {
+        qreal alpha = alpha255 / 255.0;
+        qreal oneMinusAlpha = 1.0 - alpha;
+        return QColor(qRound(alpha * over.red()   + oneMinusAlpha * base.red()),
+                      qRound(alpha * over.green() + oneMinusAlpha * base.green()),
+                      qRound(alpha * over.blue()  + oneMinusAlpha * base.blue()));
+    }
     static bool        isPointCloseTo(int x, int xr, int delta)
     {
         return ((x > (xr - delta)) && (x < (xr + delta)));


### PR DESCRIPTION
i run this application on my laptop and find that the CPU is quite high, so i did some flame graph analysis to see if i could reduce CPU (to have longer battery life). i had already run volk_profile. i found that actually the rendering was taking up more CPU than the actual GNUradio and DSP operations. i did the following operations:

- cache meter font so it can be reused
- update meter less often (only when the 0.1's place needed updating). the extra renders caused excessive blit operations when the CPlotter was drawing but the CMeter was updating the back buffer. they will still happen, but ideally significantly less often. a better solution could be to sync up the CMeter refreshes with the CPlotter, but i held off on that.
- cache peak circles as QImage so we dont need to calculate ellipse rasters on each frame for each ellipse occurence. the raster is the same and identical so a simple QImage draw will be faster.
- sliding window waterfall implementation. this eliminates a large memmove on each frame. instead the line is written across the top of a QImage which is 2x height in size and the "window" to be copied is slided up. once the window hits the top, then the top is copied to the bottom and the window sliding starts from the bottom back to the top. see diagram.
- use polygons for fills (instead of single line fills). each fill was attempted to be done in parallel. but the solution was to do fewer fills.
- prevent rounding errors. the plotter vs waterfall slider ratio was yielding fractional values sometimes. instead make sure the split is even. this make the drawing simple memmoves instead of a more expensive scale operation. i did this by flipping the math operations to ensure we are working with full pixel values before multiplying by the device pixel ratio.
- avoid unnecessary fills on mac: unifiedTitleAndToolBarOnMac makes the window translucent which means that the window must be cleared before each render. this is unnecessary since the painting is opaque.
- use solid colors. the alpha composition was more expensive. by precomputing the colors to be solid colors the composition is faster since we are copying and avoiding a bunch of extra math to do the alpha blending. i made the end result looks basically identical.
- store QPoint buffers on CPlotter object. allocate them once and reuse them.
- use opaque flag on widget. we are indeed painting every pixel so this flag should be set. disable autofill background.

sliding window implementation:
<img width="537" alt="image" src="https://github.com/user-attachments/assets/97c9b59e-26d9-46cd-b3c1-29ed9173a441">

i ran a test with these settings and docks open:
<img width="1680" alt="Screen Shot 2024-10-15 at 20 19 52" src="https://github.com/user-attachments/assets/abd0ccaf-73c6-4869-8418-9c3de6ef9c1a">


before:
![2024-10-15_20 19 01-WindowServer_sample txt](https://github.com/user-attachments/assets/5d98220b-75df-4ae6-a686-ce4cce1befa5)

after:
![2024-10-15_20 50 44-WindowServer_sample txt](https://github.com/user-attachments/assets/4e39b66c-95f4-4063-9183-a0a84f6e0916)

notable differences:
![savings](https://github.com/user-attachments/assets/dcc4a8bf-3799-46fd-b93d-972de9f89562)

i was doing 10fps at  110%, but now that is around 60%.
i was topping out at around 20 fps with around 130% cpu, but now that is around 100% cpu.

now i'm topping out around 40fps with around 110% cpu, so these changes provide a significant improvement.

open question: should the dock audio CPlotter share the same fps as the main CPlotter? it seems to be preset to 25fps (1000/40ms).
