### PR TITLE
Use default FFT plot & waterfall ranges when settings are invalid

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.17.8: In progress...
+
+     FIXED: Use default FFT plot & waterfall ranges when settings are invalid.
+
+
     2.17.7: Released May 27, 2025
 
        NEW: Start/stop I/Q recording via remote control.

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -50,6 +50,8 @@ Q_LOGGING_CATEGORY(plotter, "plotter")
 #define FFT_MIN_DB     -160.f
 #define FFT_MAX_DB      30.f
 #define FFT_MIN_DB_RANGE 2.f
+#define DEFAULT_FFT_MAX_DB -20.f
+#define DEFAULT_FFT_MIN_DB -120.f
 
 #define FILTER_WIDTH_MIN_HZ 200
 
@@ -139,8 +141,8 @@ CPlotter::CPlotter(QWidget *parent) : QFrame(parent)
 
     m_HorDivs = 12;
     m_VerDivs = 6;
-    m_PandMaxdB = m_WfMaxdB = 0.f;
-    m_PandMindB = m_WfMindB = FFT_MAX_DB;
+    m_PandMaxdB = m_WfMaxdB = DEFAULT_FFT_MAX_DB;
+    m_PandMindB = m_WfMindB = DEFAULT_FFT_MIN_DB;
 
     m_CumWheelDelta = 0;
     m_FreqUnits = 1000000;


### PR DESCRIPTION
Partially addresses #1457.

As noted in https://github.com/gqrx-sdr/gqrx/issues/1457#issuecomment-4948881843, #1218 accidentally changed the default (fallback) range for the FFT plot and waterfall from -150..0 to 30..0. Here I've changed the default to -120..-20, matching the values used on first startup.