### PR TITLE
FFT remote protocol: on-demand spectrum data command (fixes #1173)

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -82,10 +82,12 @@ Supported commands:
     Query full FFT parameters (metadata only, no values).
     Optional W: specifies target bin width for pooled output pool.
  FFT V [S:<start_hz>] [C:<n>] [W:<target_bw_hz>]
-    Get FFT spectrum data. Response format:
-     RPRT 0 F:<freq> S:<start> E:<end> B:<bw> N:<total> C:<count> [<dbfs_1> ...]
+    Get     FFT spectrum data. Response format:
+     RPRT 0 F:<freq> R:<rate> Z:<fftsize> S:<start> E:<end> B:<bw> N:<total> C:<count> [<dbfs_1> ...]
    Metadata fields:
      F    Center frequency the receiver is tuned to [Hz]
+     R    I/Q sample rate [Hz] (native_bw = R / Z)
+     Z    FFT size (number of native bins)
      S    Start frequency of the first returned bin [Hz]
      E    End frequency of the last returned bin [Hz]
      B    Bin width [Hz]

--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -78,7 +78,32 @@ Supported commands:
     Set 'Split' mode (only usable for hamlib compatibility)
  _
     Get version
-
+ FFT Q [W:<target_bw_hz>]
+    Query full FFT parameters (metadata only, no values).
+    Optional W: specifies target bin width for pooled output pool.
+ FFT V [S:<start_hz>] [C:<n>] [W:<target_bw_hz>]
+    Get FFT spectrum data. Response format:
+     RPRT 0 F:<freq> S:<start> E:<end> B:<bw> N:<total> C:<count> [<dbfs_1> ...]
+   Metadata fields:
+     F    Center frequency the receiver is tuned to [Hz]
+     S    Start frequency of the first returned bin [Hz]
+     E    End frequency of the last returned bin [Hz]
+     B    Bin width [Hz]
+     N    Total number of bins in the full FFT
+     C    Number of bins returned in this response
+   Arguments:
+      S:<start_hz>      Start frequency for the returned bins [Hz]
+      C:<n>             Number of bins to return
+      W:<target_bw_hz>  Target bin width [Hz]. Adjacent native FFT
+                        bins are power-averaged to produce wider
+                        output bins.  Defaults to the channel filter
+                        bandwidth so the output matches the audio-path
+                        resolution.  Specify W:<native_bw> (from FFT Q)
+                        for raw native resolution.  Works with Q and V.
+     Without arguments returns the full spectrum (pooled to default
+     bin filter width).  S: without C: returns all bins from S: to the right
+     edge.  C: without S: returns first C: bins from the left edge.
+    Clamping is always applied; C: reports actual returned count.
 
 Reply:
  RPRT 0

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -116,6 +116,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
 
     // remote controller
     remote = new RemoteControl();
+    remote->setReceiver(rx);
 
     /* meter timer */
     meter_timer = new QTimer(this);

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -25,14 +25,17 @@
 #include <iostream>
 #include <QString>
 #include <QStringList>
+#include <QVector>
 #include "remote_control.h"
+#include "receiver.h"
 #include "qtgui/dockrxopt.h"
 
 #define DEFAULT_RC_PORT            7356
 #define DEFAULT_RC_ALLOWED_HOSTS   "127.0.0.1"
 
 RemoteControl::RemoteControl(QObject *parent) :
-    QObject(parent)
+    QObject(parent),
+    d_rx(nullptr)
 {
 
     rc_freq = 0;
@@ -220,7 +223,9 @@ void RemoteControl::startRead()
             continue;
 
         QString cmd = cmdlist[0];
-        if (cmd == "f")
+        if (cmd == "FFT")
+            answer = cmd_get_fft(cmdlist);
+        else if (cmd == "f")
             answer = cmd_get_freq();
         else if (cmd == "F")
             answer = cmd_set_freq(cmdlist);
@@ -1053,4 +1058,197 @@ QString RemoteControl::cmd_dump_state() const
         "0\n" /* RIG_PARM_NONE */
         /* Bit field list of set parm */
         "0\n" /* RIG_PARM_NONE */);
+}
+
+/* FFT spectrum data command. */
+QString RemoteControl::cmd_get_fft(QStringList cmdlist)
+{
+    if (!d_rx)
+        return QString("RPRT 1\n");
+
+    unsigned int fftsize = d_rx->iq_fft_size();
+    if (fftsize == 0)
+        return QString("RPRT 1\n");
+
+    double quad_rate = d_rx->get_quad_rate();
+    double native_bw = quad_rate / fftsize;
+
+    /* Parse sub-command (Q or V). */
+    QString sub = cmdlist.value(1, "V");
+
+    if (sub != "Q" && sub != "V")
+        return QString("RPRT 1\n");
+
+    /* Parse optional S:<start_hz>, C:<count>, W:<target_bw_hz>. */
+    double req_start = 0.0;
+    int    req_count = -1;
+    double req_width = 0.0;
+    bool   has_start = false, has_count = false, has_width = false;
+    bool   query_only = (sub == "Q");
+
+    for (int i = 2; i < cmdlist.size(); i++)
+    {
+        QString arg = cmdlist[i];
+        if (arg.startsWith("S:"))
+        {
+            bool ok;
+            req_start = arg.mid(2).toDouble(&ok);
+            if (!ok) return QString("RPRT 1\n");
+            has_start = true;
+        }
+        else if (arg.startsWith("C:"))
+        {
+            bool ok;
+            req_count = arg.mid(2).toInt(&ok);
+            if (!ok || req_count < 0) return QString("RPRT 1\n");
+            has_count = true;
+        }
+        else if (arg.startsWith("W:"))
+        {
+            bool ok;
+            req_width = arg.mid(2).toDouble(&ok);
+            if (!ok || req_width <= 0.0) return QString("RPRT 1\n");
+            has_width = true;
+        }
+        else
+        {
+            return QString("RPRT 1\n");
+        }
+    }
+
+    /* Reject S: and C: arguments on query sub-command (W: is allowed). */
+    if (query_only && (has_start || has_count))
+        return QString("RPRT 1\n");
+
+    /* Default: pool to the channel filter bandwidth so the output
+     * bins match the audio-path resolution.  Prevents very large
+     * responses on wideband receivers when W: is not given. */
+    if (!has_width)
+    {
+        double filter_bw = (double)(rc_passband_hi - rc_passband_lo);
+        if (filter_bw > 0.0)
+        {
+            req_width = filter_bw;
+            has_width = true;
+        }
+    }
+
+    /* Compute pooling factor and output grid parameters. */
+    unsigned int pool = 1;
+    double bin_width = native_bw;
+    unsigned int total_bins = fftsize;
+
+    if (has_width)
+    {
+        unsigned int p = (unsigned int)(req_width / native_bw + 0.5);
+        if (p < 1) p = 1;
+        if (p > fftsize) p = fftsize;
+        pool = p;
+        bin_width = pool * native_bw;
+        total_bins = fftsize / pool;
+        if (total_bins == 0) total_bins = 1;
+    }
+
+    /* Full visible spectrum boundaries.
+     *
+     * The IQ FFT is connected before the NCO (receiver.cpp:1366) so the
+     * visible spectrum is centered at the hardware LO frequency, i.e.
+     * rc_freq minus the channel filter offset.  Using rc_freq directly
+     * would shift all bin frequencies by rc_filter_offset.
+     */
+    double half_span = (fftsize / 2.0) * native_bw;
+    double hw_center = (double)(rc_freq - rc_filter_offset);
+    double vis_start = hw_center - half_span;
+    double vis_end   = hw_center + half_span;
+
+    /* Determine the requested bin range in the output grid. */
+    unsigned int start_idx = 0;
+    unsigned int n_bins = total_bins;
+
+    if (has_start)
+    {
+        if (req_start >= vis_end)
+            return QString("RPRT 1\n");
+        if (req_start > vis_start)
+        {
+            double offset = (req_start - vis_start) / bin_width;
+            start_idx = (unsigned int)offset;
+            if (start_idx >= total_bins)
+                return QString("RPRT 1\n");
+        }
+    }
+
+    if (has_count)
+    {
+        n_bins = req_count;
+    }
+    else if (has_start)
+    {
+        /* S: without C: -> from start to right edge. */
+        n_bins = total_bins - start_idx;
+    }
+
+    /* Clamp to available bins. */
+    if (start_idx + n_bins > total_bins)
+        n_bins = total_bins - start_idx;
+
+    if (!has_count && n_bins == 0)
+        return QString("RPRT 1\n");
+
+    /* Compute start and end frequencies for the response. */
+    double s_freq = vis_start + start_idx * bin_width + bin_width / 2.0;
+    double e_freq = (n_bins > 0) ? (s_freq + (n_bins - 1) * bin_width) : s_freq;
+
+    /* Build response header. */
+    QString answer = QString("RPRT 0 F:%1 S:%2 E:%3 B:%4 N:%5 C:%6")
+                         .arg((qint64)(rc_freq - rc_filter_offset))
+                         .arg(s_freq, 0, 'f', 1)
+                         .arg(e_freq, 0, 'f', 1)
+                         .arg(bin_width, 0, 'f', 1)
+                         .arg(total_bins)
+                         .arg(n_bins);
+
+    /* Fetch and convert values (skip for query-only). */
+    bool need_values = (!query_only && n_bins > 0);
+
+    if (need_values)
+    {
+        std::vector<float> mag_sq(fftsize);
+        if (d_rx->get_iq_fft_data(mag_sq.data()) < 0)
+            return QString("RPRT 1\n");
+
+        float scale = 1.0f / ((float)fftsize * (float)fftsize);
+        double pool_scale = 1.0;
+        QStringList vals;
+        vals.reserve(n_bins);
+
+        if (pool > 1)
+        {
+            for (unsigned int j = start_idx; j < start_idx + n_bins; j++)
+            {
+                double sum = 0.0;
+                unsigned int base = j * pool;
+                for (unsigned int k = 0; k < pool; k++)
+                    sum += (double)mag_sq[base + k];
+                float avg = (float)(sum * pool_scale);
+                float dbfs = 10.0f * log10f(
+                    std::max(avg * scale, 1.0e-20f));
+                vals.append(QString::number(dbfs, 'f', 1));
+            }
+        }
+        else
+        {
+            for (unsigned int i = start_idx; i < start_idx + n_bins; i++)
+            {
+                float dbfs = 10.0f * log10f(
+                    std::max(mag_sq[i] * scale, 1.0e-20f));
+                vals.append(QString::number(dbfs, 'f', 1));
+            }
+        }
+
+        answer += " " + vals.join(" ");
+    }
+
+    answer += "\n";
+    return answer;
 }

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -1199,9 +1199,13 @@ QString RemoteControl::cmd_get_fft(QStringList cmdlist)
     double s_freq = vis_start + start_idx * bin_width + bin_width / 2.0;
     double e_freq = (n_bins > 0) ? (s_freq + (n_bins - 1) * bin_width) : s_freq;
 
