### PR TITLE
New GQRX remote control commands for device management

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -66,6 +66,18 @@ Supported commands:
     Get VFO option status (only usable for hamlib compatibility)
  \dump_state
     Dump state (only usable for hamlib compatibility)
+ \get_input_device_list
+    Get the list of available input device names
+ \get_input_device
+    Get the current input device name
+ \set_input_device <device_name>
+    Set the current input device name
+ \get_output_device_list
+    Get the list of available output device names
+ \get_output_device
+    Get the current output device name
+ \set_output_device <device_name>
+    Set the current output device name
  \get_powerstat
     Get power status (only usable for hamlib compatibility)
  v

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -115,7 +115,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     rx->set_rf_freq(144500000.0);
 
     // remote controller
-    remote = new RemoteControl();
+    remote = new RemoteControl(this);
 
     /* meter timer */
     meter_timer = new QTimer(this);

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -59,6 +59,8 @@ public:
     explicit MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent = nullptr);
     ~MainWindow() override;
 
+    QPointer<QSettings> settings() const { return m_settings; }
+
     bool loadConfig(const QString& cfgfile, bool check_crash, bool restore_mainwindow);
     bool saveConfig(const QString& cfgfile);
     void storeSession();

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -23,10 +23,26 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <map>
 #include <QString>
 #include <QStringList>
 #include "remote_control.h"
 #include "qtgui/dockrxopt.h"
+#include "qtgui/ioconfig.h"
+#include "mainwindow.h"
+
+#include <osmosdr/device.h>
+#include <osmosdr/source.h>
+#include <osmosdr/ranges.h>
+
+#ifdef WITH_PULSEAUDIO
+#include "pulseaudio/pa_device_list.h"
+#elif WITH_PORTAUDIO
+#include "portaudio/device_list.h"
+#elif defined(Q_OS_DARWIN)
+#include "osxaudio/device_list.h"
+#endif
+
 
 #define DEFAULT_RC_PORT            7356
 #define DEFAULT_RC_ALLOWED_HOSTS   "127.0.0.1"
@@ -260,6 +276,18 @@ void RemoteControl::startRead()
             answer = cmd_dump_state();
         else if (cmd == "\\get_powerstat")
             answer = QString("1\n");
+        else if (cmd == "\\get_input_device_list")
+            answer = cmd_get_input_device_list();
+        else if (cmd == "\\get_input_device")
+            answer = cmd_get_input_device();
+        else if (cmd == "\\set_input_device")
+            answer = cmd_set_input_device(cmdlist);
+        else if (cmd == "\\get_output_device_list")
+            answer = cmd_get_output_device_list();
+        else if (cmd == "\\get_output_device")
+            answer = cmd_get_output_device();
+        else if (cmd == "\\set_output_device")
+            answer = cmd_set_output_device(cmdlist);        
         else if (cmd == "q" || cmd == "Q")
         {
             // FIXME: for now we assume 'close' command
@@ -1053,4 +1081,148 @@ QString RemoteControl::cmd_dump_state() const
         "0\n" /* RIG_PARM_NONE */
         /* Bit field list of set parm */
         "0\n" /* RIG_PARM_NONE */);
