### PR TITLE
Add ZMQ IQ Sink for sending IQ data externally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(PACKAGE ${PROJECT_NAME})
 
 ########### Main global variables ###########
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build, options are: Debug GProf Valgrind Release" FORCE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: Debug GProf Valgrind Release" FORCE)
 endif()
 
 set(BUILDTYPE ${CMAKE_BUILD_TYPE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(PACKAGE ${PROJECT_NAME})
 
 ########### Main global variables ###########
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: Debug GProf Valgrind Release" FORCE)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build, options are: Debug GProf Valgrind Release" FORCE)
 endif()
 
 set(BUILDTYPE ${CMAKE_BUILD_TYPE})
@@ -140,7 +140,7 @@ include(FindPkgConfig)
 find_package(Gnuradio-osmosdr REQUIRED)
 
 set(GR_REQUIRED_COMPONENTS RUNTIME ANALOG AUDIO BLOCKS DIGITAL FILTER FFT PMT)
-find_package(Gnuradio REQUIRED COMPONENTS analog audio blocks digital filter fft network)
+find_package(Gnuradio REQUIRED COMPONENTS analog audio blocks digital filter fft network zeromq)
 if(NOT Gnuradio_FOUND)
     message(FATAL_ERROR "GnuRadio Runtime required to compile gqrx")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ if(NOT Gnuradio_VERSION VERSION_LESS "3.10")
         gnuradio::gnuradio-filter
         gnuradio::gnuradio-network
         gnuradio::gnuradio-audio
+        gnuradio::gnuradio-zeromq
         Volk::volk
     )
 else()
@@ -116,6 +117,7 @@ else()
         gnuradio::gnuradio-blocks
         gnuradio::gnuradio-digital
         gnuradio::gnuradio-filter
+        gnuradio::gnuradio-network
         gnuradio::gnuradio-audio
         Volk::volk
     )

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1625,6 +1625,19 @@ void MainWindow::stopAudioPlayback()
     }
 }
 
