### PR TITLE
remote-control: add read/write FILTER_SHAPE level

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -27,6 +27,12 @@ Supported commands:
     Get the value of the gain setting with the name <gain_name>
  L <gain_name>_GAIN <value>
     Set the value of the gain setting with the name <gain_name> to <value>
+ l FILTER_SHAPE
+    Get the channel filter shape (0 = soft, 1 = normal, 2 = sharp)
+ L FILTER_SHAPE <shape>
+    Set the channel filter shape. <shape> may be 0/1/2 or SOFT/NORMAL/SHARP
+    (case insensitive). The setting is receiver-wide and is kept across
+    demodulator changes, matching the Receiver Options filter shape selector.
  p RDS_PI
     Get the RDS PI code (in hexadecimal). Returns 0000 if not applicable.
  p RDS_PS_NAME

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -345,6 +345,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
     connect(remote, SIGNAL(stopIqRecorderEvent()), iq_tool, SLOT(stopIqRecorder()));
     connect(ui->plotter, SIGNAL(newFilterFreq(int, int)), remote, SLOT(setPassband(int, int)));
     connect(remote, SIGNAL(newPassband(int)), this, SLOT(setPassband(int)));
+    connect(remote, SIGNAL(newFilterShape(int)), this, SLOT(setFilterShape(int)));
     connect(remote, SIGNAL(gainChanged(QString, double)), uiDockInputCtl, SLOT(setGain(QString,double)));
     connect(remote, SIGNAL(dspChanged(bool)), this, SLOT(on_actionDSP_triggered(bool)));
     connect(uiDockRDS, SIGNAL(rdsPI(QString)), remote, SLOT(rdsPI(QString)));
@@ -1315,6 +1316,7 @@ void MainWindow::selectDemod(int mode_idx)
 
     remote->setMode(mode_idx);
     remote->setPassband(flo, fhi);
+    remote->setFilterShape(uiDockRxOpt->currentFilterShape());
 
     d_have_audio = (mode_idx != DockRxOpt::MODE_OFF);
 
@@ -2327,6 +2329,23 @@ void MainWindow::setPassband(int bandwidth)
     remote->setPassband(lo, hi);
 
     on_plotter_newFilterFreq(lo, hi);
+}
+
+/**
+ * @brief Set the channel filter shape from the remote control.
+ * @param index The new filter shape (0 = soft, 1 = normal, 2 = sharp).
+ *
+ * Mirrors the GUI filter-shape combo: update the combo and re-run the
+ * demodulator selection, which re-applies the channel filter with the new
+ * transition band. Out-of-range values are ignored.
+ */
+void MainWindow::setFilterShape(int index)
+{
+    if (index < receiver::FILTER_SHAPE_SOFT || index > receiver::FILTER_SHAPE_SHARP)
+        return;
+
+    uiDockRxOpt->setCurrentFilterShape(index);
+    selectDemod(uiDockRxOpt->currentDemod());
 }
 
 /** Launch Gqrx google group website. */

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -184,6 +184,7 @@ private slots:
     double setSqlLevelAuto();
     void setAudioGain(float gain);
     void setPassband(int bandwidth);
+    void setFilterShape(int index);
 
     /* audio recording and playback */
     void startAudioRec(const QString& filename);

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -42,6 +42,7 @@ RemoteControl::RemoteControl(QObject *parent) :
     rc_mode = 0;
     rc_passband_lo = 0;
     rc_passband_hi = 0;
+    rc_filter_shape = 1;          /* FILTER_SHAPE_NORMAL */
     rc_program_id = "0000";
     rds_station = QString("");
     rds_radiotext = QString("");
@@ -330,6 +331,12 @@ void RemoteControl::setPassband(int passband_lo, int passband_hi)
 {
     rc_passband_lo = passband_lo;
     rc_passband_hi = passband_hi;
+}
+
+/*! \brief Set filter shape (from mainwindow). */
+void RemoteControl::setFilterShape(int shape)
+{
+    rc_filter_shape = shape;
 }
 
 /*! \brief New remote frequency received. */
@@ -675,7 +682,7 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
         QStringList names;
         for(auto &g : gains)
             names.push_back(QString("%1_GAIN").arg(QString::fromStdString(g.name)));
