### PR TITLE
Remote protocol: separate controls for HW and RX frequencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ come with a Simplified BSD license.
 
 The following people and organisations have contributed to gqrx:
 
+* Aleksander Alekseev, R2AUK
 * Alex Grinkov
 * Alexander Fasching
 * Andrea Merello

--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -62,6 +62,14 @@ Supported commands:
  LNB_LO [frequency]
     If frequency [Hz] is specified set the LNB LO frequency used for
     display. Otherwise print the current LNB LO frequency [Hz].
+ gqrx_get_hw_freq
+    Get the hardware center frequency / VFO [Hz]
+ gqrx_set_hw_freq <frequency>
+    Set the hardware center frequency / VFO to <frequency> [Hz]
+ gqrx_get_rx_freq
+    Get the receive / filter frequency relative to the center frequency [Hz]
+ gqrx_set_rx_freq <frequency>
+    Set the receive / filter frequency to <frequency> [Hz]
  \chk_vfo
     Get VFO option status (only usable for hamlib compatibility)
  \dump_state

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -254,6 +254,14 @@ void RemoteControl::startRead()
             answer = cmd_LOS();
         else if (cmd == "LNB_LO")
             answer = cmd_lnb_lo(cmdlist);
+        else if (cmd == "gqrx_get_hw_freq")
+            answer = cmd_get_hw_freq();
+        else if (cmd == "gqrx_set_hw_freq")
+            answer = cmd_set_hw_freq(cmdlist);
+        else if (cmd == "gqrx_get_rx_freq")
+            answer = cmd_get_rx_freq();
+        else if (cmd == "gqrx_set_rx_freq")
+            answer = cmd_set_rx_freq(cmdlist);
         else if (cmd == "\\chk_vfo")
             answer = QString("0\n");
         else if (cmd == "\\dump_state")
@@ -975,6 +983,50 @@ QString RemoteControl::cmd_lnb_lo(QStringList cmdlist)
     {
         return QString("%1\n").arg((qint64)(rc_lnb_lo_mhz * 1e6));
     }
+}
+
+/* Get the HW (VFO center) frequency */
+QString RemoteControl::cmd_get_hw_freq() const
+{
+    return QString("%1\n").arg(rc_freq - rc_filter_offset);
+}
+
+/* Set the HW (VFO center) frequency directly, without adjusting filter offset */
+QString RemoteControl::cmd_set_hw_freq(QStringList cmdlist)
+{
+    bool ok;
+    qint64 freq = cmdlist.value(1, "ERR").toLongLong(&ok);
+
+    if (ok)
+    {
+        rc_freq = freq + rc_filter_offset;
+        emit newFrequency(rc_freq);
+        return QString("RPRT 0\n");
+    }
+
+    return QString("RPRT 1\n");
+}
+
+/* Get the RX (filter offset) frequency */
+QString RemoteControl::cmd_get_rx_freq() const
+{
+    return QString("%1\n").arg(rc_filter_offset);
+}
+
+/* Set the RX (filter offset) frequency directly */
+QString RemoteControl::cmd_set_rx_freq(QStringList cmdlist)
+{
+    bool ok;
+    qint64 offset = cmdlist.value(1, "ERR").toLongLong(&ok);
+
+    if (ok)
+    {
+        rc_filter_offset = offset;
+        emit newFilterOffset(rc_filter_offset);
+        return QString("RPRT 0\n");
+    }
+
+    return QString("RPRT 1\n");
 }
 
 /*

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -179,6 +179,10 @@ private:
     QString     cmd_LOS();
     QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;
+    QString     cmd_get_hw_freq() const;
+    QString     cmd_set_hw_freq(QStringList cmdlist);
+    QString     cmd_get_rx_freq() const;
+    QString     cmd_set_rx_freq(QStringList cmdlist);
 };
 
 #endif // REMOTE_CONTROL_H


### PR DESCRIPTION
The proposed patch adds low-level controls for VFO / hardware center frequency and receive (filter) frequencies. Unlike `f` / `F` commands the new commands don't have any smart logic. The client is free to implement what it needs. 

Example:

```
gqrx_get_hw_freq
10489750000
gqrx_get_rx_freq
0
gqrx_set_rx_freq 10000
RPRT 0
gqrx_get_rx_freq
10000
gqrx_get_hw_freq
10489750000
gqrx_set_hw_freq 10489755000
RPRT 0
gqrx_get_rx_freq
10000
```

I used long command names as was previously proposed here: https://github.com/gqrx-sdr/gqrx/pull/1426#issuecomment-3041442593 Tested manually on Ubuntu 24.04 x64.

Closes #1442 / #1455 and probably other duplicates. Replaces PR #1426 which to me looks abandoned.

If there is something I should change / can improve please let me know.