+void MainWindow::startIqStream(const QString& zmq_host, int zmq_port)
+{
+
+    // rx->open_iq_stream_socket("tcp://127.0.0.1", 9001);
+    rx->open_iq_stream_socket(zmq_host.toStdString(), zmq_port);
+
+}
+
+void MainWindow::stopIqStream()
+{
+    rx->close_iq_stream_socket();
+}
+
 /** Start streaming audio over UDP. */
 void MainWindow::startAudioStream(const QString& udp_host, int udp_port, bool stereo)
 {
@@ -1647,13 +1660,16 @@ void MainWindow::startIqRecording(const QString& recdir, const QString& format)
     auto sr = qRound64(rx->get_input_rate());
     auto dec = (quint32)(rx->get_input_decim());
     auto currentDate = QDateTime::currentDateTimeUtc();
-    auto filenameTemplate = currentDate.toString("%1/gqrx_yyyyMMdd_hhmmss_%2_%3_fc.%4").arg(recdir).arg(freq).arg(sr/dec);
+    // meh hack
+    //auto filenameTemplate = currentDate.toString("%1/gqrx_yyyyMMdd_hhmmss_%2_%3_fc.%4").arg(recdir).arg(freq).arg(sr/dec);
+    QString filenameTemplate = "/tmp/iq_dump.txt";
     bool sigmf = (format == "SigMF");
-    auto lastRec = filenameTemplate.arg(sigmf ? "sigmf-data" : "raw");
-
-    QFile metaFile(filenameTemplate.arg("sigmf-meta"));
+    //auto lastRec = filenameTemplate.arg(sigmf ? "sigmf-data" : "raw");
+    auto lastRec = filenameTemplate;
+    //QFile metaFile(filenameTemplate.arg("sigmf-meta"));
+    QFile metaFile(filenameTemplate);
     bool ok = true;
-    if (sigmf) {
+    /*if (sigmf) {
         auto meta = QJsonDocument { QJsonObject {
             {"global", QJsonObject {
 #if Q_BYTE_ORDER == Q_BIG_ENDIAN
@@ -1678,6 +1694,7 @@ void MainWindow::startIqRecording(const QString& recdir, const QString& format)
             ok = false;
         }
     }
+    */
 
     // start recorder; fails if recording already in progress
     if (!ok || rx->start_iq_recording(lastRec.toStdString()))

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1629,7 +1629,6 @@ void MainWindow::stopAudioPlayback()
 
 void MainWindow::startIqStream(const QString& zmq_host, int zmq_port)
 {
-    // rx->open_iq_stream_socket("tcp://127.0.0.1", 9001);
     rx->open_iq_stream_socket(zmq_host.toStdString(), zmq_port);
 }
 
@@ -1660,16 +1659,14 @@ void MainWindow::startIqRecording(const QString& recdir, const QString& format)
     auto sr = qRound64(rx->get_input_rate());
     auto dec = (quint32)(rx->get_input_decim());
     auto currentDate = QDateTime::currentDateTimeUtc();
-    // meh hack
-    //auto filenameTemplate = currentDate.toString("%1/gqrx_yyyyMMdd_hhmmss_%2_%3_fc.%4").arg(recdir).arg(freq).arg(sr/dec);
-    QString filenameTemplate = "/tmp/iq_dump.txt";
+    auto filenameTemplate = currentDate.toString("%1/gqrx_yyyyMMdd_hhmmss_%2_%3_fc.%4").arg(recdir).arg(freq).arg(sr/dec);
     bool sigmf = (format == "SigMF");
-    //auto lastRec = filenameTemplate.arg(sigmf ? "sigmf-data" : "raw");
+    auto lastRec = filenameTemplate.arg(sigmf ? "sigmf-data" : "raw");
     auto lastRec = filenameTemplate;
-    //QFile metaFile(filenameTemplate.arg("sigmf-meta"));
+    QFile metaFile(filenameTemplate.arg("sigmf-meta"));
     QFile metaFile(filenameTemplate);
     bool ok = true;
-    /*if (sigmf) {
+    if (sigmf) {
         auto meta = QJsonDocument { QJsonObject {
             {"global", QJsonObject {
 #if Q_BYTE_ORDER == Q_BIG_ENDIAN
@@ -1694,7 +1691,7 @@ void MainWindow::startIqRecording(const QString& recdir, const QString& format)
             ok = false;
         }
     }
-    */
+    
 
     // start recorder; fails if recording already in progress
     if (!ok || rx->start_iq_recording(lastRec.toStdString()))

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -268,6 +268,8 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(uiDockAudio, SIGNAL(audioPlayStarted(QString)), this, SLOT(startAudioPlayback(QString)));
     connect(uiDockAudio, SIGNAL(audioPlayStopped()), this, SLOT(stopAudioPlayback()));
     connect(uiDockAudio, SIGNAL(fftRateChanged(int)), this, SLOT(setAudioFftRate(int)));
+    connect(uiDockAudio, SIGNAL(zmqStreamStart(QString,int)), this, SLOT(startIqStream(QString,int)));
+    connect(uiDockAudio, SIGNAL(zmqStreamStop()), this, SLOT(stopIqStream()));
 
     // FFT Dock
     connect(uiDockFft, SIGNAL(fftSizeChanged(int)), this, SLOT(setIqFftSize(int)));
@@ -1627,10 +1629,8 @@ void MainWindow::stopAudioPlayback()
 
 void MainWindow::startIqStream(const QString& zmq_host, int zmq_port)
 {
-
     // rx->open_iq_stream_socket("tcp://127.0.0.1", 9001);
     rx->open_iq_stream_socket(zmq_host.toStdString(), zmq_port);
-
 }
 
 void MainWindow::stopIqStream()

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1662,9 +1662,8 @@ void MainWindow::startIqRecording(const QString& recdir, const QString& format)
     auto filenameTemplate = currentDate.toString("%1/gqrx_yyyyMMdd_hhmmss_%2_%3_fc.%4").arg(recdir).arg(freq).arg(sr/dec);
     bool sigmf = (format == "SigMF");
     auto lastRec = filenameTemplate.arg(sigmf ? "sigmf-data" : "raw");
-    auto lastRec = filenameTemplate;
+    
     QFile metaFile(filenameTemplate.arg("sigmf-meta"));
-    QFile metaFile(filenameTemplate);
     bool ok = true;
     if (sigmf) {
         auto meta = QJsonDocument { QJsonObject {

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -200,6 +200,8 @@ private slots:
     void startIqPlayback(const QString& filename, float samprate, qint64 center_freq);
     void stopIqPlayback();
     void seekIqFile(qint64 seek_pos);
+    void startIqStream(const QString& zmq_host, int zmq_port);
+    void stopIqStream();
 
     /* FFT settings */
     void setIqFftSize(int size);

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -1195,6 +1195,71 @@ receiver::status receiver::stop_udp_streaming()
 }
 
 /**
+* @brief Open socket to stream IQ data
+* @param ip address to send data to
+* @param socket to send data to
+*/
+receiver::status receiver::open_iq_stream_socket(const std::string host, int port)
+{
+
+    receiver::status status = STATUS_OK;
+
+    // host must be of the form "tcp://127.0.0.1"
+    // port will be simply an integer
+    std::string address = host + ':' + std::to_string(port);
+    char* addr = const_cast<char*>(address.c_str());
+    try
+    {
+        iq_socket_sink = gr::zeromq::pub_sink::make(sizeof(gr_complex),
+                                                           1, 
+                                                           addr);
+    }
+    catch (std::runtime_error &e)
+    {
+        std::cout << __func__ << ": couldn't open I/Q zeroMQ sink" << std::endl;
+        return STATUS_ERROR;
+    }
+
+    tb->lock();
+    if (d_decim >= 2)
+        tb->connect(input_decim, 0, iq_socket_sink, 0);
+    else
+        tb->connect(src, 0, iq_socket_sink, 0);
+    d_iq_stream = true;
+    tb->unlock();
+
+    return status;
+
+} 
+
+/**
+* @brief Close socket that streams IQ data
+*/
+receiver::status receiver::close_iq_stream_socket()
+{
+    if (!d_iq_stream) {
+        /* error: we are not streaming */
+        return STATUS_ERROR;
+    }
+
+    tb->lock();
+    iq_sink->close();
+
+    if (d_decim >= 2)
+        tb->disconnect(input_decim, 0, iq_socket_sink, 0);
+    else
+        tb->disconnect(src, 0, iq_socket_sink, 0);
+
+    tb->unlock();
+    iq_sink.reset();
+    d_iq_stream = false;
+
+    return STATUS_OK;
+    //iq_socket_sink->close();
+
+}
+
+/**
  * @brief Start I/Q data recorder.
  * @param filename The filename where to record.
  */

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -1243,7 +1243,6 @@ receiver::status receiver::close_iq_stream_socket()
     }
 
     tb->lock();
-    iq_sink->close();
 
     if (d_decim >= 2)
         tb->disconnect(input_decim, 0, iq_socket_sink, 0);
@@ -1251,11 +1250,10 @@ receiver::status receiver::close_iq_stream_socket()
         tb->disconnect(src, 0, iq_socket_sink, 0);
 
     tb->unlock();
-    iq_sink.reset();
+    iq_socket_sink.reset();
     d_iq_stream = false;
 
     return STATUS_OK;
-    //iq_socket_sink->close();
 
 }
 

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -294,9 +294,6 @@ private:
     sniffer_f_sptr    sniffer;    /*!< Sample sniffer for data decoders. */
     resampler_ff_sptr sniffer_rr; /*!< Sniffer resampler. */
 
-    
-    
-
 #ifdef WITH_PULSEAUDIO
     pa_sink_sptr              audio_snk;  /*!< Pulse audio sink. */
 #elif WITH_PORTAUDIO

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -29,6 +29,8 @@
 #include <gnuradio/blocks/wavfile_sink.h>
 #include <gnuradio/blocks/wavfile_source.h>
 #include <gnuradio/top_block.h>
+#include <gnuradio/zeromq/pub_sink.h>
+#include <gnuradio/network/tcp_sink.h>
 #include <osmosdr/source.h>
 #include <string>
 
@@ -211,6 +213,10 @@ public:
     status      stop_iq_recording();
     status      seek_iq_file(long pos);
 
+    /* IQ streams */ 
+    status      open_iq_stream_socket(const std::string host, int port);
+    status      close_iq_stream_socket();
+
     /* sample sniffer */
     status      start_sniffer(unsigned int samplrate, int buffsize);
     status      stop_sniffer();
@@ -249,6 +255,7 @@ private:
     bool        d_iq_rev;           /*!< Whether I/Q is reversed or not. */
     bool        d_dc_cancel;        /*!< Enable automatic DC removal. */
     bool        d_iq_balance;       /*!< Enable automatic IQ balance. */
+    bool        d_iq_stream;        /*!< Whether we are streaming I/Q data. */
 
     std::string input_devstr;  /*!< Current input device string. */
     std::string output_devstr; /*!< Current output device string. */
@@ -281,9 +288,14 @@ private:
     gr::blocks::null_sink::sptr         audio_null_sink0; /*!< Audio null sink used during playback. */
     gr::blocks::null_sink::sptr         audio_null_sink1; /*!< Audio null sink used during playback. */
 
+    gr::zeromq::pub_sink::sptr          iq_socket_sink; /*!< IQ sink for zeromq interface */
+
     udp_sink_f_sptr   audio_udp_sink;  /*!< UDP sink to stream audio over the network. */
     sniffer_f_sptr    sniffer;    /*!< Sample sniffer for data decoders. */
     resampler_ff_sptr sniffer_rr; /*!< Sniffer resampler. */
+
+    
+    
 
 #ifdef WITH_PULSEAUDIO
     pa_sink_sptr              audio_snk;  /*!< Pulse audio sink. */

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -29,7 +29,9 @@
 #include "qtgui/dockrxopt.h"
 
 #define DEFAULT_RC_PORT            7356
+#define DEFAULT_IQ_PORT            9001
 #define DEFAULT_RC_ALLOWED_HOSTS   "127.0.0.1"
+#define DEFAULT_IQ_ALLOWED_HOSTS   "127.0.0.1"
 
 RemoteControl::RemoteControl(QObject *parent) :
     QObject(parent)

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -130,6 +130,7 @@ private slots:
 private:
     QTcpServer  rc_server;         /*!< The active server object. */
     QTcpSocket* rc_socket;         /*!< The active socket object. */
+    std::set<QTcpSocket*> rc_sockets; /*!< The active socket objects. */
     QTcpServer  iq_server;         /*!< The active iq data server object. */
     QTcpSocket* iq_socket;         /*!< The active iq data socket object. */
 

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -128,9 +128,14 @@ private slots:
 private:
     QTcpServer  rc_server;         /*!< The active server object. */
     QTcpSocket* rc_socket;         /*!< The active socket object. */
+    QTcpServer  iq_server;         /*!< The active iq data server object. */
+    QTcpSocket* iq_socket;         /*!< The active iq data socket object. */
 
     QStringList rc_allowed_hosts;  /*!< Hosts where we accept connection from. */
     int         rc_port;           /*!< The port we are listening on. */
+
+    QStringList iq_allowed_hosts;  /*!< Hosts where we accept connection from. */
+    int         iq_port;           /*!< The port we are listening on. */
 
     qint64      rc_freq;
     qint64      rc_filter_offset;
@@ -177,6 +182,8 @@ private:
     QString     cmd_LOS();
     QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;
+    QString     cmd_start_iq_server(QString addr, int port);
+    QString     cmd_stop_iq_server(QString addr, int port);
 };
 
 #endif // REMOTE_CONTROL_H

--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -242,3 +242,22 @@ void CAudioOptions::on_udpStereo_stateChanged(int state)
 {
     emit newUdpStereo(state);
 }
+
+/** Zmq host name has changed. */
+void CAudioOptions::on_ZmqHost_textChanged(const QString &text)
+{
+    if (!text.isEmpty())
+        emit newZmqHost(text);
+}
+
+/** Zmq port number has changed. */
+void CAudioOptions::on_ZmqPort_valueChanged(int port)
+{
+    emit newZmqPort(port);
+}
+
+/** Zmq stereo setting has changed. */
+void CAudioOptions::on_ZmqStream_stateChanged(int state)
+{
+    emit newZmqStream(state);
+}

--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -23,6 +23,7 @@
 #include <QFileDialog>
 #include <QPalette>
 #include <QDebug>
+#include <iostream>
 
 #include "audio_options.h"
 #include "ui_audio_options.h"
@@ -257,7 +258,7 @@ void CAudioOptions::on_ZmqPort_valueChanged(int port)
 }
 
 /** Zmq stereo setting has changed. */