-    /* Build response header. */
-    QString answer = QString("RPRT 0 F:%1 S:%2 E:%3 B:%4 N:%5 C:%6")
+    /* Build response header.
+     * R:<quad_rate> and Z:<fftsize> allow the client to compute the
+     * exact native bin width (R/Z) without an extra native-res query. */
+    QString answer = QString("RPRT 0 F:%1 R:%2 Z:%3 S:%4 E:%5 B:%6 N:%7 C:%8")
                          .arg((qint64)(rc_freq - rc_filter_offset))
+                         .arg(quad_rate, 0, 'f', 0)
+                         .arg(fftsize)
                          .arg(s_freq, 0, 'f', 1)
                          .arg(e_freq, 0, 'f', 1)
                          .arg(bin_width, 0, 'f', 1)

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -35,6 +35,8 @@
 /* For gain_t and gain_list_t */
 #include "qtgui/dockinputctl.h"
 
+class receiver;
+
 /*! \brief Simple TCP server for remote control.
  *
  * The TCP interface is compatible with the hamlib rigtctld so that applications
@@ -81,6 +83,7 @@ public:
     {
         return rc_allowed_hosts;
     }
+    void setReceiver(receiver *rx) { d_rx = rx; }
     void setReceiverStatus(bool enabled);
     void setGainStages(gain_list_t &gain_list);
 
@@ -156,6 +159,8 @@ private:
     gain_list_t gains;             /*!< Possible and current gain settings */
     bool        is_audio_muted;
 
