### PR TITLE
Fix waterfall tooltips and click to restore view

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -308,6 +308,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(ui->plotter, SIGNAL(newSize()), this, SLOT(setWfSize()));
     connect(ui->plotter, SIGNAL(markerSelectA(qint64)), this, SLOT(setMarkerA(qint64)));
     connect(ui->plotter, SIGNAL(markerSelectB(qint64)), this, SLOT(setMarkerB(qint64)));
+    connect(ui->plotter, SIGNAL(newCenterFrequency(qint64)), this, SLOT(setNewFrequency(qint64)));
 
     // Bookmarks
     connect(uiDockBookmarks, SIGNAL(newBookmarkActivated(qint64, QString, int)), this, SLOT(onBookmarkActivated(qint64, QString, int)));

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -341,12 +341,10 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                 tt.setMSecsSinceEpoch(ms);
                 QString timeStr = tt.toString("yyyy.MM.dd hh:mm:ss.zzz");
                 const qreal ratio = (qreal) px / (qreal) w;
-                const qint64 centerFrequency = waterfallEntry.m_CenterFreq;
-                const qint64 fftCenterFrequency = waterfallEntry.m_FftCenter;
-                const qint64 halfSpan = waterfallEntry.m_Span / 2;
-                const qint64 maxFrequency = centerFrequency + fftCenterFrequency + halfSpan;
-                const qint64 minFrequency =  centerFrequency + fftCenterFrequency - halfSpan;
-                const qreal frequencySpan = maxFrequency - minFrequency;
+                const qint64 centerFrequency = waterfallEntry.m_CenterFreq + waterfallEntry.m_FftCenter;
+                const qint64 frequencySpan = waterfallEntry.m_Span;
+                const qint64 maxFrequency = centerFrequency + frequencySpan / 2;
+                const qint64 minFrequency =  centerFrequency - frequencySpan / 2;
                 const qreal kHz = (minFrequency + ratio * frequencySpan) / 1.e3;
                 showToolTip(event, QString("%1\n%2 kHz").arg(timeStr).arg(kHz, 0, 'f', 3));
             }

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -735,7 +735,7 @@ void CPlotter::mousePressEvent(QMouseEvent * event)
                         {
                             emit newCenterFrequency(waterfallEntry.m_CenterFreq + (m_DemodCenterFreq - m_CenterFreq));
                         }
-                        m_DemodCenterFreq = xFromWaterfallEntry(waterfallEntry, px);
+                        m_DemodCenterFreq = roundFreq(xFromWaterfallEntry(waterfallEntry, px), m_ClickResolution);
                         bool invalidate = false;
                         if (m_FftCenter != waterfallEntry.m_FftCenter)
                         {

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -326,30 +326,30 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
         }
         if (m_TooltipsEnabled)
         {
-            int dy = py - h;
-            int realOffset = m_WaterfallOffset + dy;
-            int waterfallHeight = m_WaterfallImage.height();
-            if (realOffset >= waterfallHeight)
+            const int dy = py - h;
+            const int waterfallHeight = m_WaterfallImage.height();
+            int idx = m_WaterfallOffset + dy;
+            if (idx >= waterfallHeight)
             {
-                realOffset -= waterfallHeight;
+                idx -= waterfallHeight;
             }
-            WaterfallEntry waterfallEntry = m_WaterfallEntries[realOffset];
-            const quint64 line_ms = waterfallEntry.ms;
-            if (line_ms > 0)
+            const WaterfallEntry waterfallEntry = m_WaterfallEntries[idx];
+            const quint64 ms = waterfallEntry.ms;
+            if (ms > 0)
             {
                 QDateTime tt;
-                tt.setMSecsSinceEpoch(line_ms);
+                tt.setMSecsSinceEpoch(ms);
                 QString timeStr = tt.toString("yyyy.MM.dd hh:mm:ss.zzz");
                 const qreal ratio = (qreal) px / (qreal) w;
                 const qint64 maxFrequency = waterfallEntry.maxFrequency;
                 const qint64 minFrequency =  waterfallEntry.minFrequency;
                 const qreal frequencySpan = maxFrequency - minFrequency;
-                const qreal kiloHz = (minFrequency + ratio * frequencySpan) / 1.e3;
-                showToolTip(event, QString("%1\n%2 kHz").arg(timeStr).arg(kiloHz, 0, 'f', 3));
+                const qreal kHz = (minFrequency + ratio * frequencySpan) / 1.e3;
+                showToolTip(event, QString("%1\n%2 kHz").arg(timeStr).arg(kHz, 0, 'f', 3));
             }
             else
             {
-                showToolTip(event, "[time not valid]");
+                QToolTip::hideText();
             }
         }
     }

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -333,7 +333,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                 QDateTime tt;
                 tt.setMSecsSinceEpoch(ms);
                 QString timeStr = tt.toString("yyyy.MM.dd hh:mm:ss.zzz");
