### PR TITLE
have playback stop at eof instead of waterfall smear

### DIFF
--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -303,6 +303,16 @@ void CIqTool::timeoutFunction(void)
             ui->slider->blockSignals(false);
             refreshTimeWidgets();
         }
+        else
+        {
+            emit stopPlayback();
+            ui->listWidget->setEnabled(true);
+            ui->recButton->setEnabled(true);
+            ui->slider->setValue(0);
+            ui->playButton->setChecked(false);
+            is_playing = false;
+            refreshTimeWidgets();
+        }
     }
     if (is_recording)
         refreshTimeWidgets();


### PR DESCRIPTION
I added logic to the IQ playback tool to stop playback when we hit eof to stop the smeared waterfall.

This is my first work on GQRX so I started simple.   Please let me know if there is more in the PR review process.