### PR TITLE
Added remote control commands for IQ recording

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -114,9 +114,6 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     rx = new receiver("", "", 1);
     rx->set_rf_freq(144500000.0);
 
-    // remote controller
-    remote = new RemoteControl();
-
     /* meter timer */
     meter_timer = new QTimer(this);
     connect(meter_timer, SIGNAL(timeout()), this, SLOT(meterTimeout()));
@@ -140,6 +137,10 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
 
     // create I/Q tool widget
     iq_tool = new CIqTool(this);
+
+    // remote controller
+    remote = new RemoteControl();
+    remote->iq_tool = iq_tool;
 
     // create DXC Objects
     dxc_options = new DXCOptions(this);

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -929,8 +929,8 @@ QString RemoteControl::cmd_AOIQ()
 {
     if (rc_mode > 0 && receiver_running)
     {
-        // here
-        emit iq_tool->startRecording();
+        iq_tool->show();
+        iq_tool->remoteRecordingCmd(true);
         iq_recorder_status = true;
     }
     return QString("RPRT 0\n");
@@ -939,7 +939,7 @@ QString RemoteControl::cmd_AOIQ()
 /* Gpredict / Gqrx specific command: LOIQ - satellite LOIQ event */
 QString RemoteControl::cmd_LOIQ()
 {
-    emit iq_tool->stopRecording();
+    iq_tool->remoteRecordingCmd(false);
     iq_recorder_status = false;
     return QString("RPRT 0\n");
 }

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -50,7 +50,7 @@ RemoteControl::RemoteControl(QObject *parent) :
     squelch_level = -150.0;
     audio_gain = -6.0;
     audio_recorder_status = false;
-    iq_recorder_status = true;
+    iq_recorder_status = false;
     receiver_running = false;
     hamlib_compatible = false;
     is_audio_muted = false;

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -62,7 +62,6 @@ class RemoteControl : public QObject
     Q_OBJECT
 public:
     explicit RemoteControl(QObject *parent = 0);
-    //RemoteControl(CIqTool *iq_tool);
     ~RemoteControl();
 
     void start_server(void);

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -156,7 +156,7 @@ private:
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);
     QString     intToModeStr(int mode);
-    
+
     /* RC commands */
     QString     cmd_get_freq() const;
     QString     cmd_set_freq(QStringList cmdlist);

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -33,6 +33,7 @@
 
 /* For gain_t and gain_list_t */
 #include "qtgui/dockinputctl.h"
+#include "qtgui/iq_tool.h"
 
 /*! \brief Simple TCP server for remote control.
  *
@@ -61,6 +62,7 @@ class RemoteControl : public QObject
     Q_OBJECT
 public:
     explicit RemoteControl(QObject *parent = 0);
+    //RemoteControl(CIqTool *iq_tool);
     ~RemoteControl();
 
     void start_server(void);
@@ -82,6 +84,8 @@ public:
     }
     void setReceiverStatus(bool enabled);
     void setGainStages(gain_list_t &gain_list);
+    CIqTool*    iq_tool;
+
 
 public slots:
     void setNewFrequency(qint64 freq);
@@ -144,6 +148,7 @@ private:
     QString     rds_station;       /*!< RDS program service (station) name */
     QString     rds_radiotext;     /*!< RDS Radiotext */
     bool        audio_recorder_status; /*!< Recording enabled */
+    bool        iq_recorder_status; /*!< IQ Recording enabled */
     bool        receiver_running;  /*!< Whether the receiver is running or not */
     bool        hamlib_compatible;
     gain_list_t gains;             /*!< Possible and current gain settings */
@@ -152,7 +157,7 @@ private:
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);
     QString     intToModeStr(int mode);
-
+    
     /* RC commands */
     QString     cmd_get_freq() const;
     QString     cmd_set_freq(QStringList cmdlist);
@@ -170,6 +175,8 @@ private:
     QString     cmd_get_param(QStringList cmdlist);
     QString     cmd_AOS();
     QString     cmd_LOS();
+    QString     cmd_AOIQ();
+    QString     cmd_LOIQ();
     QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;
 };

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -210,6 +210,24 @@ void CIqTool::cancelRecording()
     is_recording = false;
 }
 
+void CIqTool::remoteRecordingCmd(bool checked)
+{
+
+    if (checked)
+    {
+        show();
+        ui->recButton->setChecked(true);
+        on_recButton_clicked(checked);
+    }
+    else
+    {
+        on_recButton_clicked(checked);
+        ui->recButton->setChecked(false);
+        hide();
+    }
+
+}
+
 /*! \brief Catch window close events.
  *
  * This method is called when the user closes the audio options dialog

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -141,6 +141,15 @@ void CIqTool::on_playButton_clicked(bool checked)
     }
 }
 
+/*! \brief wrapper for startRecording to not need access to private attributes.
+*/
+void CIqTool::startRecording()
+{
+
+    emit startRecording(recdir->path(), ui->formatCombo->currentText());
+
+}
+
 /*! \brief Cancel playback.
  *
  * This slot can be activated to cancel an ongoing playback.

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -141,15 +141,6 @@ void CIqTool::on_playButton_clicked(bool checked)
     }
 }
 
-/*! \brief wrapper for startRecording to not need access to private attributes.
-*/
-void CIqTool::startRecording()
-{
-
-    emit startRecording(recdir->path(), ui->formatCombo->currentText());
-
-}
-
 /*! \brief Cancel playback.
  *
  * This slot can be activated to cancel an ongoing playback.

--- a/src/qtgui/iq_tool.h
+++ b/src/qtgui/iq_tool.h
@@ -60,7 +60,6 @@ public:
 
     void saveSettings(QSettings *settings);
     void readSettings(QSettings *settings);
-    void startRecording();
     void remoteRecordingCmd(bool checked);
 
 signals:

--- a/src/qtgui/iq_tool.h
+++ b/src/qtgui/iq_tool.h
@@ -61,6 +61,7 @@ public:
     void saveSettings(QSettings *settings);
     void readSettings(QSettings *settings);
     void startRecording();
+    void remoteRecordingCmd(bool checked);
 
 signals:
     void startRecording(const QString recdir, const QString format);

--- a/src/qtgui/iq_tool.h
+++ b/src/qtgui/iq_tool.h
@@ -60,6 +60,7 @@ public:
 
     void saveSettings(QSettings *settings);
     void readSettings(QSettings *settings);
+    void startRecording();
 
 signals:
     void startRecording(const QString recdir, const QString format);


### PR DESCRIPTION
I expanded the remote control / telnet commands to include AOIQ and LOIQ to emulate the AOS and LOS commands to capture the IQ data instead of audio.   I connected the remote control commands to the IQ tool by making a public pointer in remote control point to the IQ tool.

I tested my changes by opening two shells and launching gqrx from the first shell and enabled TCP communications.  On the second shell, I then ran telnet and sent the AOIQ and LOIQ commands to GQRX, confirming RPRT 0 responses:

```
telnet 127.0.0.1 7356

Trying 127.0.0.1...

Connected to 127.0.0.1.

Escape character is '^]'.

AOIQ

RPRT 0

LOIQ

RPRT 0
```

I then checked that a .raw file was created where specified in the gqrx configuration, and that was indeed a collection of IQ data I was able to play back in GQRX to show functionality.