-                const qreal kHz = xFromWaterfallEntry(waterfallEntry, px) / 1.e3;
+                const qreal kHz = waterfallFreqFromX(waterfallEntry, px) / 1.e3;
                 showToolTip(event, QString("%1\n%2 kHz").arg(timeStr).arg(kHz, 0, 'f', 3));
             }
             else
@@ -639,7 +639,7 @@ void CPlotter::mousePressEvent(QMouseEvent * event)
             {
                 emit newCenterFrequency(waterfallEntry.m_CenterFreq + (m_DemodCenterFreq - m_CenterFreq));
             }
-            m_DemodCenterFreq = roundFreq(xFromWaterfallEntry(waterfallEntry, px), m_ClickResolution);
+            m_DemodCenterFreq = roundFreq(waterfallFreqFromX(waterfallEntry, px), m_ClickResolution);
             bool invalidate = false;
             if (m_FftCenter != waterfallEntry.m_FftCenter)
             {
@@ -2366,7 +2366,7 @@ WaterfallEntry CPlotter::getWaterfallEntry(int waterfallY)
     return m_WaterfallEntries[idx];
 }
 
-qint64 CPlotter::xFromWaterfallEntry(WaterfallEntry waterfallEntry, int x) {
+qint64 CPlotter::waterfallFreqFromX(WaterfallEntry waterfallEntry, int x) {
     const qreal ratio = (qreal) x / (qreal) m_WaterfallImage.width();
     const qint64 centerFrequency = waterfallEntry.m_CenterFreq + waterfallEntry.m_FftCenter;
     const qint64 frequencySpan = waterfallEntry.m_Span;

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1064,7 +1064,7 @@ void CPlotter::resizeEvent(QResizeEvent* )
         if (wfHeight == 0)
         {
             m_WaterfallImage = QImage();
-            m_WaterfallEntries.clear();
+            m_WaterfallEntries = std::vector<WaterfallEntry>(0);
         }
 
         // New waterfall, create blank area
@@ -1073,8 +1073,7 @@ void CPlotter::resizeEvent(QResizeEvent* )
             m_WaterfallImage.setDevicePixelRatio(m_DPR);
             m_WaterfallImage.fill(Qt::black);
             m_WaterfallOffset = wfHeight;
-            m_WaterfallEntries.clear();
-            m_WaterfallEntries.reserve(wfHeight);
+            m_WaterfallEntries = std::vector<WaterfallEntry>(wfHeight);
         }
 
         // Existing waterfall, rescale width but no height as that would

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -728,15 +728,33 @@ void CPlotter::mousePressEvent(QMouseEvent * event)
                     if (dy > 0)
                     {
                         const WaterfallEntry waterfallEntry = getWaterfallEntry(dy);
-                        if (waterfallEntry.m_TimestampMs == 0 || waterfallEntry.m_CenterFreq != m_CenterFreq) 
+                        if (waterfallEntry.m_TimestampMs == 0)
                         {
                             return;
                         }
-                        m_Span = waterfallEntry.m_Span;
-                        m_FftCenter = waterfallEntry.m_FftCenter;
+                        if (m_CenterFreq != waterfallEntry.m_CenterFreq)
+                        {
+                            emit newCenterFrequency(waterfallEntry.m_CenterFreq + (m_DemodCenterFreq - m_CenterFreq));
+                        }
                         m_DemodCenterFreq = xFromWaterfallEntry(waterfallEntry, px);
-                        double zoom = (double)m_SampleFreq / (double)m_Span;
-                        emit newZoomLevel(zoom);
+                        bool invalidate = false;
+                        if (m_FftCenter != waterfallEntry.m_FftCenter)
+                        {
+                            invalidate = true;
+                            m_FftCenter = waterfallEntry.m_FftCenter;
+                        }
+                        if (m_Span != waterfallEntry.m_Span)
+                        {
+                            invalidate = true;
+                            m_Span = waterfallEntry.m_Span;
+                            double zoom = (double)m_SampleFreq / (double)m_Span;
+                            emit newZoomLevel(zoom);
+                        }
+                        if (invalidate) {
+                            m_MaxHoldValid = false;
+                            m_MinHoldValid = false;
+                            m_histIIRValid = false;
+                        }
                     }
                     else
                     {

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -735,6 +735,8 @@ void CPlotter::mousePressEvent(QMouseEvent * event)
                         m_Span = waterfallEntry.m_Span;
                         m_FftCenter = waterfallEntry.m_FftCenter;
                         m_DemodCenterFreq = xFromWaterfallEntry(waterfallEntry, px);
+                        double zoom = (double)m_SampleFreq / (double)m_Span;
+                        emit newZoomLevel(zoom);
                     }
                     else
                     {

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -169,7 +169,6 @@ CPlotter::CPlotter(QWidget *parent) : QFrame(parent)
     tlast_wf_ms = 0;
     tlast_plot_drawn_ms = 0;
     tlast_wf_drawn_ms = 0;
-    wf_valid_since_ms = 0;
     msec_per_wfline = 0;
     tlast_peaks_ms = 0;
     wf_epoch = 0;
@@ -602,7 +601,6 @@ void CPlotter::setWaterfallSpan(quint64 span_ms)
         wf_count = 0;
         msec_per_wfline = (double)wf_span / (qreal)m_WaterfallImage.height();
     }
-    wf_valid_since_ms = tnow;
     clearWaterfallBuf();
 }
 
