### PR TITLE
Build both x86_64 and arm64 macOS DMG's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,14 @@ jobs:
           path: Gqrx-*.AppImage
   macos:
     name: MacOS
-    runs-on: macos-13
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
+    # NOTE: in the free tier, `macos-13` is x86_64 only, while `macos-14` is arm64 only.
+    # when we increase the baseline to 14 eventually, we will be losing x86_64 support,
+    # so hopefully all of the macs will be arm64 by then.
+    # see https://github.com/actions/runner-images/issues/9741
+    runs-on: ${{ matrix.arch == 'x86_64' && 'macos-13' || 'macos-14' }}
     steps:
       - name: Check for Secret availability
         id: secret-check
@@ -79,13 +86,12 @@ jobs:
           fi
       - name: Install dependencies
         run: |
+          uname -a
           # for https://github.com/actions/runner-images/issues/9272
           sudo chown -R runner:admin /usr/local/
           brew update
           brew install --HEAD librtlsdr
-          brew install airspy airspyhf boost dylibbundler gnuradio hackrf libbladerf libserialport portaudio pybind11 six uhd qt@6 || true
-          brew tap pothosware/homebrew-pothos
-          brew install soapyremote
+          brew install airspy airspyhf boost dylibbundler gnuradio hackrf libbladerf libserialport portaudio pybind11 six soapyremote uhd qt@6 || true
 
           cd /tmp
           git clone https://github.com/analogdevicesinc/libiio.git
@@ -93,7 +99,7 @@ jobs:
           git checkout v0.23
           mkdir build
           cd build
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=Release ..
           make -j4
           sudo make install
 
@@ -102,7 +108,7 @@ jobs:
           cd libad9361-iio
           mkdir build
           cd build
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=Release ..
           make -j4
           sudo make install
 
@@ -111,19 +117,19 @@ jobs:
           cd SoapyPlutoSDR
           mkdir build
           cd build
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=Release ..
           make -j4
           sudo make install
 
           cd /tmp
-          cp /Library/Frameworks/iio.framework/iio /usr/local/lib/libiio.dylib
-          install_name_tool -id "/usr/local/lib/libiio.dylib" /usr/local/lib/libiio.dylib
-          cp /Library/Frameworks/ad9361.framework/ad9361 /usr/local/lib/libad9361.dylib
-          install_name_tool -id "/usr/local/lib/libad9361.dylib" /usr/local/lib/libad9361.dylib
-          install_name_tool -delete_rpath /Library/Frameworks /usr/local/lib/libad9361.dylib
-          install_name_tool -change @rpath/iio.framework/Versions/0.23/iio /usr/local/lib/libiio.dylib /usr/local/lib/libad9361.dylib
-          install_name_tool -change @rpath/iio.framework/Versions/0.23/iio /usr/local/lib/libiio.dylib /usr/local/lib/SoapySDR/modules0.*/libPlutoSDRSupport.so
-          install_name_tool -change @rpath/ad9361.framework/Versions/0.2/ad9361 /usr/local/lib/libad9361.dylib /usr/local/lib/SoapySDR/modules0.*/libPlutoSDRSupport.so
+          sudo cp /Library/Frameworks/iio.framework/iio /usr/local/lib/libiio.dylib
+          sudo install_name_tool -id "/usr/local/lib/libiio.dylib" /usr/local/lib/libiio.dylib
+          sudo cp /Library/Frameworks/ad9361.framework/ad9361 /usr/local/lib/libad9361.dylib
+          sudo install_name_tool -id "/usr/local/lib/libad9361.dylib" /usr/local/lib/libad9361.dylib
+          sudo install_name_tool -delete_rpath /Library/Frameworks /usr/local/lib/libad9361.dylib
+          sudo install_name_tool -change @rpath/iio.framework/Versions/0.23/iio /usr/local/lib/libiio.dylib /usr/local/lib/libad9361.dylib
+          sudo install_name_tool -change @rpath/iio.framework/Versions/0.23/iio /usr/local/lib/libiio.dylib /usr/local/lib/SoapySDR/modules0.*/libPlutoSDRSupport.so
+          sudo install_name_tool -change @rpath/ad9361.framework/Versions/0.2/ad9361 /usr/local/lib/libad9361.dylib /usr/local/lib/SoapySDR/modules0.*/libPlutoSDRSupport.so
 
           cd /tmp
           git clone https://gitea.osmocom.org/sdr/gr-iqbal.git
@@ -131,7 +137,7 @@ jobs:
           git submodule update --init --recursive
           mkdir build
           cd build
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=Release ..
           make -j4
           sudo make install
 
@@ -140,7 +146,7 @@ jobs:
           cd gr-osmosdr
           mkdir build
           cd build
