### PR TITLE
Optimize Plotter Fills

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1597,7 +1597,7 @@ void CPlotter::draw(bool newData)
             {
                 const QPointF point = m_PlotMode == PLOT_MODE_MAX ? m_maxLineBuf[i] : m_avgLineBuf[i];
                 const qreal yFill = point.y();
-                painter2.fillRect(QRectF(point.x(), yFill, 1.0, yFillMax - yFill), m_FftFillCol);
+                painter2.fillRect(QRectF(point.x() - 1.0, yFill, 1.0, yFillMax - yFill), m_FftFillCol);
             }
             painter2.fillRect(QRectF(xmin, yFillMax, npts, plotHeight - yFillMax), m_FftFillCol);
         }
@@ -1656,7 +1656,7 @@ void CPlotter::draw(bool newData)
             {
                 const QPointF maxPoint = m_maxLineBuf[i];
                 const qreal yMax = maxPoint.y();
-                painter2.fillRect(QRectF(maxPoint.x(), yMax, 1.0, m_avgLineBuf[i].y() - yMax), m_FilledModeFillCol);
+                painter2.fillRect(QRectF(maxPoint.x() - 1.0, yMax, 1.0, m_avgLineBuf[i].y() - yMax), m_FilledModeFillCol);
             }
         }
 

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1672,7 +1672,7 @@ void CPlotter::draw(bool newData)
                 {
                     const int ix = i + xmin;
                     const int yMax = qRound(m_maxLineBuf[i].y());
-                    const int yAvg = qRound(m_maxLineBuf[i].y());
+                    const int yAvg = qRound(m_avgLineBuf[i].y());
                     if (yMax < y && y < yAvg) {
                         painter2.drawPoint(QPoint(ix, y));
                     }

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1591,16 +1591,15 @@ void CPlotter::draw(bool newData)
 
         if (m_FftFill && m_PlotMode != PLOT_MODE_HISTOGRAM)
         {
-            QLineF lines[npts];
             qreal yFillMax = 0;
             for (i = 0; i < npts; i++)
             {
                 QPointF yFill = m_PlotMode == PLOT_MODE_MAX ? m_maxLineBuf[i] : m_avgLineBuf[i];
-                lines[i] = QLineF(yFill, QPointF(yFill.x(), plotHeight));
+                m_fillLineBuf[i] = QLineF(yFill, QPointF(yFill.x(), plotHeight));
                 yFillMax = std::max(yFillMax, yFill.y());
             }
             painter2.setPen(QPen(m_FftFillCol));
-            painter2.drawLines(lines, npts);
+            painter2.drawLines(m_fillLineBuf, npts);
             painter2.fillRect(QRectF(xmin, yFillMax, npts, plotHeight - yFillMax), QBrush(m_FftFillCol));
         }
 
@@ -1654,13 +1653,12 @@ void CPlotter::draw(bool newData)
 
         if (m_PlotMode == PLOT_MODE_FILLED)
         {
-            QLineF lines[npts];
             for (i = 0; i < npts; i++)
             {
-                lines[i] = QLineF(m_maxLineBuf[i], m_avgLineBuf[i]);
+                m_fillLineBuf[i] = QLineF(m_maxLineBuf[i], m_avgLineBuf[i]);
             }
             painter2.setPen(QPen(m_FilledModeFillCol));
-            painter2.drawLines(lines, npts);
+            painter2.drawLines(m_fillLineBuf, npts);
         }
 
         if (doMaxLine)

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1593,14 +1593,14 @@ void CPlotter::draw(bool newData)
             }
             yFillMin = std::min(yFillMin, qRound(yFill));
             yFillMax = std::max(yFillMax, qRound(yFill));