-void CAudioOptions::on_ZmqStream_stateChanged(int state)
+void CAudioOptions::on_zmqStream_toggled()
 {
-    emit newZmqStream(state);
+    emit newZmqStream();
 }

--- a/src/qtgui/audio_options.h
+++ b/src/qtgui/audio_options.h
@@ -75,6 +75,10 @@ signals:
     void newUdpPort(int port);
     void newUdpStereo(bool enabled);
 
+    void newZmqHost(const QString text);
+    void newZmqPort(int port);
+    void newZmqStream(bool enabled);
+
 private slots:
     void on_fftSplitSlider_valueChanged(int value);
     void on_pandRangeSlider_valuesChanged(int min, int max);
@@ -85,6 +89,11 @@ private slots:
     void on_udpHost_textChanged(const QString &text);
     void on_udpPort_valueChanged(int port);
     void on_udpStereo_stateChanged(int state);
+
+    void on_ZmqHost_textChanged(const QString &text);
+    void on_ZmqPort_valueChanged(int port);
+    void on_ZmqStream_stateChanged(int state);
+
 
 private:
     Ui::CAudioOptions *ui;                   /*!< The user interface widget. */

--- a/src/qtgui/audio_options.h
+++ b/src/qtgui/audio_options.h
@@ -77,7 +77,7 @@ signals:
 
     void newZmqHost(const QString text);
     void newZmqPort(int port);
