### PR TITLE
autorange mode for plotter

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -358,6 +358,8 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
 
     // enable frequency tooltips on FFT plot
     ui->plotter->setTooltipsEnabled(true);
+    ui->plotter->setTooltipsEnabled(false);     // +kai, to nervous on display
+    ui->plotter->m_autoRangeAllowed = true;     // rf plotter can do autorange
 
     // Create list of input devices. This must be done before the configuration is
     // restored because device probing might change the device configuration
@@ -537,9 +539,17 @@ bool MainWindow::loadConfig(const QString& cfgfile, bool check_crash,
     // main window settings
     if (restore_mainwindow)
     {
-        restoreGeometry(m_settings->value("gui/geometry",
-                                          saveGeometry()).toByteArray());
+        restoreGeometry(m_settings->value("gui/geometry", saveGeometry()).toByteArray());
         restoreState(m_settings->value("gui/state", saveState()).toByteArray());
+    }
+
+    /*
+     * Initialization plotter's auto range mode.
+     */
+    bool_val = m_settings->value("gui/autorange", false).toBool();
+    if (bool_val)
+    {
+       ui->plotter->setAutoRange(bool_val);
     }
 
     QString indev = m_settings->value("input/device", "").toString();
@@ -787,6 +797,8 @@ void MainWindow::storeSession()
     if (m_settings)
     {
         m_settings->setValue("input/frequency", ui->freqCtrl->getFrequency());
+        m_settings->setValue("gui/autorange", ui->plotter->m_autoRangeActive);      // save status of autorange mode
+        
         m_settings->setValue("fft/fft_center", ui->plotter->getFftCenterFreq());
 
         uiDockInputCtl->saveSettings(m_settings);

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -146,6 +146,11 @@ public:
         WATERFALL_MODE_SYNC = 2
     };
 
+    float   m_autoRange_noiseFloor;     // noisefloor for auto range
+    float   m_autoRange_minAvg;         // noisefloor for auto range
+    bool    m_autoRangeActive=true;     // auto range mode enabled
+    bool    m_autoRangeAllowed = false; // only RF plotter can do autorange
+
 signals:
     void newDemodFreq(qint64 freq, qint64 delta); /* delta is the offset from the center */
     void newLowCutFreq(int f);
@@ -181,6 +186,7 @@ public slots:
     void enableBandPlan(bool enable);
     void enableMarkers(bool enabled);
     void setMarkers(qint64 a, qint64 b);
+    void setAutoRange(bool enabled);
     void clearWaterfall();
     void updateOverlay();
 
@@ -256,6 +262,7 @@ private:
     float       m_histMaxIIR;
     std::vector<float> m_fftIIR;
     std::vector<float> m_fftData;
+    std::vector<float> m_fftCopy;           // for auto mode
     std::vector<float> m_X;                // scratch array of matching size for local calculation
     float      m_wfbuf[MAX_SCREENSIZE]{}; // used for accumulating waterfall data at high time spans
     float       m_fftMaxHoldBuf[MAX_SCREENSIZE]{};


### PR DESCRIPTION
Automatic estimation of noisefloor in spectrum, min for waterfall and panadapter is adjusted automatically, max uses the old delta (max-min).

- double click y-axis to enable/disable
- y-axis turns green
- autorange mode is rememberd in settings

Noise Floor detection a la Simon Brown, quote:
"A few weeks previously a reasonable logic was implemented for measuring the noise floor. Purists will not be happy - they rarely are, but it works for me. Take the output from the SDR radio, ignore 15% of the bandwidth at the high and low end of the output to avoid the ant-alias filtering, and we're left with a healthy 70% of the signal.
Now sort the FFT bins by value, take the mean of the lowest 10% and that's the noise floor."

Percent values are slightly different, a moving average is added over lowest bins and over time.