+}
+
+
+/*
+ * The '\get_input_device_list' command
+ */
+QString RemoteControl::cmd_get_input_device_list()
+{
+    std::map<QString, QVariant> devList;
+    CIoConfig::getDeviceList(devList);
+
+    QString devListString;
+    for (const auto &dev : devList)    {
+        devListString += dev.first + "\n";
+    }  
+
+    return devListString;
+}
+
+/*
+ * The '\get_input_device' command
+ */
+QString RemoteControl::cmd_get_input_device() const
+{
+    std::map<QString, QVariant> devList;
+    CIoConfig::getDeviceList(devList);
+    QPointer<QSettings> settingsPtr;
+    MainWindow *mw = qobject_cast<MainWindow*>(parent());
+    if (mw)
+        settingsPtr = mw->settings();
+
+    auto *ioconf = new CIoConfig(settingsPtr.data(), devList, nullptr);
+    QString indev = settingsPtr->value("input/device", "").toString();
+    delete ioconf;
+
+    return indev + "\n";
+}
+
+/*
+ * The '\set_input_device' command
+ */
+QString RemoteControl::cmd_set_input_device(QStringList cmdlist) const
+{
+    if (cmdlist.size() != 2)
+        return QString("RPRT 1\n");
+
+    std::map<QString, QVariant> devList;
+    CIoConfig::getDeviceList(devList);
+    QPointer<QSettings> settingsPtr;
+    MainWindow *mw = qobject_cast<MainWindow*>(parent());
+    if (mw)
+        settingsPtr = mw->settings();
+
+    auto *ioconf = new CIoConfig(settingsPtr.data(), devList, nullptr);
+    QString indev = cmdlist[1];
+      settingsPtr->setValue("input/device", indev);
+    mw->storeSession();
+    mw->loadConfig(settingsPtr->fileName(), false, false);
+    delete ioconf;
+
+    return QString("RPRT 0\n");   
+}
+
+
+/*
+ * The '\get_output_device_list' command
+ */
+QString RemoteControl::cmd_get_output_device_list()
+{
+    // get list of audio output devices
+    QString devListString = "Default\n";
+
+#ifdef WITH_PULSEAUDIO
+    pa_device_list devices;
+    outDevList = devices.get_output_devices();
+    for (auto &dev : outDevList)
+    {
+        QString outdevName = QString(dev.get_name().c_str());
+        QString outdevDesc = QString(dev.get_description().c_str());
+        devListString += outdevName + "\n";
+    }
+#elif WITH_PORTAUDIO
+    portaudio_device_list   devices;
+    outDevList = devices.get_output_devices();
+    for (auto &dev : outDevList)
+    {
+        QString outdevName = QString(dev.get_name().c_str());
+        QString outdevDesc = QString(dev.get_description().c_str());
+        devListString += outdevName + "\n";
+    }
+#elif defined(Q_OS_DARWIN)
+    osxaudio_device_list devices;
+    outDevList = devices.get_output_devices();
+    for (auto &dev : outDevList)
+    {
+        QString outdevName = QString(dev.get_name().c_str());
+        QString outdevDesc = QString(dev.get_description().c_str());
+        devListString += outdevName + "\n";
+    }
+#endif // WITH_PULSEAUDIO
+
+    return devListString;
+}
+
+/*
+ * The '\get_output_device' command
+ */
+QString RemoteControl::cmd_get_output_device() const
+{
+    std::map<QString, QVariant> devList;
+    CIoConfig::getDeviceList(devList);
+    QPointer<QSettings> settingsPtr;
+    MainWindow *mw = qobject_cast<MainWindow*>(parent());
+    if (mw)
+        settingsPtr = mw->settings();
+
+    auto *ioconf = new CIoConfig(settingsPtr.data(), devList, nullptr);
+    QString indev = settingsPtr->value("output/device", "").toString();
+    delete ioconf;
+
+    return indev + "\n";
+}
+
+/*
+ * The '\set_output_device' command
+ */
+QString RemoteControl::cmd_set_output_device(QStringList cmdlist) const
+{
+    if (cmdlist.size() != 2)
+        return QString("RPRT 1\n");
+
+    std::map<QString, QVariant> devList;
+    CIoConfig::getDeviceList(devList);
+    QPointer<QSettings> settingsPtr;
+    MainWindow *mw = qobject_cast<MainWindow*>(parent());
+    if (mw)
+        settingsPtr = mw->settings();
+
+    auto *ioconf = new CIoConfig(settingsPtr.data(), devList, nullptr);
+    QString indev = cmdlist[1];
+    settingsPtr->setValue("output/device", indev);
+    delete ioconf;
+
+    return QString("RPRT 0\n");   
 }

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -31,10 +31,6 @@
 #include "qtgui/ioconfig.h"
 #include "mainwindow.h"
 
-#include <osmosdr/device.h>
-#include <osmosdr/source.h>
-#include <osmosdr/ranges.h>
-
 #ifdef WITH_PULSEAUDIO
 #include "pulseaudio/pa_device_list.h"
 #elif WITH_PORTAUDIO
