### PR TITLE
Rebuild DDC block when sample rate changes

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -8,6 +8,7 @@
   IMPROVED: Reduced CPU utilization of plot and waterfall display.
   IMPROVED: Display and formatting of RDS data.
      FIXED: Decoding of RDS flags.
+     FIXED: Incorrect channel filter offset, for some devices.
    CHANGED: x86 DMG release requires macOS 13.7 or later.
 
 

--- a/src/dsp/downconverter.cpp
+++ b/src/dsp/downconverter.cpp
@@ -54,14 +54,13 @@ downconverter_cc::~downconverter_cc()
 void downconverter_cc::set_decim_and_samp_rate(unsigned int decim, double samp_rate)
 {
     d_samp_rate = samp_rate;
-    if (decim != d_decim)
-    {
-        d_decim = decim;
-        lock();
-        disconnect_all();
-        connect_all();
-        unlock();
-    }
+    d_decim = decim;
+
+    lock();
+    disconnect_all();
+    connect_all();
+    unlock();
+
     update_proto_taps();
     update_phase_inc();
 }


### PR DESCRIPTION
`downconverter_cc::set_decim_and_samp_rate` currently skips rebuilding the DDC block if the decimation value has not changed. This leads to trouble, because it's possible for the sample rate to change while the decimation value remains the same. In this case, a new `freq_xlating_fir_filter_ccf` needs to be constructed, but that doesn't happen.

To trigger the bug, open an RTL-SDR device through SoapyRTLSDR, and set the sample rate to 2400000. Clicking on a signal will not tune it, because the Frequency Xlating FIR Filter block has its sample rate set to 2048000, the default value used by the SoapyRTLSDR driver.

To fix the problem, I changed `downconverter_cc::set_decim_and_samp_rate` to always rebuild the DDC block, thereby constructing a new Frequency Xlating FIR Filter block.