+    receiver   *d_rx;                 /*!< Receiver for on-demand FFT data */
+
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);
     QString     intToModeStr(int mode);
@@ -179,6 +184,7 @@ private:
     QString     cmd_LOS();
     QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;
+    QString     cmd_get_fft(QStringList cmdlist);
 };
 
 #endif // REMOTE_CONTROL_H


### PR DESCRIPTION
## Summary

Adds a new `FFT` remote-control verb (with `Q`/`V` sub-commands) that returns IQ spectrum data from the receiver's panadapter in one (or multiple) request, enabling fast FFT-based scanning without iterating through individual frequencies.

Fixes #1173 — provides the remote-control FFT data access to Gqrx.

## Key features

- `FFT V` — returns pooled dBFS values for the full visible spectrum
- `FFT Q` — query-only (metadata without values, for parameter discovery)
- `S:<start_hz>` / `C:<n>` — sub-range slicing (start frequency, bin count)
- `W:<target_bw_hz>` — on-demand bin pooling. Adjacent native FFT bins are power-averaged to produce wider output bins. Defaults to the channel filter bandwidth so the output matches the audio-path resolution, preventing very large responses on wideband receivers. Specify `W:<native_bw>` for raw native resolution.
- `R:<rate>` / `Z:<fftsize>` — returned with every response so the client can compute the exact native bin width as `R / Z` without an extra query.