@@ -1105,18 +1101,13 @@ QString RemoteControl::cmd_get_input_device_list()
  */
 QString RemoteControl::cmd_get_input_device() const
 {
-    std::map<QString, QVariant> devList;
-    CIoConfig::getDeviceList(devList);
-    QPointer<QSettings> settingsPtr;
+    // Just read the stored setting: probing the hardware (getDeviceList) here
+    // stalls for seconds while a device is open, and this getter doesn't need it.
     MainWindow *mw = qobject_cast<MainWindow*>(parent());
-    if (mw)
-        settingsPtr = mw->settings();
+    if (!mw || !mw->settings())
+        return QString("RPRT 1\n");
 
-    auto *ioconf = new CIoConfig(settingsPtr.data(), devList, nullptr);
-    QString indev = settingsPtr->value("input/device", "").toString();
-    delete ioconf;
-
-    return indev + "\n";
+    return mw->settings()->value("input/device", "").toString() + "\n";
 }
 
 /*
@@ -1124,24 +1115,18 @@ QString RemoteControl::cmd_get_input_device() const
  */
 QString RemoteControl::cmd_set_input_device(QStringList cmdlist) const
 {
-    if (cmdlist.size() != 2)
+    MainWindow *mw = qobject_cast<MainWindow*>(parent());
+    if (!mw || !mw->settings() || cmdlist.size() < 2)
         return QString("RPRT 1\n");
 
-    std::map<QString, QVariant> devList;
-    CIoConfig::getDeviceList(devList);
-    QPointer<QSettings> settingsPtr;
-    MainWindow *mw = qobject_cast<MainWindow*>(parent());
-    if (mw)
-        settingsPtr = mw->settings();
-
-    auto *ioconf = new CIoConfig(settingsPtr.data(), devList, nullptr);
-    QString indev = cmdlist[1];
-      settingsPtr->setValue("input/device", indev);
+    // gr-osmosdr device strings can contain spaces, so re-join everything after
+    // the command word rather than taking a single token.
+    QString indev = cmdlist.mid(1).join(" ");
+    mw->settings()->setValue("input/device", indev);
     mw->storeSession();
-    mw->loadConfig(settingsPtr->fileName(), false, false);
-    delete ioconf;
+    mw->loadConfig(mw->settings()->fileName(), false, false);
 
-    return QString("RPRT 0\n");   
+    return QString("RPRT 0\n");
 }
 
 
@@ -1190,18 +1175,11 @@ QString RemoteControl::cmd_get_output_device_list()
  */
 QString RemoteControl::cmd_get_output_device() const
 {
-    std::map<QString, QVariant> devList;
-    CIoConfig::getDeviceList(devList);
-    QPointer<QSettings> settingsPtr;
     MainWindow *mw = qobject_cast<MainWindow*>(parent());
-    if (mw)
-        settingsPtr = mw->settings();
+    if (!mw || !mw->settings())
+        return QString("RPRT 1\n");
 
-    auto *ioconf = new CIoConfig(settingsPtr.data(), devList, nullptr);
-    QString indev = settingsPtr->value("output/device", "").toString();
-    delete ioconf;
-
-    return indev + "\n";
+    return mw->settings()->value("output/device", "").toString() + "\n";
 }
 
 /*
@@ -1209,20 +1187,12 @@ QString RemoteControl::cmd_get_output_device() const
  */
 QString RemoteControl::cmd_set_output_device(QStringList cmdlist) const
 {
-    if (cmdlist.size() != 2)
+    MainWindow *mw = qobject_cast<MainWindow*>(parent());
+    if (!mw || !mw->settings() || cmdlist.size() < 2)
         return QString("RPRT 1\n");
 
-    std::map<QString, QVariant> devList;
-    CIoConfig::getDeviceList(devList);
-    QPointer<QSettings> settingsPtr;
-    MainWindow *mw = qobject_cast<MainWindow*>(parent());
-    if (mw)
-        settingsPtr = mw->settings();
+    // Audio device names routinely contain spaces ("Built-in Output").
+    mw->settings()->setValue("output/device", cmdlist.mid(1).join(" "));
 
-    auto *ioconf = new CIoConfig(settingsPtr.data(), devList, nullptr);
-    QString indev = cmdlist[1];
-    settingsPtr->setValue("output/device", indev);
-    delete ioconf;
-
-    return QString("RPRT 0\n");   
+    return QString("RPRT 0\n");
 }

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -35,6 +35,14 @@
 /* For gain_t and gain_list_t */
 #include "qtgui/dockinputctl.h"
 