@@ -625,7 +623,6 @@ quint64 CPlotter::getWfTimeRes() const
 void CPlotter::setFftRate(int rate_hz)
 {
     fft_rate = rate_hz;
-    wf_valid_since_ms = QDateTime::currentMSecsSinceEpoch();
     clearWaterfallBuf();
 }
 
@@ -1441,8 +1438,6 @@ void CPlotter::draw(bool newData)
 
             // cursor times are relative to last time drawn
             tlast_wf_ms = tnow_ms;
-            if (wf_valid_since_ms == 0)
-                wf_valid_since_ms = tnow_ms;
             tlast_wf_drawn_ms = tnow_ms;
 
             // move the offset "up"
@@ -2335,23 +2330,6 @@ qint64 CPlotter::freqFromX(int x)
     qint64 f = qRound64((double)m_CenterFreq + (double)m_FftCenter
                         - (double)m_Span / 2.0 + ratio * (double)m_Span);
     return f;
-}
-
-/** Calculate time offset of a given line on the waterfall */
-quint64 CPlotter::msecFromY(int y)
-{
-    int h = m_OverlayPixmap.height();
-
-    // ensure we are in the waterfall region
-    if (y < h)
-        return 0;
-
-    qreal dy = (qreal)y - (qreal)h;
-
-    if (msec_per_wfline > 0)
-        return tlast_wf_drawn_ms - dy * msec_per_wfline;
-    else
-        return tlast_wf_drawn_ms - dy * getWfTimeRes();
 }
 
 // Round frequency to click resolution value

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -334,15 +334,18 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                 idx -= waterfallHeight;
             }
             const WaterfallEntry waterfallEntry = m_WaterfallEntries[idx];
-            const quint64 ms = waterfallEntry.ms;
+            const quint64 ms = waterfallEntry.m_TimestampMs;
             if (ms > 0)
             {
                 QDateTime tt;
                 tt.setMSecsSinceEpoch(ms);
                 QString timeStr = tt.toString("yyyy.MM.dd hh:mm:ss.zzz");
                 const qreal ratio = (qreal) px / (qreal) w;
-                const qint64 maxFrequency = waterfallEntry.maxFrequency;
-                const qint64 minFrequency =  waterfallEntry.minFrequency;
+                const qint64 centerFrequency = waterfallEntry.m_CenterFreq;
+                const qint64 fftCenterFrequency = waterfallEntry.m_FftCenter;
+                const qint64 halfSpan = waterfallEntry.m_Span / 2;
+                const qint64 maxFrequency = centerFrequency + fftCenterFrequency + halfSpan;
+                const qint64 minFrequency =  centerFrequency + fftCenterFrequency - halfSpan;
                 const qreal frequencySpan = maxFrequency - minFrequency;
                 const qreal kHz = (minFrequency + ratio * frequencySpan) / 1.e3;
                 showToolTip(event, QString("%1\n%2 kHz").arg(timeStr).arg(kHz, 0, 'f', 3));
@@ -1448,9 +1451,10 @@ void CPlotter::draw(bool newData)
             // draw black areas where data will not be drawn
             memset(m_WaterfallImage.scanLine(m_WaterfallOffset), 0, m_WaterfallImage.bytesPerLine());
             WaterfallEntry& waterfallEntry = m_WaterfallEntries[m_WaterfallOffset];
-            waterfallEntry.ms = tnow_ms;
-            waterfallEntry.minFrequency = getMinFrequency();
-            waterfallEntry.maxFrequency = getMaxFrequency();
+            waterfallEntry.m_TimestampMs = tnow_ms;
+            waterfallEntry.m_CenterFreq = m_CenterFreq;
+            waterfallEntry.m_FftCenter = m_FftCenter;
+            waterfallEntry.m_Span = m_Span;
 
             const bool useWfBuf = msec_per_wfline > 0;
             float _lineFactor;

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -658,6 +658,10 @@ void CPlotter::mousePressEvent(QMouseEvent * event)
                 m_MinHoldValid = false;
                 m_histIIRValid = false;
             }