## Why

Traditional frequency-stepping scan is slow (one "F <freq>\n" per hop + settle time + "l\n"). Reading the full FFT in one request gives a scanner instant access to all signals within the receiver's bandwidth. On-demand pooling (`W:`) avoids forcing every client to understand native FFT parameters while keeping the wire protocol compact.

## Files changed

| File | Change |
|---|---|
| `src/applications/gqrx/remote_control.cpp` | `cmd_get_fft()` implementation with full FFT read, sub-range slicing, bin pooling, and default-to-filter-bandwidth logic |
| `src/applications/gqrx/remote_control.h` | `d_rx` member, `setReceiver()`, `cmd_get_fft()` declaration |
| `src/applications/gqrx/mainwindow.cpp` | Wire up receiver access: `remote->setReceiver(rx)` |
| `resources/remote-control.txt` | FFT command documentation added |

## Protocol reference

See `remote-control.txt` for full protocol spec.

## Protocol examples

```
FFT Q
RPRT 0 F:27155000 R:5000000 Z:131072 S:24659997.3 E:29647256.2 B:9994.5 N:500 C:500

FFT Q W:1000
RPRT 0 F:27155000 R:5000000 Z:131072 S:24655495.9 E:29654275.2 B:991.8 N:5041 C:5041

FFT V C:5
RPRT 0 F:27155000 R:5000000 Z:131072 S:24659997.3 E:24699975.3 B:9994.5 N:500 C:5 -91.3 -92.0 -91.9 -92.4 -91.5

FFT V C:5 W:1000
RPRT 0 F:27155000 R:5000000 Z:131072 S:24655495.9 E:24659463.2 B:991.8 N:5041 C:5 -103.8 -102.8 -102.7 -100.7 -101.2

FFT V S:27155000 C:3
RPRT 0 F:27155000 R:5000000 Z:131072 S:27158624.0 E:27178613.0 B:9994.5 N:500 C:3 -59.7 -60.5 -61.0

FFT V S:27155000 C:3 W:1000
RPRT 0 F:27155000 R:5000000 Z:131072 S:27154885.6 E:27156869.2 B:991.8 N:5041 C:3 -70.2 -70.2 -70.2
```

## Example client for testing

Please, clone and compile https://github.com/neural75/gqrx-scanner/tree/feature/fft-scan
and run it with:
`./bin/gqrx-scanner -m fft -v -l 1000:3000 --vox`