+#ifdef WITH_PULSEAUDIO
+#include "pulseaudio/pa_device_list.h"
+#elif WITH_PORTAUDIO
+#include "portaudio/device_list.h"
+#elif defined(Q_OS_DARWIN)
+#include "osxaudio/device_list.h"
+#endif
+
 /*! \brief Simple TCP server for remote control.
  *
  * The TCP interface is compatible with the hamlib rigtctld so that applications
@@ -156,6 +164,14 @@ private:
     gain_list_t gains;             /*!< Possible and current gain settings */
     bool        is_audio_muted;
 
+#ifdef WITH_PULSEAUDIO
+    vector<pa_device>           outDevList;
+#elif WITH_PORTAUDIO
+    vector<portaudio_device>    outDevList;
+#elif defined(Q_OS_DARWIN)
+    vector<osxaudio_device>     outDevList;
+#endif
+
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);
     QString     intToModeStr(int mode);
@@ -179,6 +195,12 @@ private:
     QString     cmd_LOS();
     QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;
+    QString     cmd_get_input_device_list();
+    QString     cmd_get_input_device() const;
+    QString     cmd_set_input_device(QStringList cmdlist) const;
+    QString     cmd_get_output_device_list();
+    QString     cmd_get_output_device() const;
+    QString     cmd_set_output_device(QStringList cmdlist) const;
 };
 
 #endif // REMOTE_CONTROL_H

--- a/src/qtgui/ioconfig.ui
+++ b/src/qtgui/ioconfig.ui
@@ -22,7 +22,6 @@
     <widget class="QGroupBox" name="groupBoxInput">
      <property name="font">
       <font>
-       <weight>50</weight>
        <bold>false</bold>
       </font>
      </property>
@@ -136,7 +135,7 @@
       <item row="1" column="1">
        <widget class="QLineEdit" name="inDevEdit">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The device argument is a delimited string used to locate devices on your system. Use the device id or name (if applicable) to specify a certain device or list of devices. If left blank, the first device found will be used.&lt;/p&gt;&lt;p&gt;Examples (some arguments may be optional):&lt;/p&gt;&lt;p&gt;fcd=0&lt;br/&gt;rtl=0&lt;br/&gt;rtl=0,rtl_xtal=28.80001e6,tuner_xtal=26e6,buffers=64 ...&lt;br/&gt;rtl_tcp=127.0.0.1:1234,psize=16384&lt;br/&gt;plutosdr,uri=usb:6.36.5&lt;br/&gt;file=/path/to/file.ext,freq=428e6,rate=1e6,repeat=true,throttle=true ... &lt;/p&gt;&lt;p&gt;You can test the device strings in gnuradio-companion.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The device argument is a delimited string used to locate devices on your system. Use the device id or name (if applicable) to specify a certain device or list of devices. If left blank, the first device found will be used.&lt;/p&gt;&lt;p&gt;Examples (some arguments may be optional):&lt;/p&gt;&lt;p&gt;fcd=0&lt;br/&gt;rtl=0&lt;br/&gt;rtl=0,direct_samp=2&lt;br/&gt;rtl=0,rtl_xtal=28.80001e6,tuner_xtal=26e6,buffers=64 ...&lt;br/&gt;rtl_tcp=127.0.0.1:1234,psize=16384&lt;br/&gt;plutosdr,uri=usb:6.36.5&lt;br/&gt;file=/path/to/file.ext,freq=428e6,rate=1e6,repeat=true,throttle=true ... &lt;/p&gt;&lt;p&gt;You can test the device strings in gnuradio-companion.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string/>
@@ -247,7 +246,6 @@
        <widget class="QLabel" name="sampRateLabel">
         <property name="font">
          <font>
-          <weight>50</weight>
           <bold>false</bold>
          </font>
         </property>

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -113,7 +113,7 @@ public:
     }
 
     void setFftCenterFreq(qint64 f) {
-        qint64 limit = ((qint64)m_SampleFreq - m_Span) / 2 - 1;
+        qint64 limit = qFabs(((qint64)m_SampleFreq - m_Span) / 2 - 1);
         m_FftCenter = qBound(-limit, f, limit);
     }
 


### PR DESCRIPTION
Add new commands to GQRX Remote Control Protocol for device management:     
   \get_input_device_list
   \get_input_device
   \set_input_device
   \get_output_device_list
   \get_output_device
   \set_output_device

Edited a tooltip in the I/O Configuration window to add an example of the popular "rtl=0,direct_samp=2" setting.

Mitigated a crash that occured during debugging in plotter.h due to a negative value.