-        answer = QString("SQL STRENGTH AF %1\n").arg(names.join(" "));
+        answer = QString("SQL STRENGTH AF FILTER_SHAPE %1\n").arg(names.join(" "));
     }
     else if (lvl.compare("STRENGTH", Qt::CaseInsensitive) == 0 || lvl.isEmpty())
     {
@@ -688,6 +695,10 @@ QString RemoteControl::cmd_get_level(QStringList cmdlist)
     else if (lvl.compare("AF", Qt::CaseInsensitive) == 0)
     {
         answer = QString("%1\n").arg((double)audio_gain, 0, 'f', 1);
+    }
+    else if (lvl.compare("FILTER_SHAPE", Qt::CaseInsensitive) == 0)
+    {
+        answer = QString("%1\n").arg(rc_filter_shape);
     }
     else if (lvl.endsWith("_GAIN"))
     {
@@ -721,7 +732,7 @@ QString RemoteControl::cmd_set_level(QStringList cmdlist)
         QStringList names;
         for(auto &g : gains)
             names.push_back(QString("%1_GAIN").arg(QString::fromStdString(g.name)));
-        answer = QString("SQL AF %1\n").arg(names.join(" "));
+        answer = QString("SQL AF FILTER_SHAPE %1\n").arg(names.join(" "));
     }
     else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
     {
@@ -747,6 +758,34 @@ QString RemoteControl::cmd_set_level(QStringList cmdlist)
             answer = QString("RPRT 0\n");
             new_audio_gain = std::max<float>(-80.0f, std::min<float>(50.0f, new_audio_gain));
             emit newAudioGain(new_audio_gain);
+        }
+        else
+        {
+            answer = QString("RPRT 1\n");
+        }
+    }
+    else if (lvl.compare("FILTER_SHAPE", Qt::CaseInsensitive) == 0)
+    {
+        QString arg = cmdlist.value(2, "");
+        bool ok;
+        int shape = arg.toInt(&ok);
+
+        /* also accept the GUI labels */
+        if (!ok)
+        {
+            if (arg.compare("SOFT", Qt::CaseInsensitive) == 0)
+            { shape = 0; ok = true; }
+            else if (arg.compare("NORMAL", Qt::CaseInsensitive) == 0)
+            { shape = 1; ok = true; }
+            else if (arg.compare("SHARP", Qt::CaseInsensitive) == 0)
+            { shape = 2; ok = true; }
+        }
+
+        if (ok && shape >= 0 && shape <= 2)
+        {
+            rc_filter_shape = shape;
+            emit newFilterShape(rc_filter_shape);
+            answer = QString("RPRT 0\n");
         }
         else
         {

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -92,6 +92,7 @@ public slots:
     void setSignalLevel(float level);
     void setMode(int mode);
     void setPassband(int passband_lo, int passband_hi);
+    void setFilterShape(int shape);
     void setSquelchLevel(double level);
     void setAudioGain(float gain);
     void setAudioMuted(bool muted);
@@ -111,6 +112,7 @@ signals:
     void newLnbLo(double freq_mhz);
     void newMode(int mode);
     void newPassband(int passband);
+    void newFilterShape(int shape);
     void newSquelchLevel(double level);
     void newAudioGain(float gain);
     void startAudioRecorderEvent();
@@ -142,6 +144,7 @@ private:
     int         rc_mode;           /*!< Current mode. */
     int         rc_passband_lo;    /*!< Current low cutoff. */
     int         rc_passband_hi;    /*!< Current high cutoff. */
+    int         rc_filter_shape;   /*!< Current filter shape (0=soft, 1=normal, 2=sharp). */
     bool        rds_status;        /*!< RDS decoder enabled */
     float       signal_level;      /*!< Signal level in dBFS */
     double      squelch_level;     /*!< Squelch level in dBFS */


### PR DESCRIPTION
Adds a `FILTER_SHAPE` level to the remote-control interface so a client can query and set the channel-filter transition band (Soft / Normal / Sharp) that today is only reachable from the Receiver Options dock.

## Commands

```
l FILTER_SHAPE            -> 0 | 1 | 2          (0 = soft, 1 = normal, 2 = sharp)
L FILTER_SHAPE <shape>    -> RPRT 0 / RPRT 1    (<shape> = 0/1/2 or SOFT/NORMAL/SHARP, case-insensitive)
l ? / L ?                 -> now also list FILTER_SHAPE
```

Exposed as a **level** rather than an extra field on `m` / `M`, so hamlib/rigctld
clients (gpredict, WSJT-X, …) that parse `m` as exactly two lines are unaffected,
and so support is discoverable the usual way — look for `FILTER_SHAPE` in `l ?`.

## Behaviour

- The shape is receiver-wide and preserved across demodulator changes, exactly
  like the GUI selector.
- Setting it routes through `MainWindow::selectDemod()` — the same path the
  Receiver Options combo uses — so the running filter is updated immediately and
  remote / GUI state stay in sync both ways:
  - RC -> GUI: `RemoteControl::newFilterShape(int)` -> `MainWindow::setFilterShape(int)`
  - GUI -> RC: `MainWindow::selectDemod()` -> `RemoteControl::setFilterShape(int)`
- Out-of-range / unparseable values return `RPRT 1` and change nothing.

## Changes

| File | |
|---|---|
| `remote_control.h/.cpp` | `rc_filter_shape` (init NORMAL), `setFilterShape(int)` slot, `newFilterShape(int)` signal, `FILTER_SHAPE` in `cmd_get_level`/`cmd_set_level` + both `?` lists |
| `mainwindow.h/.cpp` | `setFilterShape(int)` slot (clamps, `setCurrentFilterShape`, re-runs `selectDemod`); one `connect()`; one sync line in `selectDemod()` |
| `resources/remote-control.txt` | documents the two commands |

No DSP/flowgraph changes — `receiver::set_filter()` already takes the shape.

## Testing

Builds clean on macOS (arm64, Qt 5.15.18, GNU Radio 3.8.5). Verify at runtime,
with **Tools ▸ Remote control** enabled:

```
$ printf 'l ?\nL FILTER_SHAPE 2\nl FILTER_SHAPE\nL FILTER_SHAPE normal\nL FILTER_SHAPE 5\n' | nc localhost 7356
# expect: list contains FILTER_SHAPE ; RPRT 0 ; 2 ; RPRT 0 ; RPRT 1
```

The Receiver Options "Shape" combo should follow each `L FILTER_SHAPE`, and a
manual combo change should be reflected by a later `l FILTER_SHAPE`.

Motivation: my AntennaHead / LocalRadio project drives gqrx over this interface
and wants filter shape alongside the frequency / mode / passband / gain controls
it already uses.