### PR TITLE
Add new remote command to adjust center frequency

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -5,6 +5,8 @@ Supported commands:
     Get frequency [Hz]
  F <frequency>
     Set frequency [Hz]
+ C <frequency>
+    Set center frequency [Hz]
  m
     Get demodulator mode and passband
  M <mode> [passband]

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -224,6 +224,8 @@ void RemoteControl::startRead()
             answer = cmd_get_freq();
         else if (cmd == "F")
             answer = cmd_set_freq(cmdlist);
+        else if (cmd == "C")
+            answer = cmd_set_center_freq(cmdlist);
         else if (cmd == "m")
             answer = cmd_get_mode();
         else if (cmd == "M")
@@ -357,6 +359,13 @@ void RemoteControl::setNewRemoteFreq(qint64 freq)
         emit newFrequency(freq);
     }
 
+    rc_freq = freq;
+}
+
+/*! \brief New remote center frequency received. */
+void RemoteControl::setNewRemoteCenterFreq(qint64 freq)
+{
+    emit newFrequency(freq);
     rc_freq = freq;
 }
 
@@ -616,6 +625,21 @@ QString RemoteControl::cmd_set_freq(QStringList cmdlist)
     if (ok)
     {
         setNewRemoteFreq((qint64)freq);
+        return QString("RPRT 0\n");
+    }
+
+    return QString("RPRT 1\n");
+}
+
+/* Set new center frequency */
+QString RemoteControl::cmd_set_center_freq(QStringList cmdlist)
+{
+    bool ok;
+    double freq = cmdlist.value(1, "ERR").toDouble(&ok);
+
+    if (ok)
+    {
+        setNewRemoteCenterFreq((qint64)freq);
         return QString("RPRT 0\n");
     }
 

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -157,12 +157,14 @@ private:
     bool        is_audio_muted;
 
     void        setNewRemoteFreq(qint64 freq);
+    void        setNewRemoteCenterFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);
     QString     intToModeStr(int mode);
 
     /* RC commands */
     QString     cmd_get_freq() const;
     QString     cmd_set_freq(QStringList cmdlist);
+    QString     cmd_set_center_freq(QStringList cmdlist);
     QString     cmd_get_mode();
     QString     cmd_set_mode(QStringList cmdlist);
     QString     cmd_get_level(QStringList cmdlist);


### PR DESCRIPTION
I sometimes use gqrx as a panadapter.  I want to sync the frequency of my ham radio with the center frequency of gqrx.  The F remote command to change frequency will just adjust the tuning line if the jump is small.  I do not want to wait until I get near the edge of the bandwidth before the center frequency changes.  I want it to stay centered.  I made a quick new command "C" that changes the center frequency every time.