+            emit newDemodFreq(m_DemodCenterFreq, m_DemodCenterFreq - m_CenterFreq);
+            m_CursorCaptured = CENTER;
+            m_GrabPosition = 1;
+            updateOverlay();
         }
         else
         {

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -869,7 +869,7 @@ void CPlotter::zoomStepX(float step, int x)
     // Explicitly set m_Span instead of calling setSpanFreq(), which also calls
     // setFftCenterFreq() and updateOverlay() internally. Span needs to be set
     // before frequency limits can be checked in setFftCenterFreq().
-    m_Span = new_span;
+    m_Span = new_span_int;
     setFftCenterFreq(qRound64((f_max + f_min) / 2.0f));
 
     m_MaxHoldValid = false;
@@ -1987,8 +1987,8 @@ void CPlotter::drawOverlay()
         static const qreal nLevels = h / (levelHeight + slant);
         if (m_BookmarksEnabled)
         {
-            tags = Bookmarks::Get().getBookmarksInRange(m_CenterFreq + m_FftCenter - m_Span / 2,
-                                                        m_CenterFreq + m_FftCenter + m_Span / 2);
+            tags = Bookmarks::Get().getBookmarksInRange(getMinFrequency(),
+                                                        getMaxFrequency());
         }
         else
         {
@@ -1996,8 +1996,8 @@ void CPlotter::drawOverlay()
         }
         if (m_DXCSpotsEnabled)
         {
-            QList<DXCSpotInfo> dxcspots = DXCSpots::Get().getDXCSpotsInRange(m_CenterFreq + m_FftCenter - m_Span / 2,
-                                                                             m_CenterFreq + m_FftCenter + m_Span / 2);
+            QList<DXCSpotInfo> dxcspots = DXCSpots::Get().getDXCSpotsInRange(getMinFrequency(),
+                                                                             getMaxFrequency());
             QListIterator<DXCSpotInfo> iter(dxcspots);
             while(iter.hasNext())
             {
@@ -2059,8 +2059,8 @@ void CPlotter::drawOverlay()
 
     if (m_BandPlanEnabled)
     {
-        QList<BandInfo> bands = BandPlan::Get().getBandsInRange(m_CenterFreq + m_FftCenter - m_Span / 2,
-                                                                m_CenterFreq + m_FftCenter + m_Span / 2);
+        QList<BandInfo> bands = BandPlan::Get().getBandsInRange(getMinFrequency(),
+                                                                getMaxFrequency());
 
         m_BandPlanHeight = metrics.height() + VER_MARGIN;
         for (auto & band : bands)
@@ -2125,7 +2125,7 @@ void CPlotter::drawOverlay()
     }
 
     // Frequency grid
-    qint64  StartFreq = m_CenterFreq + m_FftCenter - m_Span / 2;
+    qint64  StartFreq = getMinFrequency();
     QString label;
     label.setNum(float((StartFreq + m_Span) / m_FreqUnits), 'f', m_FreqDigits);
     calcDivSize(StartFreq, StartFreq + m_Span,

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -724,7 +724,6 @@ void CPlotter::mousePressEvent(QMouseEvent * event)
                 // left-click with no modifiers: set center frequency
                 else if (mods == 0) {
                     const int dy = py - h;
-                    
                     if (dy > 0)
                     {
                         const WaterfallEntry waterfallEntry = getWaterfallEntry(dy);

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -234,6 +234,8 @@ private:
     qint64      freqFromX(int x);
     void        zoomStepX(float factor, int x);
     static qint64      roundFreq(qint64 freq, int resolution);
+    WaterfallEntry     getWaterfallEntry(int waterfallY);
+    qint64      xFromWaterfallEntry(WaterfallEntry waterfallEntry, int x);
     void        clampDemodParameters();
     static QColor      blend(QColor base, QColor over, int alpha255)
     {

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -213,6 +213,14 @@ private:
         MARKER_B
     };
 
+    qint64 getMinFrequency() const {
+        return m_CenterFreq + m_FftCenter - m_Span / 2;
+    }
+
+    qint64 getMaxFrequency() const {
+        return m_CenterFreq + m_FftCenter + m_Span / 2;
+    }
+
     void        drawOverlay();
     void        makeFrequencyStrs();
     int         xFromFreq(qint64 freq);

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -22,6 +22,12 @@
 
 #define MARKER_OFF std::numeric_limits<qint64>::min()
 
+struct WaterfallEntry {
+    quint64 ms;
+    qint64 minFrequency;
+    qint64 maxFrequency;
+};
+
 class CPlotter : public QFrame
 {
     Q_OBJECT
@@ -281,6 +287,7 @@ private:
     QPixmap     m_PeakPixmap;
     QImage      m_WaterfallImage;
     int         m_WaterfallOffset;
+    std::vector<WaterfallEntry>  m_WaterfallEntries;
     QColor      m_ColorTbl[256];
     QSize       m_Size;
     qreal       m_DPR{};

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -110,6 +110,8 @@ public:
         if (rate > 0.0f)
         {
             m_SampleFreq = rate;
+            m_WaterfallEntries.clear();
+            m_WaterfallEntries.reserve(m_WaterfallImage.height());
             updateOverlay();
         }
     }

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -165,6 +165,7 @@ signals:
     void newSize();
     void markerSelectA(qint64 freq);
     void markerSelectB(qint64 freq);
+    void newCenterFrequency(qint64 freq);
 
 public slots:
     // zoom functions

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -237,7 +237,7 @@ private:
     void        zoomStepX(float factor, int x);
     static qint64      roundFreq(qint64 freq, int resolution);
     WaterfallEntry     getWaterfallEntry(int waterfallY);
-    qint64      xFromWaterfallEntry(WaterfallEntry waterfallEntry, int x);
+    qint64      waterfallFreqFromX(WaterfallEntry waterfallEntry, int x);
     void        clampDemodParameters();
     static QColor      blend(QColor base, QColor over, int alpha255)
     {

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -233,7 +233,6 @@ private:
     qint64      freqFromX(int x);
     void        zoomStepX(float factor, int x);
     static qint64      roundFreq(qint64 freq, int resolution);
-    quint64     msecFromY(int y);
     void        clampDemodParameters();
     static QColor      blend(QColor base, QColor over, int alpha255)
     {
@@ -367,7 +366,6 @@ private:
     quint64     tlast_wf_ms;        // last time waterfall has been updated
     quint64     tlast_plot_drawn_ms;// last time the plot was drawn
     quint64     tlast_wf_drawn_ms;  // last time waterfall was drawn
-    quint64     wf_valid_since_ms;  // last time before action that invalidates time line
     double      msec_per_wfline{};  // milliseconds between waterfall updates
     quint64     wf_epoch;           // msec time of last waterfal rate change
     quint64     wf_count;           // waterfall lines drawn since last rate change

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -110,8 +110,7 @@ public:
         if (rate > 0.0f)
         {
             m_SampleFreq = rate;
-            m_WaterfallEntries.clear();
-            m_WaterfallEntries.reserve(m_WaterfallImage.height());
+            m_WaterfallEntries = std::vector<WaterfallEntry>(m_WaterfallImage.height());
             updateOverlay();
         }
     }

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -23,9 +23,10 @@
 #define MARKER_OFF std::numeric_limits<qint64>::min()
 
 struct WaterfallEntry {
-    quint64 ms;
-    qint64 minFrequency;
-    qint64 maxFrequency;
+    quint64 m_TimestampMs;
+    qint64 m_CenterFreq;
+    qint64 m_FftCenter;
+    qint64 m_Span;
 };
 
 class CPlotter : public QFrame


### PR DESCRIPTION
- the waterfall tooltips were misleading when the view changed. they were only accurate for the current view. the solution is to store the view parameters (center, fft center, span) and timestamp to properly construct the tooltip's time and frequency.
- since that data is now stored, it is pretty easy to restore the view if the user were to click on a point on the waterfall. currently, clicking on the waterfall changes the demod frequency.
- the datapoints are stored in a vector of structs. the same circular buffer implementation that the waterfall image uses is used as well.
- the waterfall used to invalidate when the lookback range changed, but since the timestamp is stored for each row that is not needed. also if the DSP was disabled then reenabled, that would seamlessly keep track of the history (with a discontinuity in the timeseries).
- the only thing which causes the timeseries to invalidate is if the sample rate of the DSP were to change. this is because we cannot faithfully or safely restore the view when a user clicks.
fixes #554