-    void newZmqStream(bool enabled);
+    void newZmqStream();
 
 private slots:
     void on_fftSplitSlider_valueChanged(int value);
@@ -92,7 +92,7 @@ private slots:
 
     void on_ZmqHost_textChanged(const QString &text);
     void on_ZmqPort_valueChanged(int port);
-    void on_ZmqStream_stateChanged(int state);
+    void on_zmqStream_toggled();
 
 
 private:

--- a/src/qtgui/audio_options.ui
+++ b/src/qtgui/audio_options.ui
@@ -312,7 +312,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="tab3">
       <attribute name="title">
        <string>IQ Stream</string>
       </attribute>
@@ -321,8 +321,8 @@
         <rect>
          <x>10</x>
          <y>10</y>
-         <width>179</width>
-         <height>83</height>
+         <width>231</width>
+         <height>71</height>
         </rect>
        </property>
        <layout class="QGridLayout" name="gridLayoutZMQ">
@@ -343,7 +343,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QSpinBox" name="udpPortZMQ">
+         <widget class="QSpinBox" name="ZmqPort">
           <property name="toolTip">
            <string>Network port to stream to</string>
           </property>
@@ -359,12 +359,12 @@
          </widget>
         </item>
         <item row="0" column="1" colspan="2">
-         <widget class="QLineEdit" name="udpHostZMQ">
+         <widget class="QLineEdit" name="ZmqHost">
           <property name="toolTip">
            <string>Network host to stream to</string>
           </property>
           <property name="text">