-          cmake -DCMAKE_CXX_FLAGS=-Wno-register ..
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-Wno-register ..
           LIBRARY_PATH=/usr/local/opt/icu4c/lib make -j4
           sudo make install
       - name: Install Apple certificate
@@ -166,7 +172,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Configure
-        run: mkdir build && cd build && cmake ..
+        run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
       - name: Compile
         working-directory: build
         run: make -j4
@@ -206,7 +212,7 @@ jobs:
       - name: Save artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gqrx-macos-${{ github.run_id }}
+          name: gqrx-macos-${{ matrix.arch }}-${{ github.run_id }}
           path: Gqrx-*.dmg
   windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     name: MacOS CI
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-latest]
         backend: [Portaudio, Gr-audio]
     runs-on: ${{ matrix.os }}
     steps:

--- a/macos_bundle.sh
+++ b/macos_bundle.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
-GQRX_VERSION=$(<build/version.txt)
+GQRX_VERSION="$(<build/version.txt)"
 IDENTITY=Y3GC27WZ4S
+BREW_PREFIX="$(brew --prefix)"
+MACDEPLOYQT6="${BREW_PREFIX}"/opt/qt@6/bin/macdeployqt
 
 mkdir -p Gqrx.app/Contents/MacOS
 mkdir -p Gqrx.app/Contents/Resources
@@ -49,26 +51,24 @@ EOM
 
 cp build/src/gqrx Gqrx.app/Contents/MacOS
 cp resources/icons/gqrx.icns Gqrx.app/Contents/Resources
-PREFIX=$(brew --prefix)
-MACDEPLOYQT6=${PREFIX}/opt/qt@6/bin/macdeployqt
 # NOTE: PlutoSDR is built locally, so it will not in the brew path
 cp /usr/local/lib/SoapySDR/modules*/libPlutoSDRSupport.so Gqrx.app/Contents/soapy-modules
