### PR TITLE
Move macOS builds to Conda

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,71 +85,28 @@ jobs:
           else
             echo "available=false" >> $GITHUB_OUTPUT;
           fi
-      - name: Install dependencies
-        run: |
-          uname -a
-          # for https://github.com/actions/runner-images/issues/9272
-          sudo chown -R runner:admin /usr/local/
-          brew update
-          brew install --HEAD librtlsdr
-          brew install airspy airspyhf boost dylibbundler gnuradio hackrf libbladerf libserialport portaudio pybind11 six soapyremote uhd qt@6 || true
-
-          cd /tmp
-          git clone https://github.com/analogdevicesinc/libiio.git
-          cd libiio
-          git checkout v0.26
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ..
-          make -j4
-          sudo make install
-
-          cd /tmp
-          git clone https://github.com/analogdevicesinc/libad9361-iio.git
-          cd libad9361-iio
-          mkdir build
-          cd build
-          cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release ..
-          make -j4
-          sudo make install
-
-          cd /tmp
-          git clone https://github.com/pothosware/SoapyPlutoSDR.git
-          cd SoapyPlutoSDR
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ..
-          make -j4
-          sudo make install
-
-          cd /tmp
-          sudo cp /Library/Frameworks/iio.framework/iio /usr/local/lib/libiio.dylib
-          sudo install_name_tool -id "/usr/local/lib/libiio.dylib" /usr/local/lib/libiio.dylib
-          sudo cp /Library/Frameworks/ad9361.framework/ad9361 /usr/local/lib/libad9361.dylib
-          sudo install_name_tool -id "/usr/local/lib/libad9361.dylib" /usr/local/lib/libad9361.dylib
-          sudo install_name_tool -delete_rpath /Library/Frameworks /usr/local/lib/libad9361.dylib
-          sudo install_name_tool -change @rpath/iio.framework/Versions/0.23/iio /usr/local/lib/libiio.dylib /usr/local/lib/libad9361.dylib
-          sudo install_name_tool -change @rpath/iio.framework/Versions/0.23/iio /usr/local/lib/libiio.dylib /usr/local/lib/SoapySDR/modules0.*/libPlutoSDRSupport.so
-          sudo install_name_tool -change @rpath/ad9361.framework/Versions/0.2/ad9361 /usr/local/lib/libad9361.dylib /usr/local/lib/SoapySDR/modules0.*/libPlutoSDRSupport.so
-
-          cd /tmp
-          git clone https://gitea.osmocom.org/sdr/gr-iqbal.git
-          cd gr-iqbal
-          git submodule update --init --recursive
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ..
-          make -j4
-          sudo make install
-
-          cd /tmp
-          git clone https://gitea.osmocom.org/sdr/gr-osmosdr.git
-          cd gr-osmosdr
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-Wno-register ..
-          LIBRARY_PATH=/usr/local/opt/icu4c/lib make -j4
-          sudo make install
+      - name: Install conda dependencies
+        id: setup-micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: gqrx
+          create-args: >-
+            c-compiler
+            cxx-compiler
+            cmake
+            make
+            pkg-config
+            gnuradio-core
+            gnuradio-osmosdr
+            libboost-devel
+            qt6-main
+            soapysdr
+            soapysdr-module-audio
+            soapysdr-module-lms7
+            soapysdr-module-plutosdr
+            soapysdr-module-remote
+            soapysdr-module-volk-converters
+            volk
       - name: Install Apple certificate
         if: ${{ steps.secret-check.outputs.available == 'true' }}
         env:
@@ -173,11 +130,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Configure
+        shell: bash -el {0}
         run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
       - name: Compile
         working-directory: build
         run: make -j4
       - name: Build app bundle
+        env:
+          CONDA_PREFIX: ${{ steps.setup-micromamba.outputs.environment-path }}
         run: ./macos_bundle.sh ${{ steps.secret-check.outputs.available }}
       - name: Notarize app bundle
         if: ${{ steps.secret-check.outputs.available == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,24 +72,26 @@ jobs:
         backend: [Portaudio, Gr-audio]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install dependencies
-        run: |
-          # for https://github.com/actions/runner-images/issues/9272
-          sudo chown -R runner:admin /usr/local/
-          brew update
-          brew install airspy boost gnuradio hackrf libbladerf librtlsdr pybind11 six uhd qt@6 || true
-
-          cd /tmp
-          git clone https://gitea.osmocom.org/sdr/gr-osmosdr.git
-          cd gr-osmosdr
-          mkdir build
-          cd build
-          cmake -DCMAKE_CXX_FLAGS=-Wno-register ..
-          LIBRARY_PATH=/usr/local/opt/icu4c/lib make -j4
-          sudo make install
+      - name: Install conda dependencies
+        id: setup-micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: gqrx
+          create-args: >-
+            c-compiler
+            cxx-compiler
+            cmake
+            make
+            pkg-config
+            gnuradio-core
+            gnuradio-osmosdr
+            libboost-devel
+            qt6-main
+            volk
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Configure
+        shell: bash -el {0}
         run: mkdir build && cd build && cmake -DOSX_AUDIO_BACKEND:STRING=${{ matrix.backend }} ..
       - name: Compile
         working-directory: build

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
        NEW: Start/stop I/Q recording via remote control.
   IMPROVED: Allow multiple simultaneous remote control connections.
+     FIXED: DMG release for ARM-based Macs fails to start.
      FIXED: Compilation error affecting MSVC.
 
 

--- a/src/applications/gqrx/main.cpp
+++ b/src/applications/gqrx/main.cpp
@@ -67,6 +67,7 @@ int main(int argc, char *argv[])
     {
         qputenv("SOAPY_SDR_PLUGIN_PATH", plugin_path.toUtf8());
         qputenv("SOAPY_SDR_ROOT", "/invalid");
+        qputenv("CONDA_PREFIX", "/invalid");
     }
 
     // setup controlport via environment variables


### PR DESCRIPTION
Fixes #1414.

Recent Gqrx builds fail to start on macOS, due to a problem with Homebrew's fftw package. Building Gqrx using Homebrew packages has been troublesome, so I'd like to switch over to using Conda packages instead. A wide variety of SDR packages are available, which will eliminate the need to build dependencies from source. Gqrx's AppImage releases are already built using Conda packages, so we'll also have one fewer package source to deal with.

Many thanks to @kgarrels, who did the heavy lifting and prototyped a Conda-based build. I cleaned up the prototype, and it appears to be running well. I would appreciate help with testing various SDR models on both Intel- and ARM-based Macs.

Disk images are available here: https://github.com/gqrx-sdr/gqrx/actions/runs/15242711733