-           <string>localhost</string>
+           <string>tcp://127.0.0.1</string>
           </property>
          </widget>
         </item>
@@ -386,11 +386,11 @@
         </item>
        </layout>
       </widget>
-      <widget class="QPushButton" name="zmqStreamButton">
+      <widget class="QPushButton" name="zmqStream">
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>100</y>
+         <y>90</y>
          <width>111</width>
          <height>31</height>
         </rect>

--- a/src/qtgui/audio_options.ui
+++ b/src/qtgui/audio_options.ui
@@ -21,7 +21,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tab0">
       <attribute name="title">
@@ -58,7 +58,7 @@
             <number>100</number>
            </property>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -85,7 +85,7 @@
             <string>Pandapter dB range</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -104,7 +104,7 @@
             <number>-80</number>
            </property>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -117,7 +117,7 @@
             <string>Waterfall dB range</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -136,7 +136,7 @@
             <number>-80</number>
            </property>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -208,7 +208,7 @@
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -300,7 +300,7 @@
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -311,6 +311,11 @@
         </spacer>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>IQ Stream</string>
+      </attribute>
      </widget>
     </widget>
    </item>

--- a/src/qtgui/audio_options.ui
+++ b/src/qtgui/audio_options.ui
@@ -262,6 +262,13 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="udpStereo">
+           <property name="text">
+            <string>Stereo</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="1" colspan="2">
           <widget class="QLineEdit" name="udpHost">
            <property name="toolTip">
