### PR TITLE
remote-control: add bookmark download and recall commands

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -68,6 +68,25 @@ Supported commands:
     Dump state (only usable for hamlib compatibility)
  \get_powerstat
     Get power status (only usable for hamlib compatibility)
+ \get_bookmarks
+    Get all bookmarks. The first reply line is the bookmark count N, followed
+    by N lines, each formatted as:
+      <frequency_Hz>|<name>|<modulation>|<bandwidth_Hz>|<tags>
+    where <tags> is a comma separated list. The characters '|', CR and LF are
+    replaced with a space in <name>, <modulation> and tag names so every
+    bookmark is a single unambiguous line.
+ \get_bookmarks_in_range <lo> <hi>
+    Like \get_bookmarks but only bookmarks with lo <= frequency <= hi [Hz].
+ \get_bookmark_tags
+    Get all bookmark tag names: a count line followed by one name per line.
+ \set_bookmark <index>
+    Activate the bookmark at <index> (0-based, in \get_bookmarks order): tune
+    to it and apply its mode and bandwidth. Returns RPRT 1 if out of range.
+ \set_bookmark_freq <frequency>
+    Activate the first bookmark whose frequency equals <frequency> [Hz]. This
+    is independent of the list order. Returns RPRT 1 if there is no match.
+ \reload_bookmarks
+    Reload bookmarks.csv from disk, e.g. after editing it outside Gqrx.
  v
     Get 'VFO' (only usable for hamlib compatibility)
  V

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -311,6 +311,7 @@ MainWindow::MainWindow(const QString& cfgfile, bool edit_conf, QWidget *parent) 
 
     // Bookmarks
     connect(uiDockBookmarks, SIGNAL(newBookmarkActivated(qint64, QString, int)), this, SLOT(onBookmarkActivated(qint64, QString, int)));
+    connect(remote, SIGNAL(newBookmarkActivated(qint64, QString, int)), this, SLOT(onBookmarkActivated(qint64, QString, int)));
     connect(uiDockBookmarks->actionAddBookmark, SIGNAL(triggered()), this, SLOT(on_actionAddBookmark_triggered()));
     connect(&Bookmarks::Get(), SIGNAL(BookmarksChanged()), ui->plotter, SLOT(updateOverlay()));
 

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -27,6 +27,7 @@
 #include <QStringList>
 #include "remote_control.h"
 #include "qtgui/dockrxopt.h"
+#include "qtgui/bookmarks.h"
 
 #define DEFAULT_RC_PORT            7356
 #define DEFAULT_RC_ALLOWED_HOSTS   "127.0.0.1"
@@ -260,6 +261,18 @@ void RemoteControl::startRead()
             answer = cmd_dump_state();
         else if (cmd == "\\get_powerstat")
             answer = QString("1\n");
+        else if (cmd == "\\get_bookmarks")
+            answer = cmd_get_bookmarks();
+        else if (cmd == "\\get_bookmarks_in_range")
+            answer = cmd_get_bookmarks_in_range(cmdlist);
+        else if (cmd == "\\get_bookmark_tags")
+            answer = cmd_get_bookmark_tags();
+        else if (cmd == "\\set_bookmark")
+            answer = cmd_set_bookmark(cmdlist);
+        else if (cmd == "\\set_bookmark_freq")
+            answer = cmd_set_bookmark_freq(cmdlist);
+        else if (cmd == "\\reload_bookmarks")
+            answer = cmd_reload_bookmarks();
         else if (cmd == "q" || cmd == "Q")
         {
             // FIXME: for now we assume 'close' command
@@ -1053,4 +1066,146 @@ QString RemoteControl::cmd_dump_state() const
         "0\n" /* RIG_PARM_NONE */
         /* Bit field list of set parm */
         "0\n" /* RIG_PARM_NONE */);