-            yInnerFillMin = std::min(yFillMin, qRound(yMaxD));
-            yInnerFillMax = std::max(yFillMax, qRound(yAvgD));
+            yInnerFillMin = std::min(yInnerFillMin, qRound(yMaxD));
+            yInnerFillMax = std::max(yInnerFillMax, qRound(yAvgD));
         }
 
         if (m_FftFill && m_PlotMode != PLOT_MODE_HISTOGRAM)
         {
             painter2.setPen(QPen(m_FftFillCol));
-            for (int y = yFillMin; y < yFillMax; y++)
+            for (int y = yFillMin; y <= yFillMax; y++)
             {
                 for (i = 0; i < npts; i++)
                 {

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1673,7 +1673,7 @@ void CPlotter::draw(bool newData)
                     const int ix = i + xmin;
                     const int yMax = qRound(m_maxLineBuf[i].y());
                     const int yAvg = qRound(m_avgLineBuf[i].y());
-                    if (yMax < y && y < yAvg) {
+                    if (yMax <= y && y <= yAvg) {
                         painter2.drawPoint(QPoint(ix, y));
                     }
                 }

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1506,13 +1506,6 @@ void CPlotter::draw(bool newData)
         QPainter painter2(&m_2DPixmap);
         painter2.translate(QPointF(0.5, 0.5));
 
-
-        // draw the pandapter
-        QBrush fillBrush = QBrush(m_FftFillCol);
-
-        // Fill between max and avg
-        QBrush maxFillBrush = QBrush(m_FilledModeFillCol);
-
         // Diagonal fill for area between markers. Scale the pattern to DPR.
         QColor abFillColor = QColor::fromRgba(PLOTTER_MARKER_COLOR);
         abFillColor.setAlpha(128);
@@ -1547,8 +1540,10 @@ void CPlotter::draw(bool newData)
 
         const float binSizeY = (float)plotHeight / (float)histBinsDisplayed;
         QPolygonF abPolygon;
-        QPolygonF underPolygon;
-        QPolygonF avgMaxPolygon;
+        int yFillMin = plotHeight;
+        int yFillMax = 0;
+        int yInnerFillMin = plotHeight;
+        int yInnerFillMax = 0;
         for (i = 0; i < npts; i++)
         {
             const int ix = i + xmin;
@@ -1596,22 +1591,28 @@ void CPlotter::draw(bool newData)
             if (fillMarkers && (ix) > minMarker && (ix) < maxMarker) {
                 abPolygon << QPointF(ixPlot, yFill);
             }
-            if (m_FftFill && m_PlotMode != PLOT_MODE_HISTOGRAM)
-            {
-                underPolygon << QPointF(ixPlot, yFill);
-            }
-            if (m_PlotMode == PLOT_MODE_FILLED)
-            {
-                avgMaxPolygon << m_maxLineBuf[i];
-            }
+            yFillMin = std::min(yFillMin, qRound(yFill));
+            yFillMax = std::max(yFillMax, qRound(yFill));
+            yInnerFillMin = std::min(yFillMin, qRound(yMaxD));
+            yInnerFillMax = std::max(yFillMax, qRound(yAvgD));
         }
 
-        if (!underPolygon.isEmpty())
+        if (m_FftFill && m_PlotMode != PLOT_MODE_HISTOGRAM)
         {
-            underPolygon << QPointF(underPolygon.last().x(), plotHeight);
-            underPolygon << QPointF(underPolygon.first().x(), plotHeight);
-            painter2.setBrush(fillBrush);
-            painter2.drawPolygon(underPolygon);
+            painter2.setPen(QPen(m_FftFillCol));
+            for (int y = yFillMin; y < yFillMax; y++)
+            {
+                for (i = 0; i < npts; i++)
+                {
+                    const int ix = i + xmin;
+                    const QPointF point = m_PlotMode == PLOT_MODE_MAX ? m_maxLineBuf[i] : m_avgLineBuf[i];
+                    const int yFill = qRound(point.y());
+                    if (yFill < y) {
+                        painter2.drawPoint(QPoint(ix, y));
+                    }
+                }
+            }
+            painter2.fillRect(QRect(xmin, yFillMax, npts, plotHeight - yFillMax), QBrush(m_FftFillCol));
         }
 
         if (!abPolygon.isEmpty())
@@ -1662,14 +1663,21 @@ void CPlotter::draw(bool newData)
             m_MinHoldValid = true;
         }
 
-        if (!avgMaxPolygon.isEmpty())
+        if (m_PlotMode == PLOT_MODE_FILLED)
         {
-            for (i = npts - 1; i >= 0; i--)
+            painter2.setPen(QPen(m_FilledModeFillCol));
+            for (int y = yInnerFillMin; y < yInnerFillMax; y++)
             {
-                avgMaxPolygon << m_avgLineBuf[i];
+                for (i = 0; i < npts; i++)
+                {
+                    const int ix = i + xmin;
+                    const int yMax = qRound(m_maxLineBuf[i].y());
+                    const int yAvg = qRound(m_maxLineBuf[i].y());
+                    if (yMax < y && y < yAvg) {
+                        painter2.drawPoint(QPoint(ix, y));
+                    }
+                }
             }
-            painter2.setBrush(maxFillBrush);
-            painter2.drawPolygon(avgMaxPolygon);
         }
 
         if (doMaxLine)

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -253,6 +253,7 @@ private:
     QPointF     m_avgLineBuf[MAX_SCREENSIZE]{};
     QPointF     m_maxLineBuf[MAX_SCREENSIZE]{};
     QPointF     m_holdLineBuf[MAX_SCREENSIZE]{};
+    QLineF      m_fillLineBuf[MAX_SCREENSIZE]{};
     float       m_histMaxIIR;
     std::vector<float> m_fftIIR;
     std::vector<float> m_fftData;

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -253,7 +253,6 @@ private:
     QPointF     m_avgLineBuf[MAX_SCREENSIZE]{};
     QPointF     m_maxLineBuf[MAX_SCREENSIZE]{};
     QPointF     m_holdLineBuf[MAX_SCREENSIZE]{};
-    QLineF      m_fillLineBuf[MAX_SCREENSIZE]{};
     float       m_histMaxIIR;
     std::vector<float> m_fftIIR;
     std::vector<float> m_fftData;


### PR DESCRIPTION
fixes #1386

something about the polygon fills is not super efficient. i would imagine there is some sort of flood filling happening which is overkill since we know each pixels state. for this reason, i used drawPixel. i also go left to right row by row since that has the best performance. i also made the fill below a fillRect which is efficient for bulk regions.

<img width="941" alt="image" src="https://github.com/user-attachments/assets/4ffb497c-016d-4626-87f8-c61794262cb2">

UPDATE:
used vertical lines instead