@@ -288,13 +295,6 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="udpStereo">
-           <property name="text">
-            <string>Stereo</string>
-           </property>
-          </widget>
-         </item>
         </layout>
        </item>
        <item>
@@ -316,6 +316,110 @@
       <attribute name="title">
        <string>IQ Stream</string>
       </attribute>
+      <widget class="QWidget" name="layoutWidget">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>179</width>
+         <height>83</height>
+        </rect>
+       </property>
+       <layout class="QGridLayout" name="gridLayoutZMQ">
+        <item row="1" column="0">
+         <widget class="QLabel" name="portLabelZMQ">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Network port to stream to</string>
+          </property>
+          <property name="text">
+           <string>ZMQ port</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="udpPortZMQ">
+          <property name="toolTip">
+           <string>Network port to stream to</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>65535</number>
+          </property>
+          <property name="value">
+           <number>9001</number>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QLineEdit" name="udpHostZMQ">
+          <property name="toolTip">
+           <string>Network host to stream to</string>
+          </property>
+          <property name="text">
+           <string>localhost</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="hostLabelZMQ">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Network host to stream to</string>
+          </property>
+          <property name="text">
+           <string>ZMQ Host</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QPushButton" name="zmqStreamButton">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>100</y>
+         <width>111</width>
+         <height>31</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Lock panadapter and waterfall sliders together</string>
+       </property>
+       <property name="statusTip">
+        <string>Lock panadapter and waterfall sliders together</string>
+       </property>
+       <property name="text">
+        <string>Stream</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
      </widget>
     </widget>
    </item>

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -34,7 +34,10 @@ DockAudio::DockAudio(QWidget *parent) :
     QDockWidget(parent),
     ui(new Ui::DockAudio),
     autoSpan(true),
-    rx_freq(144000000)
+    rx_freq(144000000),
+    zmq_stream(false),
+    zmq_host("tcp://127.0.0.1"),
+    zmq_port(9001)
 {
     ui->setupUi(this);
 
@@ -48,7 +51,9 @@ DockAudio::DockAudio(QWidget *parent) :
     connect(audioOptions, SIGNAL(newUdpPort(int)), this, SLOT(setNewUdpPort(int)));
     connect(audioOptions, SIGNAL(newUdpStereo(bool)), this, SLOT(setNewUdpStereo(bool)));
     
-    connect(audioOptions, SIGNAL(newZmqHost(Qstring)), this, SLOT(setNewZmqHost(Qstring)));
+    connect(audioOptions, SIGNAL(newZmqHost(QString)), this, SLOT(setNewZmqHost(QString)));
+    connect(audioOptions, SIGNAL(newZmqPort(int)), this, SLOT(setNewZmqPort(int)));
+    connect(audioOptions, SIGNAL(newZmqStream()), this, SLOT(setNewZmqStream()));
 
     connect(ui->audioSpectrum, SIGNAL(pandapterRangeChanged(float,float)), audioOptions, SLOT(setPandapterSliderValues(float,float)));
 
@@ -509,9 +514,18 @@ void DockAudio::setNewZmqPort(int port)
     zmq_port = port;
 }
 