+}
+
+/* Replace the wire-format field separators so each bookmark stays on one
+ * unambiguous line. */
+static QString rc_bookmark_sanitize(QString s)
+{
+    return s.replace('|', ' ').replace('\r', ' ').replace('\n', ' ');
+}
+
+/* Format one bookmark as: freq|name|modulation|bandwidth|tag,tag,... */
+static QString rc_bookmark_line(const BookmarkInfo &info)
+{
+    QStringList tags;
+    for (const auto &tag : info.tags)
+        tags.push_back(rc_bookmark_sanitize(tag->name));
+
+    return QString("%1|%2|%3|%4|%5\n")
+            .arg(info.frequency)
+            .arg(rc_bookmark_sanitize(info.name))
+            .arg(rc_bookmark_sanitize(info.modulation))
+            .arg(info.bandwidth)
+            .arg(tags.join(","));
+}
+
+/*
+ * The '\get_bookmarks' command.
+ *
+ * Reply: a line with the bookmark count, then one line per bookmark:
+ *   <freq_Hz>|<name>|<modulation>|<bandwidth_Hz>|<comma separated tags>
+ */
+QString RemoteControl::cmd_get_bookmarks()
+{
+    Bookmarks &bookmarks = Bookmarks::Get();
+    const int count = bookmarks.size();
+
+    QString answer = QString("%1\n").arg(count);
+    for (int i = 0; i < count; i++)
+        answer += rc_bookmark_line(bookmarks.getBookmark(i));
+
+    return answer;
+}
+
+/*
+ * The '\get_bookmarks_in_range <lo> <hi>' command.
+ *
+ * Same reply format as '\get_bookmarks', limited to lo <= frequency <= hi [Hz].
+ */
+QString RemoteControl::cmd_get_bookmarks_in_range(QStringList cmdlist)
+{
+    bool lo_ok, hi_ok;
+    qint64 lo = cmdlist.value(1, "").toLongLong(&lo_ok);
+    qint64 hi = cmdlist.value(2, "").toLongLong(&hi_ok);
+
+    if (!lo_ok || !hi_ok || lo > hi)
+        return QString("RPRT 1\n");
+
+    Bookmarks &bookmarks = Bookmarks::Get();
+    QString rows;
+    int count = 0;
+    for (int i = 0; i < bookmarks.size(); i++)
+    {
+        const BookmarkInfo &info = bookmarks.getBookmark(i);
+        if (info.frequency >= lo && info.frequency <= hi)
+        {
+            rows += rc_bookmark_line(info);
+            count++;
+        }
+    }
+
+    return QString("%1\n").arg(count) + rows;
+}
+
+/*
+ * The '\get_bookmark_tags' command.
+ *
+ * Reply: a line with the tag count, then one tag name per line.
+ */
+QString RemoteControl::cmd_get_bookmark_tags()
+{
+    QList<TagInfo::sptr> tags = Bookmarks::Get().getTagList();
+
+    QString answer = QString("%1\n").arg(tags.size());
+    for (const auto &tag : tags)
+        answer += rc_bookmark_sanitize(tag->name) + "\n";
+
+    return answer;
+}
+
+/*
+ * The '\set_bookmark <index>' command.
+ *
+ * Activate the bookmark at <index> (0-based, in '\get_bookmarks' order): tune to
+ * it and apply its mode and bandwidth.
+ */
+QString RemoteControl::cmd_set_bookmark(QStringList cmdlist)
+{
+    bool ok;
+    int index = cmdlist.value(1, "").toInt(&ok);
+    Bookmarks &bookmarks = Bookmarks::Get();
+
+    if (!ok || index < 0 || index >= bookmarks.size())
+        return QString("RPRT 1\n");
+
+    const BookmarkInfo &info = bookmarks.getBookmark(index);
+    emit newBookmarkActivated(info.frequency, info.modulation, (int)info.bandwidth);
+
+    return QString("RPRT 0\n");
+}
+
+/*
+ * The '\set_bookmark_freq <frequency>' command.
+ *
+ * Activate the first bookmark whose frequency equals <frequency> [Hz]. This is
+ * independent of the list order, so it survives edits between calls.
+ */
+QString RemoteControl::cmd_set_bookmark_freq(QStringList cmdlist)
+{
+    bool ok;
+    qint64 freq = cmdlist.value(1, "").toLongLong(&ok);
+    if (!ok)
+        return QString("RPRT 1\n");
+
+    Bookmarks &bookmarks = Bookmarks::Get();
+    for (int i = 0; i < bookmarks.size(); i++)
+    {
+        const BookmarkInfo &info = bookmarks.getBookmark(i);
+        if (info.frequency == freq)
+        {
+            emit newBookmarkActivated(info.frequency, info.modulation, (int)info.bandwidth);
+            return QString("RPRT 0\n");
+        }
+    }
+
+    return QString("RPRT 1\n");
+}
+
+/*
+ * The '\reload_bookmarks' command: re-read bookmarks.csv from disk.
+ */
+QString RemoteControl::cmd_reload_bookmarks()
+{
+    return Bookmarks::Get().load() ? QString("RPRT 0\n") : QString("RPRT 1\n");
 }

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -121,6 +121,7 @@ signals:
     void dspChanged(bool value);
     void newRDSmode(bool value);
     void newAudioMuted(bool muted);
