### PR TITLE
Bump macOS CI versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           path: Gqrx-*.AppImage
   macos:
     name: MacOS
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Check for Secret availability
         id: secret-check
@@ -79,6 +79,8 @@ jobs:
           fi
       - name: Install dependencies
         run: |
+          # for https://github.com/actions/runner-images/issues/9272
+          sudo chown -R runner:admin /usr/local/
           brew update
           brew install --HEAD librtlsdr
           brew install airspy airspyhf boost dylibbundler gnuradio hackrf libbladerf libserialport portaudio pybind11 six uhd qt@6 || true
@@ -111,7 +113,7 @@ jobs:
           cd build
           cmake ..
           make -j4
-          make install
+          sudo make install
 
           cd /tmp
           cp /Library/Frameworks/iio.framework/iio /usr/local/lib/libiio.dylib
@@ -131,7 +133,7 @@ jobs:
           cd build
           cmake ..
           make -j4
-          make install
+          sudo make install
 
           cd /tmp
           git clone https://gitea.osmocom.org/sdr/gr-osmosdr.git
@@ -140,7 +142,7 @@ jobs:
           cd build
           cmake -DCMAKE_CXX_FLAGS=-Wno-register ..
           LIBRARY_PATH=/usr/local/opt/icu4c/lib make -j4
-          make install
+          sudo make install
       - name: Install Apple certificate
         if: ${{ steps.secret-check.outputs.available == 'true' }}
         env:
@@ -237,7 +239,7 @@ jobs:
     - name: Clone and build GNU Radio
       working-directory: ${{ runner.temp }}
       run: |
-        git clone --branch v3.10.9.2 --depth 1 https://github.com/gnuradio/gnuradio.git
+        git clone --branch v3.10.11.0 --depth 1 https://github.com/gnuradio/gnuradio.git
         cd gnuradio
         cmake -S . -B build \
           -DCMAKE_INSTALL_PREFIX=${RUNNER_TEMP}/msys64/mingw64 \
@@ -337,7 +339,7 @@ jobs:
           libfftw3f-3.dll \
           libfftw3f_threads-3.dll \
           libFLAC.dll \
-          libfmt.dll \
+          libfmt-11.dll \
           libfreetype-6.dll \
           libgcc_s_seh-1.dll \
           libglib-2.0-0.dll \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,14 @@ jobs:
     name: MacOS CI
     strategy:
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-13, macos-14]
         backend: [Portaudio, Gr-audio]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies
         run: |
+          # for https://github.com/actions/runner-images/issues/9272
+          sudo chown -R runner:admin /usr/local/
           brew update
           brew install airspy boost gnuradio hackrf libbladerf librtlsdr pybind11 six uhd qt@6 || true
 
@@ -84,7 +86,7 @@ jobs:
           cd build
           cmake -DCMAKE_CXX_FLAGS=-Wno-register ..
           LIBRARY_PATH=/usr/local/opt/icu4c/lib make -j4
-          make install
+          sudo make install
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Configure


### PR DESCRIPTION
per https://github.com/orgs/Homebrew/discussions/5603

macOS 12 is no longer supported by homebrew. it will run but the fast installation from "bottles" (precompiled blobs) will no longer work. this causes the dependencies to be compiled from source which takes a very long time, hence the timeouts.

for this reason i'm moving to the later versions which are still supported and have the fast bottles.

~NOTE: the sdk baseline is not changing, so versions 12 and earlier should still work.~