-void DockAudio::setNewZmqStream(bool enabled)
+void DockAudio::setNewZmqStream()
 {
-    zmq_stream = enabled;
+    if (!zmq_stream)
+    {
+        zmq_stream = true;
+        emit zmqStreamStart(zmq_host, zmq_port);
+    }
+    else
+    {
+        zmq_stream = false;
+        emit zmqStreamStop();
+    }
 }
 
 void DockAudio::recordToggleShortcut() {

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -35,9 +35,9 @@ DockAudio::DockAudio(QWidget *parent) :
     ui(new Ui::DockAudio),
     autoSpan(true),
     rx_freq(144000000),
-    zmq_stream(false),
     zmq_host("tcp://127.0.0.1"),
-    zmq_port(9001)
+    zmq_port(9001),
+    zmq_stream(false)
 {
     ui->setupUi(this);
 

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -47,6 +47,8 @@ DockAudio::DockAudio(QWidget *parent) :
     connect(audioOptions, SIGNAL(newUdpHost(QString)), this, SLOT(setNewUdpHost(QString)));
     connect(audioOptions, SIGNAL(newUdpPort(int)), this, SLOT(setNewUdpPort(int)));
     connect(audioOptions, SIGNAL(newUdpStereo(bool)), this, SLOT(setNewUdpStereo(bool)));
+    
+    connect(audioOptions, SIGNAL(newZmqHost(Qstring)), this, SLOT(setNewZmqHost(Qstring)));
 
     connect(ui->audioSpectrum, SIGNAL(pandapterRangeChanged(float,float)), audioOptions, SLOT(setPandapterSliderValues(float,float)));
 
@@ -491,6 +493,25 @@ void DockAudio::setNewUdpPort(int port)
 void DockAudio::setNewUdpStereo(bool enabled)
 {
     udp_stereo = enabled;
+}
+
+/* ! \brief Slot called when new zmq host has been entered */
+void DockAudio::setNewZmqHost(const QString &host)
+{
+    if (host.isEmpty())
+        zmq_host = "tcp://127.0.0.1";
+    else
+        zmq_host = host;
+}
+
+void DockAudio::setNewZmqPort(int port)
+{
+    zmq_port = port;
+}
+
+void DockAudio::setNewZmqStream(bool enabled)
+{
+    zmq_stream = enabled;
 }
 
 void DockAudio::recordToggleShortcut() {

--- a/src/qtgui/dockaudio.h
+++ b/src/qtgui/dockaudio.h
@@ -103,6 +103,11 @@ signals:
     /*! \brief Audio mute chenged. */
     void audioMuted(bool muted);
 
+    void zmqStreamStart(const QString &host, int port);
+
+    void zmqStreamStop();
+    
+
 private slots:
     void on_audioGainSlider_valueChanged(int value);
     void on_audioStreamButton_clicked(bool checked);
@@ -118,7 +123,7 @@ private slots:
     void setNewUdpStereo(bool enabled);
     void setNewZmqHost(const QString &host);
     void setNewZmqPort(int port);
-    void setNewZmqStream(bool enabled);
+    void setNewZmqStream();
 
 
 private:

--- a/src/qtgui/dockaudio.h
+++ b/src/qtgui/dockaudio.h
@@ -116,6 +116,9 @@ private slots:
     void setNewUdpHost(const QString &host);
     void setNewUdpPort(int port);
     void setNewUdpStereo(bool enabled);
+    void setNewZmqHost(const QString &host);
+    void setNewZmqPort(int port);
+    void setNewZmqStream(bool enabled);
 
 
 private:
@@ -127,6 +130,10 @@ private:
     QString        udp_host;     /*! UDP client host name. */
     int            udp_port;     /*! UDP client port number. */
     bool           udp_stereo;   /*! Enable stereo streaming for UDP. */
+
+    QString        zmq_host;     /*! UDP client host name. */
+    int            zmq_port;     /*! UDP client port number. */
+    bool           zmq_stream;   /*! Enable stereo streaming for UDP. */
 
     bool           autoSpan;     /*! Whether to allow mode-dependent auto span. */
 

--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -303,6 +303,16 @@ void CIqTool::timeoutFunction(void)
             ui->slider->blockSignals(false);
             refreshTimeWidgets();
         }
+        else
+        {
+            emit stopPlayback();
+            ui->listWidget->setEnabled(true);
+            ui->recButton->setEnabled(true);
+            ui->slider->setValue(0);
+            ui->playButton->setChecked(false);
+            is_playing = false;
+            refreshTimeWidgets();
+        }
     }
     if (is_recording)
         refreshTimeWidgets();


### PR DESCRIPTION
I have added code and GUI features to allow a ZMQ sink block from GNURadio to be easily set up.  This will stream raw IQ data from the device to other sinks, eg GRC or other processes with digital demodulation capabilities.

I have tested this by opening a ZMQ socket in GRC and plotting the waterfall from the IQ data fed out by GQRX.  I have also opened ZMQ sockets in C and confirmed that nontrivial data is coming through the socket.