+    void newBookmarkActivated(qint64 freq, QString demod, int bandwidth);
 
 private slots:
     void acceptConnection();
@@ -179,6 +180,12 @@ private:
     QString     cmd_LOS();
     QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;
+    QString     cmd_get_bookmarks();
+    QString     cmd_get_bookmarks_in_range(QStringList cmdlist);
+    QString     cmd_get_bookmark_tags();
+    QString     cmd_set_bookmark(QStringList cmdlist);
+    QString     cmd_set_bookmark_freq(QStringList cmdlist);
+    QString     cmd_reload_bookmarks();
 };
 
 #endif // REMOTE_CONTROL_H


### PR DESCRIPTION
Lets a remote-control client read the bookmark list and jump to an entry —
useful for building an external UI on top of gqrx. (My AntennaHead / LocalRadio
project drives gqrx this way and already uses the frequency / mode / passband /
gain commands.)

## New commands

| Command | Reply |
|---|---|
| `\get_bookmarks` | count line `N`, then `N` lines `<freq_Hz>\|<name>\|<modulation>\|<bandwidth_Hz>\|<tag,tag,…>` |
| `\get_bookmarks_in_range <lo> <hi>` | same, limited to `lo <= frequency <= hi` [Hz]; `RPRT 1` on bad args |
| `\get_bookmark_tags` | count line, then one tag name per line |
| `\set_bookmark <index>` | `RPRT 0` — tune to the bookmark at 0-based `<index>` (in `\get_bookmarks` order) and apply its mode + bandwidth; `RPRT 1` if out of range |
| `\set_bookmark_freq <frequency>` | `RPRT 0` — activate the first bookmark whose frequency equals `<frequency>` [Hz]; order-independent; `RPRT 1` if no match |
| `\reload_bookmarks` | re-read `bookmarks.csv` from disk; `RPRT 0` / `RPRT 1` |

## Design notes

- **Framing.** `\get_bookmarks` uses a count line then one line per record, like
  `\dump_state`'s "lines" style. Fields are `|`-separated; `|`, CR and LF are
  replaced with a space in `name`, `modulation` and tag names so a record is
  always exactly one line (`bookmarks.csv` itself is unquoted `;`-separated, so a
  wire separator has to be chosen and sanitised rather than inherited).
- **Addressing.** `\set_bookmark <index>` is simple but can go stale if the list
  changes between calls, so `\set_bookmark_freq <Hz>` is provided as an
  order-independent alternative. Neither command takes a name argument — the
  command line is whitespace-split and bookmark names contain spaces.
- **Apply path.** `\set_bookmark*` emit a new `RemoteControl::newBookmarkActivated`
  signal wired to the existing `MainWindow::onBookmarkActivated` slot — the same
  slot the Bookmarks dock uses — so tuning, mode and bandwidth handling are
  identical to activating a bookmark in the GUI. No `MainWindow` dependency is
  added to `remote_control.cpp`; reads go through the `Bookmarks` singleton.
- **Read + apply only** — no `\add_bookmark` / `\remove_bookmark`.
- **Compatibility.** All additions are new `\`-verbs; no existing command's
  request or reply changes.

## Changes

| File | |
|---|---|
| `remote_control.h` | `newBookmarkActivated(qint64,QString,int)` signal; 6 `cmd_*` declarations |
| `remote_control.cpp` | `#include "qtgui/bookmarks.h"`; 6 dispatch entries; 6 handlers + two small static formatting helpers |
| `mainwindow.cpp` | one `connect()` next to the existing dock connection |
| `resources/remote-control.txt` | documents the six commands |

## Testing

Builds clean on macOS (arm64, Qt 5.15.18, GNU Radio 3.8.5). Verify at runtime
after saving a couple of bookmarks, with **Tools ▸ Remote control** enabled:

```
$ printf '\\get_bookmarks\n\\get_bookmark_tags\n\\set_bookmark 0\n\\set_bookmark_freq 95500000\n\\set_bookmark 99\n' | nc localhost 7356
# expect: count+rows ; count+tags ; RPRT 0 ; RPRT 0 ; RPRT 1   (receiver retunes on each RPRT 0)
```