### PR TITLE
Fix create tag context menu from bookmark dock

### DIFF
--- a/src/qtgui/bookmarkstaglist.cpp
+++ b/src/qtgui/bookmarkstaglist.cpp
@@ -23,6 +23,7 @@
 #include "bookmarkstaglist.h"
 #include "bookmarks.h"
 #include <QColorDialog>
+#include <QInputDialog>
 #include <stdio.h>
 #include <QMenu>
 #include <QHeaderView>
@@ -247,9 +248,14 @@ bool BookmarksTagList::RenameSelectedTag()
 
 void BookmarksTagList::AddNewTag()
 {
-    AddTag("*new*");
-    scrollToBottom();
-    editItem(item(rowCount()-1, 1));
+    bool ok;
+    QString text = QInputDialog::getText(this, "Create New Tag", "Tag Name:",
+        QLineEdit::Normal, "*new*", &ok);
+    if (ok && !text.isEmpty())
+    {
+        Bookmarks::Get().findOrAddTag(text);
+        updateTags();
+    }
 }
 
 void BookmarksTagList::AddTag(QString name, Qt::CheckState checkstate, QColor color)


### PR DESCRIPTION
defect: when using the create tag context menu option from the bookmarks dock, the new tag is not visible in the new bookmark dialog or the edit tags (when a bookmark is double clicked). i believe this is because the editing of tags is disabled currently. that would have ordinarily saved the tag, but instead that tag goes into limbo now.

fix: use a dedicated input dialog for the new tag instead of the editing of a new table row.