-cp ${PREFIX}/lib/SoapySDR/modules*/libremoteSupport.so Gqrx.app/Contents/soapy-modules
+cp "${BREW_PREFIX}"/lib/SoapySDR/modules*/libremoteSupport.so Gqrx.app/Contents/soapy-modules
 chmod 644 Gqrx.app/Contents/soapy-modules/*
 
-dylibbundler -s ${PREFIX}/opt/icu4c/lib/ -od -b -x Gqrx.app/Contents/MacOS/gqrx -x Gqrx.app/Contents/soapy-modules/libPlutoSDRSupport.so -x Gqrx.app/Contents/soapy-modules/libremoteSupport.so -d Gqrx.app/Contents/libs/
-${MACDEPLOYQT6} Gqrx.app -no-strip -always-overwrite # TODO: Remove macdeployqt workaround
+dylibbundler -s "${BREW_PREFIX}"/opt/icu4c/lib/ -od -b -x Gqrx.app/Contents/MacOS/gqrx -x Gqrx.app/Contents/soapy-modules/libPlutoSDRSupport.so -x Gqrx.app/Contents/soapy-modules/libremoteSupport.so -d Gqrx.app/Contents/libs/
+"${MACDEPLOYQT6}" Gqrx.app -no-strip -always-overwrite # TODO: Remove macdeployqt workaround
 if [ "$1" = "true" ]; then
-    ${MACDEPLOYQT6} Gqrx.app -no-strip -always-overwrite -sign-for-notarization=$IDENTITY
+    "${MACDEPLOYQT6}" Gqrx.app -no-strip -always-overwrite -sign-for-notarization="${IDENTITY}"
 else
-    ${MACDEPLOYQT6} Gqrx.app -no-strip -always-overwrite
+    "${MACDEPLOYQT6}" Gqrx.app -no-strip -always-overwrite
 fi
 
 for f in Gqrx.app/Contents/libs/*.dylib Gqrx.app/Contents/soapy-modules/*.so Gqrx.app/Contents/Frameworks/*.framework Gqrx.app/Contents/Frameworks/*.dylib Gqrx.app/Contents/MacOS/gqrx
 do
     if [ "$1" = "true" ]; then
-        codesign --force --verify --verbose --timestamp --options runtime --entitlements /tmp/Entitlements.plist --sign $IDENTITY $f
+        codesign --force --verify --verbose --timestamp --options runtime --entitlements /tmp/Entitlements.plist --sign "${IDENTITY}" "$f"
     else
-        codesign --remove-signature $f
+        codesign --remove-signature "$f"
     fi
 done

--- a/macos_bundle.sh
+++ b/macos_bundle.sh
@@ -49,16 +49,14 @@ EOM
 
 cp build/src/gqrx Gqrx.app/Contents/MacOS
 cp resources/icons/gqrx.icns Gqrx.app/Contents/Resources
-# see https://apple.stackexchange.com/questions/437618/why-is-homebrew-installed-in-opt-homebrew-on-apple-silicon-macs
-MACDEPLOYQT6=/usr/local/opt/qt@6/bin/macdeployqt
-if [ -f /opt/homebrew/opt/qt@6/bin/macdeployqt ]; then
-    MACDEPLOYQT6=/opt/homebrew/opt/qt@6/bin/macdeployqt
-fi
-cp /*/*/lib/SoapySDR/modules*/libPlutoSDRSupport.so Gqrx.app/Contents/soapy-modules
-cp /*/*/lib/SoapySDR/modules*/libremoteSupport.so Gqrx.app/Contents/soapy-modules
+PREFIX=$(brew --prefix)
+MACDEPLOYQT6=${PREFIX}/opt/qt@6/bin/macdeployqt
+# NOTE: PlutoSDR is built locally, so it will not in the brew path
+cp /usr/local/lib/SoapySDR/modules*/libPlutoSDRSupport.so Gqrx.app/Contents/soapy-modules
+cp ${PREFIX}/lib/SoapySDR/modules*/libremoteSupport.so Gqrx.app/Contents/soapy-modules
 chmod 644 Gqrx.app/Contents/soapy-modules/*
 
-dylibbundler -s /usr/local/opt/icu4c/lib/ -od -b -x Gqrx.app/Contents/MacOS/gqrx -x Gqrx.app/Contents/soapy-modules/libPlutoSDRSupport.so -x Gqrx.app/Contents/soapy-modules/libremoteSupport.so -d Gqrx.app/Contents/libs/
+dylibbundler -s ${PREFIX}/opt/icu4c/lib/ -od -b -x Gqrx.app/Contents/MacOS/gqrx -x Gqrx.app/Contents/soapy-modules/libPlutoSDRSupport.so -x Gqrx.app/Contents/soapy-modules/libremoteSupport.so -d Gqrx.app/Contents/libs/
 ${MACDEPLOYQT6} Gqrx.app -no-strip -always-overwrite # TODO: Remove macdeployqt workaround
 if [ "$1" = "true" ]; then
     ${MACDEPLOYQT6} Gqrx.app -no-strip -always-overwrite -sign-for-notarization=$IDENTITY

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,11 +2,12 @@
     2.17.6: In progress...
 
        NEW: Fetch RDS Program Service & RadioText via remote control.
+       NEW: DMG release for ARM-based Macs.
   IMPROVED: Save I/Q recording format to settings.
   IMPROVED: Reduced CPU utilization of plot and waterfall display.
   IMPROVED: Display and formatting of RDS data.
      FIXED: Decoding of RDS flags.
-   CHANGED: DMG release requires macOS 13.7 or later.
+   CHANGED: x86 DMG release requires macOS 13.7 or later.
 
 
     2.17.5: Released April 18, 2024


### PR DESCRIPTION
fixes #1104

- i tried doing the conda version, but found that the qt in there does not bundle properly and was bundling the libraries twice. i may dig into it further later, but this still uses the brew installation methodology
- there are a few gotchas: 
- the macos-13 GH runner is x86_64 only in the free tier and the macos-14 GH runner is arm64 only in the free tier, so technically the two produced artifacts have different OS baselines. both brew and conda do not produce universal2 binaries and seem to pin to the OS baselines, so not much i think we could do to get out of this. when we move to macos-14 baseline in the future (since one day macos-13 will be deprecated like macos-12 just was), we will only have an arm64 CI/build environment. this would normally bother me, but given apple has not made an intel laptop since 2019 and they are a few years away from dropping support on macos-13, it should probably work for most people.
- soapyremote is in the main brew repository now. pothos has SoapyPlutoSDR but the dependencies libad9361 and libiio are not up to date. ideally we could eventually move back to the pothos version.
- homebrew moved the prefix (on arm64) from /usr/local to /opt/homebrew which was annoying to support.
- macos-13 still has weirdness with the permissions on /usr/local so more sudo is needed.
- build Release versions using cmake
- remove CFBundleGetInfoString since its deprecated and the "get info" in the Finder uses the version string now
- upgrade CI to use "macos-latest" which is currently macos-14 but will eventually be macos-15.
- i found the quirks in the bundle script around broti, png, sharpuv, freetype were not needed since the libraries appeared to be properly relocated. i could not find any history around why those carveouts existed.
- if i had to guess i broke something in this, it would be around soapyplutosdr or something soapy
- my test build https://github.com/yuzawa-san/gqrx/actions/runs/11431458195
- i QA'd on my own x86_64 sonoma mac and found it worked. i had a friend try to QA on their arm64 sequoia mac but the system integrity mode choked on the unsigned artifact. so i'll open this PR and they the signed one built here. once i validate that with my friend's computer i'll take this out of draft mode.